### PR TITLE
Factor common logic out of alr.gpr and alire.gpr

### DIFF
--- a/alire.gpr
+++ b/alire.gpr
@@ -1,5 +1,6 @@
 with "aaa";
 with "ada_toml";
+with "alire_common";
 with "ajunitgen";
 with "semantic_versioning";
 with "simple_logging";
@@ -9,65 +10,16 @@ library project Alire is
 
    for Library_Name use "alire";
 
-   type Any_Build_Mode is ("debug", "release");
-   Build_Mode : Any_Build_Mode := external ("ALIRE_BUILD_MODE", "debug");
-
-   for Source_Dirs use ("src/alire", 
-                        "src/alire/os_linux");
+   for Source_Dirs use ("src/alire", "src/alire/os_linux");
 
    for Library_Dir use "lib";
    for Object_Dir use "obj";
 
    for Languages use ("Ada");
 
-   Ada_Switches := ();
-
-   case Build_Mode is
-      when "debug" =>
-         Ada_Switches := (
-            --  Build with no optimization in debug mode
-            "-g", "-O0",
-
-            --  Enable lots of extra runtime checks
-            "-gnatVa", "-gnato", "-fstack-check", "-gnata",
-
-            --  Enable full errors, verbose details
-            "-gnatf",
-
-            --  Enable all warnings and treat them as errors
-            "-gnatwae");
-
-      when "release" =>
-         --  Build with lots of optimizations, generate debug info (useful for
-         --  tracebacks) and use maximum runtime checks. Also enable all
-         --  warnings, but do not turn them into errors.
-         Ada_Switches := (
-            --  Build with lots of optimizations. Generate debug info (useful
-            --  for tracebacks).
-            "-O2", "-g",
-
-            --  Generate position-independent code
-            "-fPIC",
-
-            --  Enable lots of extra runtime checks
-            "-gnatVa", "-gnatwa", "-gnato", "-fstack-check", "-gnata",
-            "-gnatf", "-fPIC");
-   end case;
-
-   package Compiler is
-      for Default_Switches ("Ada") use Ada_Switches;
-   end Compiler;
-
-   package Builder is
-      for Switches ("ada") use ("-s", "-j0", "-g");
-   end Builder;
-
-   package Binder is
-      for Switches ("ada") use ("-Es", "-g", "-static");
-   end Binder;
-
-   package Ide is
-      for Vcs_Kind use "Git";
-   end Ide;
+   package Compiler renames Alire_Common.Compiler;
+   package Builder renames Alire_Common.Builder;
+   package Binder renames Alire_Common.Binder;
+   package Ide renames Alire_Common.Ide;
 
 end Alire;

--- a/alire_common.gpr
+++ b/alire_common.gpr
@@ -1,0 +1,58 @@
+abstract project Alire_Common is
+
+   type Any_Build_Mode is ("debug", "release");
+   Build_Mode : Any_Build_Mode := external ("ALIRE_BUILD_MODE", "debug");
+   --  Profile for the build, depending on the use case. Debug favors
+   --  debuggability (for developper convenience) while release favors
+   --  optimizations.
+
+   package Compiler is
+      case Build_Mode is
+         when "debug" =>
+            for Default_Switches ("Ada") use (
+               --  Build with no optimization in debug mode
+               "-g", "-O0",
+
+               --  Enable lots of extra runtime checks
+               "-gnatVa", "-gnato", "-fstack-check", "-gnata",
+
+               --  Enable full errors, verbose details
+               "-gnatf",
+
+               --  Enable all warnings and treat them as errors
+               "-gnatwae");
+
+            for Default_Switches ("C") use ("-g", "-O0", "-Wall");
+            --  Likewise for C units
+
+         when "release" =>
+            for Default_Switches ("Ada") use (
+               --  Build with lots of optimizations. Generate debug info
+               --  (useful for tracebacks).
+               "-O2", "-g",
+
+               --  Generate position-independent code
+               "-fPIC",
+
+               --  Enable lots of extra runtime checks
+               "-gnatVa", "-gnatwa", "-gnato", "-fstack-check", "-gnata",
+               "-gnatf", "-fPIC");
+
+            for Default_Switches ("C") use ("-g", "-O2", "-Wall", "-fPIC");
+            --  Likewise for C units
+      end case;
+   end Compiler;
+
+   package Builder is
+      for Switches ("Ada") use ("-s", "-j0", "-g");
+   end Builder;
+
+   package Binder is
+      for Switches ("Ada") use ("-Es", "-g", "-static");
+   end Binder;
+
+   package Ide is
+      for Vcs_Kind use "Git";
+   end Ide;
+
+end Alire_Common;

--- a/alr.gpr
+++ b/alr.gpr
@@ -1,6 +1,7 @@
 with "aaa";
 with "ada_toml";
 with "alire";
+with "alire_common";
 with "ajunitgen";
 with "semantic_versioning";
 with "simple_logging";
@@ -8,11 +9,7 @@ with "xml_ez_out";
 
 project Alr is
 
-   type Any_Build_Mode is ("debug", "release");
-   Build_Mode : Any_Build_Mode := external ("ALR_BUILD_MODE", "debug");
-
-   for Source_Dirs use ("src/alr", 
-                        "src/alr/os_linux");
+   for Source_Dirs use ("src/alr", "src/alr/os_linux");
 
    for Object_Dir use "obj";
    for Exec_Dir use "bin";
@@ -20,73 +17,9 @@ project Alr is
 
    for Languages use ("Ada", "C");
 
-   Ada_Switches := ();
-   C_Switches := ();
-
-   case Build_Mode is
-      when "debug" =>
-         Ada_Switches := (
-            --  Build with no optimization in debug mode
-            "-g", "-O0",
-
-            --  Enable lots of extra runtime checks
-            "-gnatVa", "-gnato", "-fstack-check", "-gnata",
-
-            --  Enable full errors, verbose details
-            "-gnatf",
-
-            --  Enable all warnings and treat them as errors
-            "-gnatwae");
-
-         --  Likewise for C units
-         C_Switches := ("-g", "-O0", "-Wall");
-
-      when "release" =>
-         --  Build with lots of optimizations, generate debug info (useful for
-         --  tracebacks) and use maximum runtime checks. Also enable all
-         --  warnings, but do not turn them into errors.
-         Ada_Switches := (
-            --  Build with lots of optimizations. Generate debug info (useful
-            --  for tracebacks).
-            "-O2", "-g",
-
-            --  Force the use of Ada 2012
-            "-gnat12",
-
-            --  Generate extra code to write profile information (prof)
-            "-p",
-
-            --  Generate position-independent code
-            "-fPIC",
-
-            --  Enable lots of extra runtime checks
-            "-gnatVa", "-gnatwa", "-gnato", "-fstack-check", "-gnata",
-            "-gnatf", "-fPIC");
-
-         --  Likewise for C units
-         C_Switches := ("-g", "-O2", "-Wall", "-fPIC");
-   end case;
-
-   package Compiler is
-      for Default_Switches ("Ada") use Ada_Switches;
-      for Default_Switches ("C") use C_Switches;
-   end Compiler;
-
-   package Builder is
-      for Switches ("ada") use ("-s", "-j0", "-g");
-      for Executable ("alr-main.adb") use "alr";
-   end Builder;
-
-   package Binder is
-      for Switches ("ada") use ("-Es", "-g", "-static");
-   end Binder;
-
-   package Linker is
-      for Switches ("ada") use ("-g");
-   end Linker;
-
-   package Ide is
-      for Vcs_Kind use "Git";
-   end Ide;
+   package Compiler renames Alire_Common.Compiler;
+   package Builder renames Alire_Common.Builder;
+   package Binder renames Alire_Common.Binder;
+   package Ide renames Alire_Common.Ide;
 
 end Alr;


### PR DESCRIPTION
As a side effect, there is a single scenario variable left to select the
build profile: ALIRE_BUILD_MODE. This is more convenient, as someone
who wants to build alire using some build mode most probably also wants
to build alr in the same build mode.