### PR TITLE
Load a single release from a non-index TOML file

### DIFF
--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -519,10 +519,14 @@ package body Alire.Releases is
       Relinfo := TOML.Merge (Relinfo, R.Origin.To_TOML);
 
       -- Dependencies
-      Relinfo.Set (TOML_Keys.Dependency, R.Dependencies.To_TOML);
+      if not R.Dependencies.Is_Empty then
+         Relinfo.Set (TOML_Keys.Dependency, R.Dependencies.To_TOML);
+      end if;
 
       -- Forbidden
-      Relinfo.Set (TOML_Keys.Forbidden, R.Forbidden.To_TOML);
+      if not R.Forbidden.Is_Empty then
+         Relinfo.Set (TOML_Keys.Forbidden, R.Forbidden.To_TOML);
+      end if;
 
       -- Available
       if R.Available.Is_Empty or else R.Available = Alire.Requisites.Booleans.Always_True then

--- a/src/alire/alire-root.adb
+++ b/src/alire/alire-root.adb
@@ -1,3 +1,4 @@
+with Alire.Containers;
 with Alire.Directories;
 with Alire.Paths;
 with Alire.TOML_Index;
@@ -16,13 +17,24 @@ package body Alire.Root is
          Compiler => Env.Compiler);
 
       if Path /= "" then
-         return Roots.New_Root
-           (TOML_Index.Load_Release_From_File
+         declare
+            Release : Containers.Release_Holders.Holder;
+            Result  : TOML_Index.Load_Result;
+         begin
+            TOML_Index.Load_Release_From_File
               (Filename    => Directories.Find_Single_File
                  (Path      => Path / Paths.Working_Folder_Inside_Root,
                   Extension => Paths.Crate_File_Extension_With_Dot),
-               Environment => Index_Env),
-            Path);
+               Environment => Index_Env,
+               Release     => Release,
+               Result      => Result);
+
+            if Result.Success then
+               return Roots.New_Root (Release.Element, Path);
+            else
+               return Roots.New_Invalid_Root;
+            end if;
+         end;
       else
          return Roots.New_Invalid_Root;
       end if;

--- a/src/alire/alire-root.adb
+++ b/src/alire/alire-root.adb
@@ -1,13 +1,28 @@
 with Alire.Directories;
+with Alire.Paths;
+with Alire.TOML_Index;
 
 package body Alire.Root is
 
-   function Current return Roots.Root is
-      Path : constant String := Directories.Detect_Root_Path;
+   function Current (Env : Environment.Setup) return Roots.Root is
+      use Alire.Directories;
+      Path      : constant String := Directories.Detect_Root_Path;
+      Index_Env : TOML_Index.Environment_Variables;
    begin
+      Alire.TOML_Index.Set_Environment
+        (Env      => Index_Env,
+         Distrib  => Env.Distro,
+         OS       => Env.OS,
+         Compiler => Env.Compiler);
+
       if Path /= "" then
-         -- TODO: fix this to detect & load the crate toml file
-         return Roots.New_Invalid_Root;
+         return Roots.New_Root
+           (TOML_Index.Load_Release_From_File
+              (Filename    => Directories.Find_Single_File
+                 (Path      => Path / Paths.Working_Folder_Inside_Root,
+                  Extension => Paths.Crate_File_Extension_With_Dot),
+               Environment => Index_Env),
+            Path);
       else
          return Roots.New_Invalid_Root;
       end if;

--- a/src/alire/alire-root.ads
+++ b/src/alire/alire-root.ads
@@ -1,9 +1,10 @@
+with Alire.Environment;
 with Alire.Releases;
 with Alire.Roots;
 
 package Alire.Root is
 
-   function Current return Roots.Root;
+   function Current (Env : Environment.Setup) return Roots.Root;
 
    --  TODO
    --  This global is a remain of when self-compilation existed

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -347,10 +347,11 @@ package body Alire.TOML_Index is
    -- Load_Release_From_File --
    ----------------------------
 
-   function Load_Release_From_File
+   procedure Load_Release_From_File
      (Filename    : String;
-      Environment : Environment_Variables)
-      return        Releases.Release
+      Environment : Environment_Variables;
+      Release     : out Containers.Release_Holders.Holder;
+      Result      : out Load_Result)
    is
       Pkg      : Package_Type;
       Value    : TOML.TOML_Value;

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -376,7 +376,7 @@ package body Alire.TOML_Index is
 
       --  Generate the releases to be imported
 
-      Import_TOML_Package_As_Releases (Pkg, Environment, Releases);
+      Decode_TOML_Package_As_Releases (Pkg, Environment, Releases);
 
       --  Verify and return
       if Releases.Is_Empty then
@@ -507,7 +507,7 @@ package body Alire.TOML_Index is
 
       --  Generate the releases to be imported
 
-      Import_TOML_Package_As_Releases (Pkg, Environment, Releases);
+      Decode_TOML_Package_As_Releases (Pkg, Environment, Releases);
 
       --  Finally import them to the catalog
 
@@ -1594,7 +1594,7 @@ package body Alire.TOML_Index is
    -- Import_TOML_Package_As_Releases --
    -------------------------------------
 
-   procedure Import_TOML_Package_As_Releases
+   procedure Decode_TOML_Package_As_Releases
      (Pkg         : Package_Type;
       Environment : Environment_Variables;
       Releases    : out Containers.Release_Sets.Set)
@@ -1888,7 +1888,7 @@ package body Alire.TOML_Index is
       when Evaluation_Error =>
          Trace.Error (+Error_Message);
          null;
-   end Import_TOML_Package_As_Releases;
+   end Decode_TOML_Package_As_Releases;
 
    --------------------
    -- Index_Releases --

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -1868,7 +1868,11 @@ package body Alire.TOML_Index is
                  (Project            => +(+Pkg.Name),
                   Version            => R.Version,
                   Origin             => Origin,
-                  Notes              => +Pkg.Common.Notes,
+                  Notes              => +US.Head
+                    (Pkg.Common.Notes, Alire.Max_Description_Length),
+                  -- It crops too long notes, so something TODO about this
+                  -- Since it didn't fail before, I guess they weren't added
+                  --  this way (only as property?)
                   Dependencies       => Dependencies,
                   Properties         => Index."and"
                     (Index."and" (General_Properties, Properties (Pkg.Common)),

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -347,11 +347,10 @@ package body Alire.TOML_Index is
    -- Load_Release_From_File --
    ----------------------------
 
-   procedure Load_Release_From_File
+   function Load_Release_From_File
      (Filename    : String;
-      Environment : Environment_Variables;
-      Release     : out Containers.Release_Holders.Holder;
-      Result      : out Load_Result)
+      Environment : Environment_Variables)
+      return        Releases.Release
    is
       Pkg      : Package_Type;
       Value    : TOML.TOML_Value;

--- a/src/alire/alire-toml_index.ads
+++ b/src/alire/alire-toml_index.ads
@@ -317,7 +317,7 @@ private
    --  Result.Success to true. If the package description is invalid, set it to
    --  false and produce an error message.
 
-   procedure Import_TOML_Package_As_Releases
+   procedure Decode_TOML_Package_As_Releases
      (Pkg         : Package_Type;
       Environment : Environment_Variables;
       Releases    : out Containers.Release_Sets.Set);

--- a/src/alire/alire-toml_index.ads
+++ b/src/alire/alire-toml_index.ads
@@ -8,9 +8,11 @@ private with TOML;
 private with Semantic_Versioning;
 
 private with Alire.Actions;
+with Alire.Containers;
 with Alire.TOML_Expressions;
 private with Alire.Licensing;
 with Alire.Platforms;
+with Alire.Releases;
 
 package Alire.TOML_Index is
 
@@ -52,6 +54,14 @@ package Alire.TOML_Index is
    --  Load a specific package from the TOML catalog in the given directory
    --  using the given environment variables.  This does nothing if the package
    --  is already loaded.
+
+   procedure Load_Release_From_File
+     (Filename    : String;
+      Environment : Environment_Variables;
+      Release     : out Containers.Release_Holders.Holder;
+      Result      : out Load_Result) with
+     Post => Result.Success = not Release.Is_Empty;
+   --  Load a file that must contain a single release.
 
 private
 
@@ -307,9 +317,15 @@ private
    --  Result.Success to true. If the package description is invalid, set it to
    --  false and produce an error message.
 
-   procedure Import_TOML_Package
+   procedure Import_TOML_Package_As_Releases
      (Pkg         : Package_Type;
-      Environment : Environment_Variables);
-   --  Import the given package to Alire's internal index
+      Environment : Environment_Variables;
+      Releases    : out Containers.Release_Sets.Set);
+   --  Generate one fully populated release per version loaded in Pkg
+
+   procedure Index_Releases
+     (Pkg      : Package_Type;
+      Releases : Containers.Release_Sets.Set);
+   --  Add the given releases to the internal index
 
 end Alire.TOML_Index;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -8,7 +8,6 @@ with Alire;
 with Alire.Config;
 with Alire.Features.Index;
 with Alire.Index;
-with Alire.Root;
 with Alire.Roots;
 with Alire.Roots.Check_Valid;
 with Alire.Utils;
@@ -32,6 +31,7 @@ with Alr.Commands.Withing;
 with Alr.Interactive;
 with Alr.Paths;
 with Alr.Platform;
+with Alr.Root;
 with Alr.Templates;
 
 with GNAT.OS_Lib;
@@ -334,7 +334,7 @@ package body Alr.Commands is
 
    procedure Requires_Buildfile is
       Guard : OS_Lib.Folder_Guard (Enter_Project_Folder) with Unreferenced;
-      Root  : constant Alire.Roots.Root := Alire.Root.Current;
+      Root  : constant Alire.Roots.Root := Alr.Root.Current;
    begin
       if Bootstrap.Session_State /= Project then
          Reportaise_Wrong_Arguments ("Cannot generate build file when not in a project");
@@ -375,7 +375,7 @@ package body Alr.Commands is
 
    procedure Requires_Project is
    begin
-      Alire.Roots.Check_Valid (Alire.Root.Current);
+      Alire.Roots.Check_Valid (Root.Current);
    end Requires_Project;
 
    ----------------------

--- a/src/alr/alr-root.adb
+++ b/src/alr/alr-root.adb
@@ -1,0 +1,21 @@
+with Alire.Environment;
+with Alire.Root;
+
+with Alr.Platform;
+
+package body Alr.Root is
+
+   -------------
+   -- Current --
+   -------------
+
+   function Current return Alire.Roots.Root is
+   begin
+      return Alire.Root.Current
+        (Env => Alire.Environment.Setup'
+           (OS       => Platform.Operating_System,
+            Distro   => Platform.Distribution,
+            Compiler => Platform.Compiler));
+   end Current;
+
+end Alr.Root;

--- a/src/alr/alr-root.ads
+++ b/src/alr/alr-root.ads
@@ -1,4 +1,8 @@
-with Alire.Root;
+with Alire.Roots;
 
-package Alr.Root renames Alire.Root;
--- TODO: delete once global Alire.Root is removed
+package Alr.Root is
+   -- TODO: delete once global Alire.Root is removed
+
+   function Current return Alire.Roots.Root;
+
+end Alr.Root;


### PR DESCRIPTION
Commands that apply to a downloaded project rely on getting the release info from a TOML file (since this can be an unreleased project, or a release that has been modified).

I have moved things a bit around in TOML_Index to be able to load a release without indexing it. Since this is your turf, maybe I have missed something in the process.

The main change is adding an extra step after decoding a Pkg, so the releases are not directly indexed.