### PR TITLE
Fixes #73 in various commands

### DIFF
--- a/src/alire/alire-dependencies.adb
+++ b/src/alire/alire-dependencies.adb
@@ -11,7 +11,9 @@ package body Alire.Dependencies is
       elsif Length (Dep.Versions) > 1 then
          raise Unimplemented; -- TODO (but not yet in index format)
       else
-         return +Operator_Image (Element (Dep.Versions, 1));
+         return +Image_Abbreviated (Dep.Versions,
+                                    Unicode        => True,
+                                    Implicit_Equal => True);
       end if;
    end To_TOML;
 

--- a/src/alire/alire-dependencies.ads
+++ b/src/alire/alire-dependencies.ads
@@ -51,12 +51,12 @@ private
    function Versions (Dep : Dependency) return Semantic_Versioning.Version_Set is
      (Dep.Versions);
 
-   function Image (Dep : Dependency) return String is -- Exceptional case: alire=0.0.0 means Unavailable
+   function Image (Dep : Dependency) return String is
      (if Dep = Unavailable
       then "Unavailable"
       else
         (Utils.To_Lower_Case (+Dep.Project) & " is " &
-           Semantic_Versioning.Image (Dep.Versions)));
+           Semantic_Versioning.Image_Ada (Dep.Versions)));
 
    overriding function Key (Dep : Dependency) return String is (+Dep.Project);
 

--- a/src/alire/alire-index.adb
+++ b/src/alire/alire-index.adb
@@ -84,7 +84,8 @@ package body Alire.Index is
             Self_Name    => Self_Name)
          do
             Master_Entries.Insert (C.Project, C);
-            Projects.Descriptions.Insert (C.Project, Description);
+            Projects.Descriptions.Include (C.Project, Description);
+            --  This description may be already present from the session project file
          end return;
       end if;
    end Manually_Catalogued_Project;

--- a/src/alire/alire-origins.adb
+++ b/src/alire/alire-origins.adb
@@ -111,7 +111,7 @@ package body Alire.Origins is
    begin
       case This.Kind is
          when Filesystem =>
-            Table.Set (TOML_Keys.Origin, +("path:" & This.Path));
+            Table.Set (TOML_Keys.Origin, +("file://" & This.Path));
          when VCS_Kinds =>
             Table.Set (TOML_Keys.Origin, +(Prefix (This.Kind) & "+" & This.URL & "@" & This.Commit));
          when Native =>

--- a/src/alire/alire-root.adb
+++ b/src/alire/alire-root.adb
@@ -20,11 +20,13 @@ package body Alire.Root is
          declare
             Release : Containers.Release_Holders.Holder;
             Result  : TOML_Index.Load_Result;
+            File    : constant String :=
+                        Directories.Find_Single_File
+                          (Path      => Path / Paths.Working_Folder_Inside_Root,
+                           Extension => Paths.Crate_File_Extension_With_Dot);
          begin
             TOML_Index.Load_Release_From_File
-              (Filename    => Directories.Find_Single_File
-                 (Path      => Path / Paths.Working_Folder_Inside_Root,
-                  Extension => Paths.Crate_File_Extension_With_Dot),
+              (Filename    => File,
                Environment => Index_Env,
                Release     => Release,
                Result      => Result);
@@ -32,6 +34,7 @@ package body Alire.Root is
             if Result.Success then
                return Roots.New_Root (Release.Element, Path);
             else
+               Trace.Debug ("Failed to load " & File & ": " & (+Result.Message));
                return Roots.New_Invalid_Root;
             end if;
          end;

--- a/src/alire/alire-root.adb
+++ b/src/alire/alire-root.adb
@@ -34,7 +34,7 @@ package body Alire.Root is
             if Result.Success then
                return Roots.New_Root (Release.Element, Path);
             else
-               Trace.Debug ("Failed to load " & File & ": " & (+Result.Message));
+               Trace.Error ("Failed to load " & File & ": " & (+Result.Message));
                return Roots.New_Invalid_Root;
             end if;
          end;

--- a/src/alire/alire-root.adb
+++ b/src/alire/alire-root.adb
@@ -34,12 +34,12 @@ package body Alire.Root is
             if Result.Success then
                return Roots.New_Root (Release.Element, Path);
             else
-               Trace.Error ("Failed to load " & File & ": " & (+Result.Message));
-               return Roots.New_Invalid_Root;
+               return Roots.New_Invalid_Root.With_Reason
+                 ("Failed to load " & File & ": " & (+Result.Message));
             end if;
          end;
       else
-         return Roots.New_Invalid_Root;
+         return Roots.New_Invalid_Root.With_Reason ("Could not detect a session folder at current or parent locations");
       end if;
    end Current;
 

--- a/src/alire/alire-roots-check_valid.adb
+++ b/src/alire/alire-roots-check_valid.adb
@@ -1,19 +1,19 @@
 with Ada.Directories;
 
-procedure Alire.Roots.Check_Valid (This : Root) is
+function Alire.Roots.Check_Valid (This : Root) return Root is
    use Ada.Directories;
 begin
-   if not Exists (This.Working_Folder) then
-      Trace.Error ("alire subfolder not found");
-      raise Program_Error;
+   if not This.Is_Valid then
+      return This; -- Keep as is
+   elsif not Exists (This.Working_Folder) then
+      return New_Invalid_Root.With_Reason ("alire subfolder not found");
    elsif Kind (This.Working_Folder) /= Directory then
-      Trace.Error ("Expected alire folder but found a: " & Kind (This.Working_Folder)'Img);
-      raise Program_Error;
+      return New_Invalid_Root.With_Reason ("Expected alire folder but found a: " & Kind (This.Working_Folder)'Img);
    elsif not Exists (This.Crate_File) then
-      Trace.Error ("Dependency file not found in alire folder");
-      raise Program_Error;
+      return New_Invalid_Root.With_Reason ("Dependency file not found in alire folder");
    elsif Kind (This.Crate_File) /= Ordinary_File then
-      Trace.Error ("Expected ordinary file but found a: " & Kind (This.Crate_File)'Img);
-      raise Program_Error;
+      return New_Invalid_Root.With_Reason ("Expected ordinary file but found a: " & Kind (This.Crate_File)'Img);
+   else
+      return This; -- Nothing untoward detected
    end if;
 end Alire.Roots.Check_Valid;

--- a/src/alire/alire-roots-check_valid.ads
+++ b/src/alire/alire-roots-check_valid.ads
@@ -1,2 +1,2 @@
-procedure Alire.Roots.Check_Valid (This : Root)
-  with Post => This.Is_Valid or else raise Program_Error;
+function Alire.Roots.Check_Valid (This : Root) return Root
+  with Post => Check_Valid'Result.Is_Valid or else Check_Valid'Result.Invalid_Reason /= "";

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -43,6 +43,7 @@ package Alire.Roots with Preelaborate is
    function New_Root (R    : Releases.Release;
                       Path : Absolute_Path) return Root;
    --  From existing release
+   --  Path must point to the session folder (parent of alire metadata folder)
 
    function Path (This : Root) return Absolute_Path with
      Pre => This.Is_Valid;

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -15,8 +15,23 @@ package Alire.Roots with Preelaborate is
 
    function Is_Valid (This : Root) return Boolean;
 
+   -------------------
+   -- Invalid roots --
+   -------------------
+
    function New_Invalid_Root return Root with
      Post => not New_Invalid_Root'Result.Is_Valid;
+
+   function With_Reason (This : Root; Reason : String) return Root with
+     Pre  => not This.Is_Valid,
+     Post => not This.Is_Valid and then With_Reason'Result.Invalid_Reason = Reason;
+
+   function Invalid_Reason (This : Root) return String with
+     Pre => not This.Is_Valid;
+
+   -----------------
+   -- Valid roots --
+   -----------------
 
    --  See Alire.Directories.Detect_Root_Path to use with the following
 
@@ -57,13 +72,21 @@ private
             Path    : Ustring;
             Release : Containers.Release_H;
          when False =>
-            null;
+            Reason  : Ustring;
       end case;
    end record;
 
    function Is_Valid (This : Root) return Boolean is (This.Valid);
 
-   function New_Invalid_Root return Root is (Valid => False);
+   function New_Invalid_Root return Root is
+     (Valid => False, Reason => +"");
+
+   function With_Reason (This : Root; Reason : String) return Root is
+     (Valid  => False,
+      Reason => +Reason);
+
+   function Invalid_Reason (This : Root) return String is
+      (+This.Reason);
 
    function New_Root (Name : Alire.Project;
                       Path : Absolute_Path) return Root is

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -96,6 +96,7 @@ package body Alire.TOML_Index is
 
    Custom_License_Prefix : constant String := "custom:";
 
+   Filesystem_Prefix : constant String := "file://";
    Native_Prefix : constant String := "native:";
 
    type Distribution_Names is
@@ -717,6 +718,10 @@ package body Alire.TOML_Index is
             --  string denotes an unavailable package.
 
             Result.Value := (Native_Package, +"");
+
+         elsif Starts_With (S, Filesystem_Prefix) then
+            Result.Value := (Filesystem,
+                             +S (S'First + Native_Prefix'Length .. S'Last));
 
          elsif Starts_With (S, "git+")
             and then Decode_VCS (S, URL, Revision)
@@ -1651,6 +1656,7 @@ package body Alire.TOML_Index is
          O := Label.Value;
          return
            (case O.Kind is
+            when Filesystem => Alire.Origins.New_Filesystem (+O.Path),
             when Git => Index.Git (+O.Repo_URL, +O.Revision),
             when Mercurial => Index.Hg (+O.Repo_URL, +O.Revision),
             when SVN => Index.SVN (+O.Repo_URL, +O.Revision),

--- a/src/alire/alire-toml_index.ads
+++ b/src/alire/alire-toml_index.ads
@@ -187,7 +187,7 @@ private
    -- Origin expressions --
    ------------------------
 
-   type Origin_Kind is (Git, Mercurial, SVN, Source_Archive, Native_Package);
+   type Origin_Kind is (Filesystem, Git, Mercurial, SVN, Source_Archive, Native_Package);
    subtype VCS_Origin_Kind is Origin_Kind range Git .. SVN;
 
    type Origin_Type (Kind : Origin_Kind := Git) is record
@@ -201,6 +201,9 @@ private
 
          when Native_Package =>
             Package_Name : US.Unbounded_String;
+
+         when Filesystem =>
+            Path : US.Unbounded_String;
       end case;
    end record;
 

--- a/src/alr/alr-bootstrap.adb
+++ b/src/alr/alr-bootstrap.adb
@@ -8,6 +8,7 @@ with Alire.Index;
 
 with Alr.OS_Lib;
 with Alr.Paths;
+with Alr.Root;
 with Alr.Utils;
 
 with GNAT.Ctrl_C;
@@ -72,8 +73,11 @@ package body Alr.Bootstrap is
 
    function Session_State return Session_States is
    begin
-      --  TODO
-      return Outside;
+      if Root.Current.Is_Valid then
+         return Project;
+      else
+         return Outside;
+      end if;
    end Session_State;
 
    -----------------

--- a/src/alr/alr-commands-compile.adb
+++ b/src/alr/alr-commands-compile.adb
@@ -39,7 +39,6 @@ package body Alr.Commands.Compile is
       end Add_Paths;
 
    begin
-      Requires_Full_Index;
       Requires_Project;
       Requires_Buildfile;
 
@@ -47,7 +46,11 @@ package body Alr.Commands.Compile is
       begin
          --  TODO: this is a costly operation that requires solving dependencies
          --  Perhaps it will be necessary in the future to cache these in the session file
-         Add_Paths;
+         --  Alternatively, with gprinstall, paths might become obsolete
+         if not Root.Current.Release.Dependencies (Platform.Properties).Is_Empty then
+            Requires_Full_Index;
+            Add_Paths;
+         end if;
 
          Spawn.Gprbuild (Root.Current.Build_File,
                          Extra_Args    => Scenario.As_Command_Line);

--- a/src/alr/alr-commands-compile.adb
+++ b/src/alr/alr-commands-compile.adb
@@ -39,6 +39,7 @@ package body Alr.Commands.Compile is
       end Add_Paths;
 
    begin
+      Requires_Full_Index;
       Requires_Project;
       Requires_Buildfile;
 

--- a/src/alr/alr-commands-pin.adb
+++ b/src/alr/alr-commands-pin.adb
@@ -1,3 +1,5 @@
+with Alire.Releases;
+
 with Alr.Commands.Update;
 with Alr.Platform;
 with Alr.Query;
@@ -14,17 +16,18 @@ package body Alr.Commands.Pin is
    is
       pragma Unreferenced (Cmd);
    begin
+      Requires_Full_Index;
       Requires_Project;
 
       declare
-         Deps : constant Query.Solution :=
+         Sol : constant Query.Solution :=
                   Query.Resolve (Root.Current.Release.Dependencies (Platform.Properties),
                                  Query_Policy);
       begin
-         if Deps.Valid then
+         if Sol.Valid then
             Templates.Generate_Prj_Alr
               (Root.Current.Release.Replacing
-                 (Dependencies => Deps.Releases.To_Dependencies));
+                 (Dependencies => Sol.Releases.To_Dependencies));
 
             Update.Execute;
          else

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -47,11 +47,14 @@ package body Alr.Commands.Show is
 
    procedure Report (Name     : Alire.Project;
                      Versions : Semver.Version_Set;
+                     Current  : Boolean; -- session or command-line requested release
                      Cmd      : Command) is
    begin
       declare
          Rel     : constant Types.Release  :=
-                     Query.Find (Name, Versions, Query_Policy);
+                     (if Current
+                      then Root.Current.Release
+                      else Query.Find (Name, Versions, Query_Policy));
       begin
          New_Line;
 
@@ -127,9 +130,6 @@ package body Alr.Commands.Show is
 
       if Num_Arguments = 1 then
          Requires_Full_Index;
-      else
-         -- TODO: load current dependency file (former alr_deps)
-         raise Program_Error with "To be fixed";
       end if;
 
       declare
@@ -139,7 +139,10 @@ package body Alr.Commands.Show is
                       else Parsers.Project_Versions (Root.Current.Release.Milestone.Image));
       begin
          --  Execute
-         Report (Allowed.Project, Allowed.Versions, Cmd);
+         Report (Allowed.Project,
+                 Allowed.Versions,
+                 Num_Arguments = 0,
+                 Cmd);
       exception
          when Alire.Query_Unsuccessful =>
             Trace.Info ("Project [" & Argument (1) & "] does not exist in the catalog.");

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -292,6 +292,8 @@ package body Alr.Commands.Test is
          end if;
       end if;
 
+      Requires_Full_Index;
+
       --  Pre-find candidates to not have duplicate tests if overlapping requested
       Find_Candidates;
 

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -105,7 +105,7 @@ package body Alr.Commands.Withing is
          New_Root  : constant Alire.Roots.Root :=
                        Alire.Roots.New_Root
                          (Root.Current.Release.Replacing (Dependencies => Deps),
-                          Root.Current.Working_Folder);
+                          Root.Current.Path);
       begin
          Templates.Generate_Prj_Alr (New_Root.Release,
                                      New_Root.Crate_File);
@@ -289,8 +289,6 @@ package body Alr.Commands.Withing is
       else
          raise Program_Error with "List should have already happended";
       end if;
-
-      Commands.Update.Execute;
    exception
       when E : Constraint_Error =>
          Exceptions.Report ("In Withing.Execute:", E);

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -374,8 +374,11 @@ package body Alr.Commands is
    ----------------------
 
    procedure Requires_Project is
+      Checked : constant Alire.Roots.Root := Alire.Roots.Check_Valid (Root.Current);
    begin
-      Alire.Roots.Check_Valid (Root.Current);
+      if not Checked.Is_Valid then
+         Reportaise_Command_Failed ("Cannot continue with invalid session: " & Checked.Invalid_Reason);
+      end if;
    end Requires_Project;
 
    ----------------------

--- a/src/alr/alr-query.adb
+++ b/src/alr/alr-query.adb
@@ -28,7 +28,7 @@ package body Alr.Query is
                               Policy   : Policies := Newest) return String is
       ((+Project) &
        (if Versions /= Semver.Any
-        then " version " & Semver.Image (Versions)
+        then " version " & Semver.Image_Ada (Versions)
         else " with " & Utils.To_Mixed_Case (Policy'Img) & " version"));
 
    ------------

--- a/stress/selftest.sh
+++ b/stress/selftest.sh
@@ -77,7 +77,7 @@ pushd hello*
 alr compile
 popd
 rm -rf hello*
-alr get -c libhello
+alr get --compile libhello
 rm -rf libhello
 
 # GET

--- a/stress/selftest.sh
+++ b/stress/selftest.sh
@@ -57,7 +57,6 @@ echo BUILD
 alr get hello
 pushd hello*
 alr build 
-alr build --online
 popd
 
 # CLEAN test
@@ -105,9 +104,9 @@ echo PIN
 alr init --bin xxx
 cd xxx
 alr with libhello
-grep -q -i Current alire/alr_deps.ads
+grep -q -i 'libhello = "any"' alire/xxx.toml
 alr pin
-grep -q -i '=' alire/alr_deps.ads
+grep -q -i 'libhello = "1.0.0"' alire/xxx.toml
 cd ..
 rm -rf xxx
 
@@ -129,7 +128,7 @@ alr search hell | grep -q -i hello
 # UPDATE
 echo UPDATE
 # outisde
-alr update --online 
+alr update
 # inside
 alr init --bin xxx
 cd xxx


### PR DESCRIPTION
Roughly each commit adresses one command, except when new functionality is added.

With this, the old test suite in stress/selftest.sh passes again.

There are still points to address affected by the migration to toml for which I will create new stand-alone issues.