### PR TITLE
Fix Alr.Root and dependent functionality

### DIFF
--- a/ISSUES.txt
+++ b/ISSUES.txt
@@ -1,1 +1,1 @@
-* Remove the Alr.Root package and fix dependent functionality
+- Remove the Alr.Root package and fix dependent functionality


### PR DESCRIPTION
When rebuilding existed, this file was used by the generated `alr_deps.ads` file to set the project in scope.
Thus, commands that work on an initialized folder are now failing.
This draft PR will address part of #73 