### PR TITLE
Better detection of broken sessions

### DIFF
--- a/src/alire/alire-roots-check_valid.ads
+++ b/src/alire/alire-roots-check_valid.ads
@@ -1,4 +1,4 @@
 function Alire.Roots.Check_Valid (This : Root) return Root
-  with Post => Check_Valid'Result.Is_Valid
-         or else
-       Check_Valid'Result.Invalid_Reason /= "";
+     with Post => Check_Valid'Result.Is_Valid or else
+                  Check_Valid'Result.Invalid_Reason /= "";
+   --  Check that given Root information is valid (paths, etc)

--- a/src/alr/alr-bootstrap.adb
+++ b/src/alr/alr-bootstrap.adb
@@ -79,6 +79,8 @@ package body Alr.Bootstrap is
    begin
       if Root.Current.Is_Valid then
          return Project;
+      elsif Alire.Directories.Detect_Root_Path /= "" then
+         return Broken;
       else
          return Outside;
       end if;

--- a/src/alr/alr-bootstrap.ads
+++ b/src/alr/alr-bootstrap.ads
@@ -8,10 +8,13 @@ package Alr.Bootstrap is
 
    type Session_States is
      (Outside,   -- Not in any Alire context
+      Broken,    -- Top-level folder is a single project, invalid TOML file
       Project,   -- Top-level folder is a single project
       Sandbox    -- Top-level folder is a sandbox with several projects
      );
    --  Sandbox mode is not implemented yet
+
+   subtype Valid_Session_States is Session_States range Project .. Sandbox;
 
    function Session_State return Session_States;
    --  Note that even if you're in a project within a sandbox, result is

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -5,6 +5,7 @@ with Alr.Platform;
 with Alr.Root;
 
 with Alire.Index;
+with Alire.Roots;
 
 with Semantic_Versioning;
 
@@ -124,8 +125,16 @@ package body Alr.Commands.Show is
 
       --  asking for info, we could return the current project
       --  We have internal data, but is it valid?
-      if Num_Arguments = 0 and then Bootstrap.Session_State = Outside then
-         Reportaise_Wrong_Arguments ("Cannot proceed with a project name");
+      if Num_Arguments = 0 Then
+         case Bootstrap.Session_State is
+            when Outside =>
+               Reportaise_Wrong_Arguments
+                 ("Cannot proceed without a project name");
+            when Broken =>
+               Requires_Project;
+            when Bootstrap.Valid_Session_States =>
+               null;
+         end case;
       end if;
 
       if Num_Arguments = 1 then


### PR DESCRIPTION
Sessions in which the local toml file isn't parsable prevent session commands to succeed. This patch makes this situation explicit, to distinguish a broken session (can't load toml file) from being outside of any session (there is no toml file to load).