### PR TITLE
Add command for management of indexes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "deps/ahven"]
-	path = deps/ahven
-	url = ./deps/ahven
 [submodule "deps/xmlezout"]
 	path = deps/xmlezout
 	url = https://github.com/alire-project/xmlezout.git
@@ -19,6 +16,3 @@
 [submodule "deps/ada-toml"]
 	path = deps/ada-toml
 	url = https://github.com/pmderodat/ada-toml.git
-[submodule "deps/alire-index"]
-	path = deps/alire-index
-	url = https://github.com/alire-project/alire-index.git

--- a/src/alire/alire-config.adb
+++ b/src/alire/alire-config.adb
@@ -1,5 +1,4 @@
 with Alire.Environment;
-with Alire.OS_Lib;
 with Alire.Platform;
 
 package body Alire.Config is
@@ -20,6 +19,10 @@ package body Alire.Config is
                                Platform.Default_Config_Folder);
       end if;
    end Path;
+
+   --------------
+   -- Set_Path --
+   --------------
 
    procedure Set_Path (Path : String) is
    begin

--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -1,3 +1,5 @@
+with Alire.OS_Lib; use Alire.OS_Lib.Operators;
+
 package Alire.Config with Preelaborate is
 
    --  For Alire to be usable as a library, options here aren't parsed
@@ -15,5 +17,7 @@ package Alire.Config with Preelaborate is
 
    procedure Set_Path (Path : String);
    --  Override
+
+   function Indexes_Directory return Absolute_Path is (Path / "indexes");
 
 end Alire.Config;

--- a/src/alire/alire-defaults.ads
+++ b/src/alire/alire-defaults.ads
@@ -1,5 +1,9 @@
 package Alire.Defaults with Preelaborate is
 
+   Community_Index : constant URL :=
+                       "git+https://github.com/alire-project/alire-index";
+   --  Default index installed on first run
+
    Description : constant String := "Shiny new project";
    --  TODO: replace this constant with a function that returns random fortunes
 

--- a/src/alire/alire-defaults.ads
+++ b/src/alire/alire-defaults.ads
@@ -4,6 +4,8 @@ package Alire.Defaults with Preelaborate is
                        "git+https://github.com/alire-project/alire-index";
    --  Default index installed on first run
 
+   Community_Index_Name : constant Restricted_Name := "community";
+
    Description : constant String := "Shiny new project";
    --  TODO: replace this constant with a function that returns random fortunes
 

--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -38,10 +38,6 @@ package body Alire.Features.Index is
       Index  : constant Index_On_Disk.Index'Class :=
                  Index_On_Disk.New_Handler (Origin, Name, Under, Result);
 
-      package Search is new Sets.Generic_Keys
-        (Key_Type => String,
-         Key      => Index_On_Disk.Name);
-
       use Alire.Directories.Operators;
    begin
       --  Try to avoid some minimal aliasing

--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -55,11 +55,6 @@ package body Alire.Features.Index is
          return Outcome_Success;
       end if;
 
-      --  Ensure no other index has the same name:
-      if Search.Contains (Find_All (Under), Name) then
-         return Outcome_Failure ("Index with given name already exists");
-      end if;
-
       Trace.Debug ("Adding index " & Origin & " at " & Under);
 
       if Result.Success then

--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -252,8 +252,8 @@ package body Alire.Features.Index is
    -- Load_All --
    --------------
 
-   procedure Load_All (Platform : Environment.Setup;
-                       From     : Absolute_Path)
+   function Load_All (Platform : Environment.Setup;
+                       From     : Absolute_Path) return Outcome
    is
       Env : Alire.TOML_Index.Environment_Variables;
    begin
@@ -268,12 +268,15 @@ package body Alire.Features.Index is
             Result : constant Outcome := Index.Load (Env);
          begin
             if not Result.Success then
-               Trace.Error ("Error while loading the index:");
-               Trace.Error (Message (Result));
-               OS_Lib.Bailout (1);
+               return
+                 Outcome_Failure
+                   ("While loading index " & Index.Name
+                    & ": " & Message (Result));
             end if;
          end;
       end loop;
+
+      return Outcome_Success;
    end Load_All;
 
    -------------------------

--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -285,4 +285,25 @@ package body Alire.Features.Index is
       end if;
    end Load_Index_Metadata;
 
+   ----------------
+   -- Update_All --
+   ----------------
+
+   function Update_All (Under : Absolute_Path) return Outcome is
+   begin
+      for Index of Find_All (Under) loop
+         declare
+            Result : constant Outcome := Index.Update;
+         begin
+            if Result.Success then
+               Trace.Detail ("Updated succesfully: " & Index.Origin);
+            else
+               return Result;
+            end if;
+         end;
+      end loop;
+
+      return Outcome_Success;
+   end Update_All;
+
 end Alire.Features.Index;

--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -1,34 +1,211 @@
+with Ada.Directories;
+with Ada.Text_IO;
+
+with Alire.Directories;
 with Alire.OS_Lib;
 with Alire.TOML_Index;
+with Alire.TOML_Keys;
+
+with GNAT.OS_Lib;
+
+with TOML;
+with TOML.File_IO;
 
 package body Alire.Features.Index is
+
+   --  Forward declarations
+
+   function Load_Index_Metadata (File  :     String;
+                                 Value : out TOML.TOML_Value) return Outcome;
+
+   ---------
+   -- Add --
+   ---------
+
+   function Add (Origin : URL;
+                 Name   : String;
+                 Under  : Absolute_Path) return Outcome is
+      Result : Outcome;
+      Index  : constant Index_On_Disk.Index'Class :=
+                 Index_On_Disk.New_Handler (Origin, Name, Under, Result);
+
+      package Search is new Sets.Generic_Keys
+        (Key_Type => String,
+         Key      => Index_On_Disk.Name);
+
+      use Alire.Directories.Operators;
+   begin
+      Trace.Debug ("Adding index " & Origin & " at " & Under);
+
+      --  Ensure no other index has the same name:
+      if Search.Contains (Find_All (Under), Name) then
+         return Outcome_Failure ("Index with given name already exists");
+      end if;
+
+      if Result.Success then
+         declare
+            use Ada.Text_IO;
+            File       : File_Type;
+            Metafolder : constant Platform_Independent_Path :=
+                           Under / Index.Name;
+         begin
+            --  Create containing folder with its metadata
+            Alire.Directories.Create_Directory (Metafolder);
+            Create (File, Out_File,
+                    Metafolder / Index_On_Disk.Metadata_Filename);
+            TOML.File_IO.Dump_To_File (Index.To_TOML, File);
+            Close (File);
+
+            --  Deploy the index
+            Result := Index.Add;
+
+            return Result;
+         exception
+            when E : others =>
+               Trace.Debug ("Exception creating index " & Origin);
+               Log_Exception (E);
+
+               if Is_Open (File) then
+                  Close (File);
+               end if;
+
+               --  Clean up if unsuccessful
+               if Ada.Directories.Exists (Under / Index.Name) then
+                  Ada.Directories.Delete_Tree (Under / Index.Name);
+               end if;
+               return Outcome_From_Exception (E);
+         end;
+      else
+         Trace.Warning ("Could not add requested index from " & Origin);
+         return Result;
+      end if;
+   end Add;
+
+   --------------
+   -- Find_All --
+   --------------
+
+   function Find_All (Under : Absolute_Path) return Index_On_Disk_Set is
+      package Dirs renames Ada.Directories;
+
+      Set : Index_On_Disk_Set;
+
+      ---------------
+      -- Check_One --
+      ---------------
+
+      procedure Check_One (Dir : Dirs.Directory_Entry_Type) is
+         use OS_Lib.Operators;
+         Metafile : constant String :=
+                      Dirs.Full_Name (Dir) / Index_On_Disk.Metadata_Filename;
+      begin
+         --  Find metadata file
+         if GNAT.OS_Lib.Is_Regular_File (Metafile) then
+            declare
+               Metadata    : TOML.TOML_Value;
+               Load_Result : constant Outcome :=
+                               Load_Index_Metadata (Metafile, Metadata);
+            begin
+               --  Load and verify contents
+               if Load_Result.Success then
+                  declare
+                     TOML_URL : constant TOML.TOML_Value :=
+                                  TOML.Get_Or_Null (Metadata,
+                                                    TOML_Keys.Index_URL);
+                  begin
+                     if TOML_URL.Is_Null then
+                        Trace.Warning ("Index metadata at " & Metafile &
+                                         " is invalid (missing URL)");
+                        return;
+                     end if;
+
+                     --  Create the handler for the on-disk index from metadata
+                     declare
+                        Result : Outcome;
+                        Index  : constant Index_On_Disk.Index'Class :=
+                                   Index_On_Disk.New_Handler
+                                     (Origin => TOML_URL.As_String,
+                                      Name   => "", -- Fixed in a later commit
+                                      Parent => Under,
+                                      Result => Result);
+                     begin
+                        if Result.Success then
+                           Set.Insert (Index);
+                        else
+                           Trace.Warning
+                             ("Index URL in " & Metafile &
+                                " is invalid: " & TOML_URL.As_String);
+                        end if;
+                     end;
+                  end;
+               else
+                  Trace.Warning ("Unable to load metadata from " & Metafile &
+                                 "; error: " & Message (Load_Result));
+               end if;
+            end;
+         end if;
+      end Check_One;
+
+   begin
+      Trace.Debug ("Looking for indexes at " & Under);
+
+      if GNAT.OS_Lib.Is_Directory (Under) then
+         Dirs.Search (Directory => Under,
+                      Pattern   => "*",
+                      Filter    => (Dirs.Directory => True,
+                                    others         => False),
+                      Process   => Check_One'Access);
+      end if;
+
+      Trace.Detail ("Found" & Set.Length'Img & " indexes");
+
+      return Set;
+   end Find_All;
 
    --------------
    -- Load_All --
    --------------
 
    procedure Load_All (Platform : Environment.Setup;
-                       From     : Absolute_Path) is
+                       From     : Absolute_Path)
+   is
+      Env : Alire.TOML_Index.Environment_Variables;
    begin
-      declare
-         Result : Alire.TOML_Index.Load_Result;
-         Env    : Alire.TOML_Index.Environment_Variables;
-      begin
-         Alire.TOML_Index.Set_Environment
-           (Env,
-            Platform.Distro,
-            Platform.OS,
-            Platform.Compiler);
-         Alire.TOML_Index.Load_Catalog
-           --  TODO: use configured indexes with `alr index`
-           (From, Env, Result);
+      Alire.TOML_Index.Set_Environment
+        (Env,
+         Platform.Distro,
+         Platform.OS,
+         Platform.Compiler);
 
-         if not Result.Success then
-            Trace.Error ("Error while loading the index:");
-            Trace.Error (Alire.TOML_Index.Error_Message (Result));
-            OS_Lib.Bailout (1);
-         end if;
-      end;
+      for Index of Find_All (From) loop
+         declare
+            Result : constant Outcome := Index.Load (Env);
+         begin
+            if not Result.Success then
+               Trace.Error ("Error while loading the index:");
+               Trace.Error (Message (Result));
+               OS_Lib.Bailout (1);
+            end if;
+         end;
+      end loop;
    end Load_All;
+
+   -------------------------
+   -- Load_Index_Metadata --
+   -------------------------
+
+   function Load_Index_Metadata (File  : String;
+                                 Value : out TOML.TOML_Value) return Outcome
+   is
+      Result : constant TOML.Read_Result := TOML.File_IO.Load_File (File);
+   begin
+      if Result.Success then
+         Value := Result.Value;
+         return Outcome_Success;
+      else
+         return Outcome_Failure ((+Result.Message) & " at line" &
+                                   Result.Location.Line'Img);
+      end if;
+   end Load_Index_Metadata;
 
 end Alire.Features.Index;

--- a/src/alire/alire-features-index.ads
+++ b/src/alire/alire-features-index.ads
@@ -23,6 +23,6 @@ package Alire.Features.Index is
                  Before : String := "") return Outcome;
    --  Add a new remote index under a folder that possibly contains more
    --    indexes in child folders. That is, Under is the parent of all indexes
-   --  Priority will be set as last, or before given index ID
+   --  Index will be set as last one, or before given index name
 
 end Alire.Features.Index;

--- a/src/alire/alire-features-index.ads
+++ b/src/alire/alire-features-index.ads
@@ -1,9 +1,26 @@
+with Ada.Containers.Indefinite_Ordered_Sets;
+
 with Alire.Environment;
+with Alire.Index_On_Disk;
 
 package Alire.Features.Index is
+
+   package Sets is new Ada.Containers.Indefinite_Ordered_Sets
+     (Index_On_Disk.Index'Class, Index_On_Disk."<", Index_On_Disk."=");
+
+   subtype Index_On_Disk_Set is Sets.Set;
+
+   function Find_All (Under : Absolute_Path) return Index_On_Disk_Set;
+   --  Find all indexes available on a disk location
 
    procedure Load_All (Platform : Environment.Setup;
                        From     : Absolute_Path);
    --  Load all indexes available at the given location
+
+   function Add (Origin : URL;
+                 Name   : String;
+                 Under  : Absolute_Path) return Outcome;
+   --  Add a new remote index under a folder that possibly contains more
+   --    indexes in child folders. That is, Under is the parent of all indexes
 
 end Alire.Features.Index;

--- a/src/alire/alire-features-index.ads
+++ b/src/alire/alire-features-index.ads
@@ -13,8 +13,8 @@ package Alire.Features.Index is
    function Find_All (Under : Absolute_Path) return Index_On_Disk_Set;
    --  Find all indexes available on a disk location
 
-   procedure Load_All (Platform : Environment.Setup;
-                       From     : Absolute_Path);
+   function Load_All (Platform : Environment.Setup;
+                      From     : Absolute_Path) return Outcome;
    --  Load all indexes available at the given location
 
    function Update_All (Under : Absolute_Path) return Outcome;

--- a/src/alire/alire-features-index.ads
+++ b/src/alire/alire-features-index.ads
@@ -19,8 +19,10 @@ package Alire.Features.Index is
 
    function Add (Origin : URL;
                  Name   : String;
-                 Under  : Absolute_Path) return Outcome;
+                 Under  : Absolute_Path;
+                 Before : String := "") return Outcome;
    --  Add a new remote index under a folder that possibly contains more
    --    indexes in child folders. That is, Under is the parent of all indexes
+   --  Priority will be set as last, or before given index ID
 
 end Alire.Features.Index;

--- a/src/alire/alire-features-index.ads
+++ b/src/alire/alire-features-index.ads
@@ -17,6 +17,9 @@ package Alire.Features.Index is
                        From     : Absolute_Path);
    --  Load all indexes available at the given location
 
+   function Update_All (Under : Absolute_Path) return Outcome;
+   --  Find and update all indexes at given location
+
    function Add (Origin : URL;
                  Name   : String;
                  Under  : Absolute_Path;

--- a/src/alire/alire-index_on_disk-directory.adb
+++ b/src/alire/alire-index_on_disk-directory.adb
@@ -1,5 +1,13 @@
 package body Alire.Index_On_Disk.Directory is
 
+   ---------------------
+   -- Index_Directory --
+   ---------------------
+
+   function Index_Directory (This : Index) return String is
+     (This.Origin
+        (This.Origin'First + File_Prefix'Length .. This.Origin'Last));
+
    -----------------
    -- New_Handler --
    -----------------

--- a/src/alire/alire-index_on_disk-directory.adb
+++ b/src/alire/alire-index_on_disk-directory.adb
@@ -1,0 +1,19 @@
+package body Alire.Index_On_Disk.Directory is
+
+   -----------------
+   -- New_Handler --
+   -----------------
+
+   function New_Handler (From   : URL;
+                         Name   : Restricted_Name;
+                         Parent : Platform_Independent_Path) return Index is
+   begin
+      return Idx : constant Index := Index'(URL_Len  => From'Length,
+                                            Name_Len => Name'Length,
+                                            Dir_Len  => Parent'Length,
+                                            Origin   => From,
+                                            Name     => Name,
+                                            Parent   => Parent);
+   end New_Handler;
+
+end Alire.Index_On_Disk.Directory;

--- a/src/alire/alire-index_on_disk-directory.adb
+++ b/src/alire/alire-index_on_disk-directory.adb
@@ -13,7 +13,8 @@ package body Alire.Index_On_Disk.Directory is
                                             Dir_Len  => Parent'Length,
                                             Origin   => From,
                                             Name     => Name,
-                                            Parent   => Parent);
+                                            Parent   => Parent,
+                                            Priority => <>);
    end New_Handler;
 
 end Alire.Index_On_Disk.Directory;

--- a/src/alire/alire-index_on_disk-directory.adb
+++ b/src/alire/alire-index_on_disk-directory.adb
@@ -4,6 +4,7 @@ package body Alire.Index_On_Disk.Directory is
    -- Index_Directory --
    ---------------------
 
+   overriding
    function Index_Directory (This : Index) return String is
      (This.Origin
         (This.Origin'First + File_Prefix'Length .. This.Origin'Last));
@@ -12,6 +13,7 @@ package body Alire.Index_On_Disk.Directory is
    -- New_Handler --
    -----------------
 
+   overriding
    function New_Handler (From   : URL;
                          Name   : Restricted_Name;
                          Parent : Platform_Independent_Path) return Index is

--- a/src/alire/alire-index_on_disk-directory.ads
+++ b/src/alire/alire-index_on_disk-directory.ads
@@ -2,7 +2,7 @@ with Alire.Utils;
 
 package Alire.Index_On_Disk.Directory is
 
-   --  A local index that is already on disk
+   --  A local index that is taken from a local filesystem path
 
    type Index (<>) is new Index_On_Disk.Index with private;
 
@@ -19,7 +19,7 @@ package Alire.Index_On_Disk.Directory is
 
    overriding
    function Index_Directory (This : Index) return String;
-   --  A file:// index is already on disk, so we don't create a folder for it.
+   --  A file:// index is already on disk, so we reuse its path
 
    overriding
    function Update (This : Index) return Outcome is (Outcome_Success);

--- a/src/alire/alire-index_on_disk-directory.ads
+++ b/src/alire/alire-index_on_disk-directory.ads
@@ -1,0 +1,28 @@
+with Alire.Utils;
+
+package Alire.Index_On_Disk.Directory is
+
+   --  A local index that is already on disk
+
+   type Index (<>) is new Index_On_Disk.Index with private;
+
+   overriding
+   function New_Handler (From   : URL;
+                         Name   : Restricted_Name;
+                         Parent : Platform_Independent_Path) return Index with
+     Pre => Utils.Starts_With (From, "file:///");
+   --  file:// + absolute path
+
+   overriding
+   function Add (This : Index) return Outcome is (Outcome_Success);
+   --  Nothing to do because general checks are done in Features.Index.Add
+
+   overriding
+   function Update (This : Index) return Outcome is (Outcome_Success);
+   --  Nothing to do since the index is on disk, externally managed
+
+private
+
+   type Index is new Index_On_Disk.Index with null record;
+
+end Alire.Index_On_Disk.Directory;

--- a/src/alire/alire-index_on_disk-directory.ads
+++ b/src/alire/alire-index_on_disk-directory.ads
@@ -18,6 +18,10 @@ package Alire.Index_On_Disk.Directory is
    --  Nothing to do because general checks are done in Features.Index.Add
 
    overriding
+   function Index_Directory (This : Index) return String;
+   --  A file:// index is already on disk, so we don't create a folder for it.
+
+   overriding
    function Update (This : Index) return Outcome is (Outcome_Success);
    --  Nothing to do since the index is on disk, externally managed
 

--- a/src/alire/alire-index_on_disk-git.adb
+++ b/src/alire/alire-index_on_disk-git.adb
@@ -1,0 +1,40 @@
+with Alire.VCSs.Git;
+
+package body Alire.Index_On_Disk.Git is
+
+   ---------
+   -- Add --
+   ---------
+
+   function Add (This : Index) return Outcome is
+     (VCSs.Git.Handler.Clone
+        (VCSs.Repo_And_Commit (This.Origin), This.Index_Directory));
+
+   -----------------
+   -- New_Handler --
+   -----------------
+
+   function New_Handler (Origin : URL;
+                         Name   : Restricted_Name;
+                         Parent : Platform_Independent_Path) return Index is
+   begin
+      return Idx : constant Index :=
+        Index'(URL_Len    => Origin'Length,
+               Name_Len   => Name'Length,
+               Dir_Len    => Parent'Length,
+               Origin     => Origin,
+               Name       => Name,
+               Parent     => Parent,
+               Has_Commit => VCSs.Commit (Origin) /= "");
+   end New_Handler;
+
+   ------------
+   -- Update --
+   ------------
+
+   function Update (This : Index) return Outcome is
+     (if This.Has_Commit
+      then Outcome_Success -- Trying to pull from a detached repo is a failure
+      else VCSs.Git.Handler.Update (This.Index_Directory));
+
+end Alire.Index_On_Disk.Git;

--- a/src/alire/alire-index_on_disk-git.adb
+++ b/src/alire/alire-index_on_disk-git.adb
@@ -25,6 +25,7 @@ package body Alire.Index_On_Disk.Git is
                Origin     => Origin,
                Name       => Name,
                Parent     => Parent,
+               Priority   => <>,
                Has_Commit => VCSs.Commit (Origin) /= "");
    end New_Handler;
 

--- a/src/alire/alire-index_on_disk-git.adb
+++ b/src/alire/alire-index_on_disk-git.adb
@@ -6,6 +6,7 @@ package body Alire.Index_On_Disk.Git is
    -- Add --
    ---------
 
+   overriding
    function Add (This : Index) return Outcome is
      (VCSs.Git.Handler.Clone
         (VCSs.Repo_And_Commit (This.Origin), This.Index_Directory));
@@ -14,6 +15,7 @@ package body Alire.Index_On_Disk.Git is
    -- New_Handler --
    -----------------
 
+   overriding
    function New_Handler (Origin : URL;
                          Name   : Restricted_Name;
                          Parent : Platform_Independent_Path) return Index is
@@ -33,6 +35,7 @@ package body Alire.Index_On_Disk.Git is
    -- Update --
    ------------
 
+   overriding
    function Update (This : Index) return Outcome is
      (if This.Has_Commit
       then Outcome_Success -- Trying to pull from a detached repo is a failure

--- a/src/alire/alire-index_on_disk-git.ads
+++ b/src/alire/alire-index_on_disk-git.ads
@@ -1,12 +1,16 @@
+with Alire.Utils;
+
 package Alire.Index_On_Disk.Git is
 
    --  Local management of remote indexes stored in git repositories
 
    type Index is new Index_On_Disk.Index with private;
 
-   function New_Handler (Origin : URL;
+   overriding
+   function New_Handler (From   : URL;
                          Name   : Restricted_Name;
-                         Parent : Platform_Independent_Path) return Index;
+                         Parent : Platform_Independent_Path) return Index with
+     Pre => Utils.Starts_With (From, "git+");
 
    function Add (This : Index) return Outcome;
    --  Clones the index repository

--- a/src/alire/alire-index_on_disk-git.ads
+++ b/src/alire/alire-index_on_disk-git.ads
@@ -12,9 +12,11 @@ package Alire.Index_On_Disk.Git is
                          Parent : Platform_Independent_Path) return Index with
      Pre => Utils.Starts_With (Origin, "git+");
 
+   overriding
    function Add (This : Index) return Outcome;
    --  Clones the index repository
 
+   overriding
    function Update (This : Index) return Outcome;
    --  Pulls the repository, unless it had a specific commit on checkout.
    --  In that case, silently do nothing and return success.

--- a/src/alire/alire-index_on_disk-git.ads
+++ b/src/alire/alire-index_on_disk-git.ads
@@ -7,10 +7,10 @@ package Alire.Index_On_Disk.Git is
    type Index is new Index_On_Disk.Index with private;
 
    overriding
-   function New_Handler (From   : URL;
+   function New_Handler (Origin : URL;
                          Name   : Restricted_Name;
                          Parent : Platform_Independent_Path) return Index with
-     Pre => Utils.Starts_With (From, "git+");
+     Pre => Utils.Starts_With (Origin, "git+");
 
    function Add (This : Index) return Outcome;
    --  Clones the index repository

--- a/src/alire/alire-index_on_disk-git.ads
+++ b/src/alire/alire-index_on_disk-git.ads
@@ -1,0 +1,24 @@
+package Alire.Index_On_Disk.Git is
+
+   --  Local management of remote indexes stored in git repositories
+
+   type Index is new Index_On_Disk.Index with private;
+
+   function New_Handler (Origin : URL;
+                         Name   : Restricted_Name;
+                         Parent : Platform_Independent_Path) return Index;
+
+   function Add (This : Index) return Outcome;
+   --  Clones the index repository
+
+   function Update (This : Index) return Outcome;
+   --  Pulls the repository, unless it had a specific commit on checkout.
+   --  In that case, silently do nothing and return success.
+
+private
+
+   type Index is new Index_On_Disk.Index with record
+      Has_Commit : Boolean;
+   end record;
+
+end Alire.Index_On_Disk.Git;

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -1,3 +1,5 @@
+with Ada.Directories;
+
 with Alire.Directories;
 with Alire.Index_On_Disk.Git;
 with Alire.TOML_Keys;
@@ -18,6 +20,32 @@ package body Alire.Index_On_Disk is
 
    function Update (This : Invalid_Index) return Outcome is
      (raise Program_Error);
+
+   ------------
+   -- Delete --
+   ------------
+
+   function Delete (This : Index'Class) return Outcome is
+      use Ada.Directories;
+   begin
+      if Exists (This.Metadata_Directory) then
+         if Kind (This.Metadata_Directory) = Directory then
+            Delete_Tree (This.Metadata_Directory);
+         else
+            return Outcome_Failure
+              ("Expected directory folder is not a folder: " &
+                 This.Metadata_Directory);
+         end if;
+      else
+         return Outcome_Failure ("Expected index directory does not exist: " &
+                                   This.Metadata_Directory);
+      end if;
+
+      return Outcome_Success;
+   exception
+      when E : others =>
+         return Outcome_From_Exception (E, "Could not delete index directory");
+   end Delete;
 
    ----------
    -- Load --

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -141,6 +141,36 @@ package body Alire.Index_On_Disk is
    ------------
 
    function Verify (This : Index'Class) return Outcome is
-     (raise Unimplemented);
+      use GNAT.OS_Lib;
+   begin
+      if not Is_Directory (This.Metadata_Directory) then
+         return Outcome_Failure ("Metadata folder over index not found");
+      elsif not Is_Directory (This.Index_Directory) then
+         return Outcome_Failure ("Index folder not found");
+      else
+         declare
+            Repo_Version_Files : constant Utils.String_Vector :=
+                                   Directories.Find_Files_Under
+                                     (Folder    => This.Index_Directory,
+                                      Name      => "index.toml",
+                                      Max_Depth => 1);
+         begin
+            case Repo_Version_Files.Length is
+               when 0 =>
+                  return Outcome_Failure
+                    ("No index version metadata found in " &
+                       This.Index_Directory);
+               when 1 =>
+                  null;
+               when others =>
+                  return Outcome_Failure
+                    ("Repo contains several version files: " &
+                       This.Index_Directory);
+            end case;
+         end;
+      end if;
+
+      return Outcome_Success;
+   end Verify;
 
 end Alire.Index_On_Disk;

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -19,9 +19,11 @@ package body Alire.Index_On_Disk is
    --  when there is no index to return.
    --  All operations on it raise Program_Error.
 
+   overriding
    function Add (This : Invalid_Index) return Outcome is
      (raise Program_Error);
 
+   overriding
    function New_Handler (Origin : URL;
                          Name   : Restricted_Name;
                          Parent : Platform_Independent_Path)
@@ -33,6 +35,7 @@ package body Alire.Index_On_Disk is
                      Dir_Len  => 0,
                      others   => <>));
 
+   overriding
    function Update (This : Invalid_Index) return Outcome is
      (raise Program_Error);
 
@@ -105,6 +108,7 @@ package body Alire.Index_On_Disk is
    -- New_Handler --
    -----------------
 
+   overriding
    function New_Handler (Origin : URL;
                          Name   : Restricted_Name;
                          Parent : Platform_Independent_Path)
@@ -220,6 +224,7 @@ package body Alire.Index_On_Disk is
    -- To_TOML --
    -------------
 
+   overriding
    function To_TOML (This : Index) return TOML.TOML_Value is
       Table : constant TOML.TOML_Value := TOML.Create_Table;
    begin

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -1,5 +1,5 @@
 with Alire.Directories;
---  with Alire.Index_On_Disk.Git;
+with Alire.Index_On_Disk.Git;
 with Alire.TOML_Keys;
 with Alire.Utils;
 with Alire.VCSs;
@@ -12,7 +12,7 @@ package body Alire.Index_On_Disk is
      (raise Program_Error);
 
    function New_Handler (Origin : URL;
-                         Name   : String;
+                         Name   : Restricted_Name;
                          Parent : Platform_Independent_Path)
                             return Invalid_Index;
 
@@ -56,7 +56,7 @@ package body Alire.Index_On_Disk is
    -----------------
 
    function New_Handler (Origin : URL;
-                         Name   : String;
+                         Name   : Restricted_Name;
                          Parent : Platform_Independent_Path)
                          return Invalid_Index is
       pragma Unreferenced (Origin, Name, Parent);
@@ -83,7 +83,7 @@ package body Alire.Index_On_Disk is
          when VCSs.VCS_Git =>
             Result := Outcome_Success;
             raise Unimplemented;
---              return Index_On_Disk.Git.New_Handler (Origin, Name, Parent);
+            return Index_On_Disk.Git.New_Handler (Origin, Name, Parent);
          when VCSs.VCS_Unknown =>
             Result := Outcome_Failure ("Unknown index kind: " & Origin);
             return Invalid_Index'(New_Handler (Origin, Name, Parent));

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -1,10 +1,13 @@
 with Ada.Directories;
 
 with Alire.Directories;
+with Alire.Index_On_Disk.Directory;
 with Alire.Index_On_Disk.Git;
 with Alire.TOML_Keys;
 with Alire.Utils;
 with Alire.VCSs;
+
+with GNAT.OS_Lib;
 
 package body Alire.Index_On_Disk is
 
@@ -18,6 +21,12 @@ package body Alire.Index_On_Disk is
                          Parent : Platform_Independent_Path)
                             return Invalid_Index;
 
+   function New_Invalid_Index return Invalid_Index'Class is
+     (Invalid_Index'(URL_Len  => 0,
+                     Name_Len => 0,
+                     Dir_Len  => 0,
+                     others   => <>));
+
    function Update (This : Invalid_Index) return Outcome is
      (raise Program_Error);
 
@@ -29,7 +38,7 @@ package body Alire.Index_On_Disk is
       use Ada.Directories;
    begin
       if Exists (This.Metadata_Directory) then
-         if Kind (This.Metadata_Directory) = Directory then
+         if Kind (This.Metadata_Directory) = Ada.Directories.Directory then
             Delete_Tree (This.Metadata_Directory);
          else
             return Outcome_Failure
@@ -87,10 +96,7 @@ package body Alire.Index_On_Disk is
                          Name   : Restricted_Name;
                          Parent : Platform_Independent_Path)
                          return Invalid_Index is
-      pragma Unreferenced (Origin, Name, Parent);
-   begin
-      return Idx : Invalid_Index (URL_Len => 0, Name_Len => 0, Dir_Len => 0);
-   end New_Handler;
+     (Invalid_Index (New_Invalid_Index));
 
    -----------------
    -- New_Handler --
@@ -99,7 +105,35 @@ package body Alire.Index_On_Disk is
    function New_Handler (Origin : URL;
                          Name   : String;
                          Parent : Platform_Independent_Path;
-                         Result : out Outcome) return Index'Class is
+                         Result : out Outcome) return Index'Class
+   is
+      use GNAT.OS_Lib;
+
+      ---------------------------
+      -- New_Directory_Handler --
+      ---------------------------
+
+      function New_Directory_Handler (Path : String) return Index'Class with
+        Pre => Is_Directory (Path);
+
+      function New_Directory_Handler (Path : String) return Index'Class is
+      begin
+         --  Ensure the given path is not one of our own configured indexes
+         if Utils.Starts_With (Path, Parent) then
+            Result := Outcome_Failure
+              ("Given index path is inside Alire configuration path");
+            return New_Invalid_Index;
+         else
+            Result := Outcome_Success;
+
+            --  Ensure the created Index wrapper has absolute path
+            return Directory.New_Handler
+              (File_Prefix & Ada.Directories.Full_Name (Path),
+               Name,
+               Parent);
+         end if;
+      end New_Directory_Handler;
+
    begin
       if Name not in Restricted_Name then
          Result := Outcome_Failure ("Name is too short/long or contains"
@@ -107,10 +141,27 @@ package body Alire.Index_On_Disk is
          return Invalid_Index'(New_Handler (Origin, Name, Parent));
       end if;
 
+      if Utils.Starts_With (Origin, File_Prefix) then
+         declare
+            Path : constant String :=
+                     Origin (Origin'First + File_Prefix'Length .. Origin'Last);
+         begin
+            if Is_Directory (Path) then
+               return New_Directory_Handler (Path);
+            elsif Is_Directory (Directory_Separator & Path) then
+               Result := Outcome_Failure
+                 ("Given relative path matches an absolute path." &
+                    " Check whether you intended file:///" & Path);
+               return New_Invalid_Index;
+            end if;
+         end;
+      elsif Is_Directory (Origin) then
+         return New_Directory_Handler (Origin);
+      end if;
+
       case VCSs.Kind (Origin) is
          when VCSs.VCS_Git =>
             Result := Outcome_Success;
-            raise Unimplemented;
             return Index_On_Disk.Git.New_Handler (Origin, Name, Parent);
          when VCSs.VCS_Unknown =>
             Result := Outcome_Failure ("Unknown index kind: " & Origin);
@@ -144,9 +195,11 @@ package body Alire.Index_On_Disk is
       use GNAT.OS_Lib;
    begin
       if not Is_Directory (This.Metadata_Directory) then
-         return Outcome_Failure ("Metadata folder over index not found");
+         return Outcome_Failure ("Metadata folder over index not found: " &
+                                   This.Metadata_Directory);
       elsif not Is_Directory (This.Index_Directory) then
-         return Outcome_Failure ("Index folder not found");
+         return Outcome_Failure ("Index folder not found: " &
+                                   This.Index_Directory);
       else
          declare
             Repo_Version_Files : constant Utils.String_Vector :=

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -91,6 +91,13 @@ package body Alire.Index_On_Disk is
       end case;
    end Load;
 
+   ----------
+   -- Name --
+   ----------
+
+   function Name (This : Index'Class) return Restricted_Name is
+     (This.Name);
+
    -----------------
    -- New_Handler --
    -----------------
@@ -218,13 +225,6 @@ package body Alire.Index_On_Disk is
                  TOML.Create_Integer (TOML.Any_Integer (This.Priority)));
       return Table;
    end To_TOML;
-
-   ---------------
-   -- Unique_Id --
-   ---------------
-
-   function Name (This : Index'Class) return Restricted_Name is
-     (This.Name);
 
    ------------
    -- Verify --

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -178,7 +178,8 @@ package body Alire.Index_On_Disk is
       case VCSs.Kind (Origin) is
          when VCSs.VCS_Git =>
             Result := Outcome_Success;
-            return Index_On_Disk.Git.New_Handler (Origin, Name, Parent);
+            return Index_On_Disk.Git.New_Handler (Origin, Name, Parent)
+                                    .With_Priority (Priority);
          when VCSs.VCS_Unknown =>
             Result := Outcome_Failure ("Unknown index kind: " & Origin);
             return Invalid_Index'(New_Handler (Origin, Name, Parent));
@@ -221,6 +222,8 @@ package body Alire.Index_On_Disk is
    begin
       Table.Set (TOML_Keys.Index_URL,
                  TOML.Create_String (This.Origin));
+      Table.Set (TOML_Keys.Index_Name,
+                 TOML.Create_String (This.Name));
       Table.Set (TOML_Keys.Index_Priority,
                  TOML.Create_Integer (TOML.Any_Integer (This.Priority)));
       return Table;

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -136,4 +136,11 @@ package body Alire.Index_On_Disk is
    function Name (This : Index'Class) return Restricted_Name is
      (This.Name);
 
+   ------------
+   -- Verify --
+   ------------
+
+   function Verify (This : Index'Class) return Outcome is
+     (raise Unimplemented);
+
 end Alire.Index_On_Disk;

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -15,6 +15,9 @@ with TOML.File_IO;
 package body Alire.Index_On_Disk is
 
    type Invalid_Index is new Index with null record;
+   --  Dummy index type, used to return a placeholder value in error handling,
+   --  when there is no index to return.
+   --  All operations on it raise Program_Error.
 
    function Add (This : Invalid_Index) return Outcome is
      (raise Program_Error);

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -1,0 +1,111 @@
+with Alire.Directories;
+--  with Alire.Index_On_Disk.Git;
+with Alire.TOML_Keys;
+with Alire.Utils;
+with Alire.VCSs;
+
+package body Alire.Index_On_Disk is
+
+   type Invalid_Index is new Index with null record;
+
+   function Add (This : Invalid_Index) return Outcome is
+     (raise Program_Error);
+
+   function New_Handler (Origin : URL;
+                         Name   : String;
+                         Parent : Platform_Independent_Path)
+                            return Invalid_Index;
+
+   function Update (This : Invalid_Index) return Outcome is
+     (raise Program_Error);
+
+   ----------
+   -- Load --
+   ----------
+
+   function Load (This : Index'Class;
+                  Env  : Alire.TOML_Index.Environment_Variables) return Outcome
+   is
+      Repo_Version_Files : constant Utils.String_Vector :=
+                             Directories.Find_Files_Under
+                               (Folder    => This.Index_Directory,
+                                Name      => "index.toml",
+                                Max_Depth => 1);
+   begin
+      case Natural (Repo_Version_Files.Length) is
+         when 0 =>
+            return Outcome_Failure ("No index.toml file found in index");
+         when 1 =>
+            Trace.Detail ("Loading index found at " &
+                            Repo_Version_Files.First_Element);
+
+            return Result : Outcome do
+               TOML_Index.Load_Catalog
+                 (Catalog_Dir => Directories.Parent
+                                   (Repo_Version_Files.First_Element),
+                  Environment => Env,
+                  Result      => Result);
+            end return;
+         when others =>
+            return Outcome_Failure ("Several index.toml files found in index");
+      end case;
+   end Load;
+
+   -----------------
+   -- New_Handler --
+   -----------------
+
+   function New_Handler (Origin : URL;
+                         Name   : String;
+                         Parent : Platform_Independent_Path)
+                         return Invalid_Index is
+      pragma Unreferenced (Origin, Name, Parent);
+   begin
+      return Idx : Invalid_Index (URL_Len => 0, Name_Len => 0, Dir_Len => 0);
+   end New_Handler;
+
+   -----------------
+   -- New_Handler --
+   -----------------
+
+   function New_Handler (Origin : URL;
+                         Name   : String;
+                         Parent : Platform_Independent_Path;
+                         Result : out Outcome) return Index'Class is
+   begin
+      if Name not in Restricted_Name then
+         Result := Outcome_Failure ("Name is too short/long or contains"
+                                    & " illegal characters");
+         return Invalid_Index'(New_Handler (Origin, Name, Parent));
+      end if;
+
+      case VCSs.Kind (Origin) is
+         when VCSs.VCS_Git =>
+            Result := Outcome_Success;
+            raise Unimplemented;
+--              return Index_On_Disk.Git.New_Handler (Origin, Name, Parent);
+         when VCSs.VCS_Unknown =>
+            Result := Outcome_Failure ("Unknown index kind: " & Origin);
+            return Invalid_Index'(New_Handler (Origin, Name, Parent));
+      end case;
+   end New_Handler;
+
+   -------------
+   -- To_TOML --
+   -------------
+
+   function To_TOML (This : Index) return TOML.TOML_Value is
+      Table : constant TOML.TOML_Value := TOML.Create_Table;
+   begin
+      Table.Set (TOML_Keys.Index_URL, TOML.Create_String (This.Origin));
+      return Table;
+   end To_TOML;
+
+   ---------------
+   -- Unique_Id --
+   ---------------
+
+   function Name (This : Index'Class) return Restricted_Name is
+     (This.Name);
+
+end Alire.Index_On_Disk;

--- a/src/alire/alire-index_on_disk.ads
+++ b/src/alire/alire-index_on_disk.ads
@@ -69,7 +69,9 @@ package Alire.Index_On_Disk is
 
    function Update (This : Index) return Outcome is abstract;
    --  If the index allows updating (e.g. git), do it.
-   --  Otherwise, silently do nothing and return success.
+   --  Otherwise, silently do nothing and return success, since at this level
+   --  there is no way to know if an indexed can be updated, and is always
+   --  called.
 
    function Verify (This : Index'Class) return Outcome;
    --  Ascertain if an index is properly populated (metadata, crates);

--- a/src/alire/alire-index_on_disk.ads
+++ b/src/alire/alire-index_on_disk.ads
@@ -48,6 +48,22 @@ package Alire.Index_On_Disk is
    function Delete (This : Index'Class) return Outcome;
    --  Remove index from current configuration and delete its folder
 
+   function Load (This : Index'Class;
+                  Env  : Alire.TOML_Index.Environment_Variables)
+                  return Outcome;
+   --  Loads the actual index contents into the in-memory index
+
+   function Update (This : Index) return Outcome is abstract;
+   --  If the index allows updating (e.g. git), do it.
+   --  Otherwise, silently do nothing and return success.
+
+   function Verify (This : Index'Class) return Outcome;
+   --  Ascertain if an index is properly populated (metadata, crates);
+
+   -----------------------
+   -- Index information --
+   -----------------------
+
    function Index_Directory (This : Index'Class) return String;
    --  Returns the actual path in which the index is to be checked out,
    --  i.e., <config>/indexes/<Parent>/<Name>/repo
@@ -55,20 +71,15 @@ package Alire.Index_On_Disk is
    function Metadata_Directory (This : Index'Class) return String;
    --  Returns the parent of the checkout directory
 
-   function Load (This : Index'Class;
-                  Env  : Alire.TOML_Index.Environment_Variables)
-                  return Outcome;
-   --  Loads the actual index contents into the in-memory index
-
    function Name (This : Index'Class) return Restricted_Name;
    --  Returns the user's given Name for the index
 
    function Origin (This : Index) return URL;
    --  A unique string that describes where to find this index (git, dir...).
 
-   function Update (This : Index) return Outcome is abstract;
-   --  If the index allows updating (e.g. git), do it.
-   --  Otherwise, silently do nothing and return success.
+   ---------------
+   -- Utilities --
+   ---------------
 
    overriding
    function To_TOML (This : Index) return TOML.TOML_Value;

--- a/src/alire/alire-index_on_disk.ads
+++ b/src/alire/alire-index_on_disk.ads
@@ -21,6 +21,8 @@ package Alire.Index_On_Disk is
    Checkout_Directory : constant String := "repo";
    Metadata_Filename  : constant String := "index.toml";
 
+   File_Prefix        : constant String := "file://";
+
    type Index (<>) is abstract new Interfaces.Tomifiable with private;
 
    pragma Warnings (Off); -- because Post doesn't mention New_Handler'Result

--- a/src/alire/alire-index_on_disk.ads
+++ b/src/alire/alire-index_on_disk.ads
@@ -82,7 +82,7 @@ package Alire.Index_On_Disk is
    -- Index information --
    -----------------------
 
-   function Index_Directory (This : Index'Class) return String;
+   function Index_Directory (This : Index) return String;
    --  Returns the actual path in which the index is to be checked out,
    --  i.e., <config>/indexes/<Parent>/<Name>/repo
 
@@ -128,7 +128,7 @@ private
 
    use OS_Lib.Operators;
 
-   function Index_Directory (This : Index'Class) return String is
+   function Index_Directory (This : Index) return String is
      (This.Parent / This.Name / Checkout_Directory);
 
    function Metadata_Directory (This : Index'Class) return String is

--- a/src/alire/alire-index_on_disk.ads
+++ b/src/alire/alire-index_on_disk.ads
@@ -37,7 +37,7 @@ package Alire.Index_On_Disk is
    --  Program_Error in all attempted operations.
 
    function New_Handler (Origin : URL;
-                         Name   : String;
+                         Name   : Restricted_Name;
                          Parent : Platform_Independent_Path)
                          return Index is abstract;
    --  Descendants use this function to initialize a URL-specific handler

--- a/src/alire/alire-index_on_disk.ads
+++ b/src/alire/alire-index_on_disk.ads
@@ -45,9 +45,15 @@ package Alire.Index_On_Disk is
    function Add (This : Index) return Outcome is abstract;
    --  Deploy the index on disk for the first time at <Parent>/<Name>/repo
 
+   function Delete (This : Index'Class) return Outcome;
+   --  Remove index from current configuration and delete its folder
+
    function Index_Directory (This : Index'Class) return String;
    --  Returns the actual path in which the index is to be checked out,
    --  i.e., <config>/indexes/<Parent>/<Name>/repo
+
+   function Metadata_Directory (This : Index'Class) return String;
+   --  Returns the parent of the checkout directory
 
    function Load (This : Index'Class;
                   Env  : Alire.TOML_Index.Environment_Variables)
@@ -85,7 +91,10 @@ private
    use OS_Lib.Operators;
 
    function Index_Directory (This : Index'Class) return String is
-      (This.Parent / This.Name / Checkout_Directory);
+     (This.Parent / This.Name / Checkout_Directory);
+
+   function Metadata_Directory (This : Index'Class) return String is
+     (This.Parent / This.Name);
 
    function Origin (This : Index) return URL is (This.Origin);
 

--- a/src/alire/alire-index_on_disk.ads
+++ b/src/alire/alire-index_on_disk.ads
@@ -1,0 +1,94 @@
+with Alire.Interfaces;
+with Alire.OS_Lib;
+with Alire.TOML_Index;
+
+with TOML;
+
+package Alire.Index_On_Disk is
+
+   --  Root abstract type that describes the operations available on a folder
+   --  that contains an index.
+   --  See child packages for actual implementations.
+   --  Some common operations are provided here with classwide parameter.
+
+   --  Index metadata are stored in the <config>/indexes/<unique_id>/index.toml
+   --  Actual index is stored in <config>/indexes/<name>/repo
+
+   --  URLs given to New_Handler functions must be complete, commit optional:
+   --  E.g.: git+https://path/to/server/and/project[@commit]
+   --  E.g.: file:///path/to/local/folder
+
+   Checkout_Directory : constant String := "repo";
+   Metadata_Filename  : constant String := "index.toml";
+
+   type Index (<>) is abstract new Interfaces.Tomifiable with private;
+
+   pragma Warnings (Off); -- because Post doesn't mention New_Handler'Result
+   function New_Handler (Origin :     URL;
+                         Name   :     String;
+                         Parent :     Platform_Independent_Path;
+                         Result : out Outcome) return Index'Class
+     with Post => Name in Restricted_Name or not Result.Success;
+   pragma Warnings (On);
+   --  Factory function.
+   --  Name is a user given name used to denote the index (like a git origin).
+   --  Parent is the folder that contains all indexes.
+   --  If not Result.Success, the returned index is invalid and will raise
+   --  Program_Error in all attempted operations.
+
+   function New_Handler (Origin : URL;
+                         Name   : String;
+                         Parent : Platform_Independent_Path)
+                         return Index is abstract;
+   --  Descendants use this function to initialize a URL-specific handler
+
+   function Add (This : Index) return Outcome is abstract;
+   --  Deploy the index on disk for the first time at <Parent>/<Name>/repo
+
+   function Index_Directory (This : Index'Class) return String;
+   --  Returns the actual path in which the index is to be checked out,
+   --  i.e., <config>/indexes/<Parent>/<Name>/repo
+
+   function Load (This : Index'Class;
+                  Env  : Alire.TOML_Index.Environment_Variables)
+                  return Outcome;
+   --  Loads the actual index contents into the in-memory index
+
+   function Name (This : Index'Class) return Restricted_Name;
+   --  Returns the user's given Name for the index
+
+   function Origin (This : Index) return URL;
+   --  A unique string that describes where to find this index (git, dir...).
+
+   function Update (This : Index) return Outcome is abstract;
+   --  If the index allows updating (e.g. git), do it.
+   --  Otherwise, silently do nothing and return success.
+
+   overriding
+   function To_TOML (This : Index) return TOML.TOML_Value;
+   --  Index metadata in TOML format
+
+   function "<" (L, R : Index'Class) return Boolean;
+   --  Useful later for collections of indexes
+
+private
+
+   type Index (URL_Len  : Natural;
+               Name_Len : Natural;
+               Dir_Len  : Natural) is abstract new Interfaces.Tomifiable with
+      record
+         Origin : URL (1 .. URL_Len);
+         Name   : Restricted_Name (1 .. Name_Len);
+         Parent : String (1 .. Dir_Len);
+      end record;
+
+   use OS_Lib.Operators;
+
+   function Index_Directory (This : Index'Class) return String is
+      (This.Parent / This.Name / Checkout_Directory);
+
+   function Origin (This : Index) return URL is (This.Origin);
+
+   function "<" (L, R : Index'Class) return Boolean is (L.Origin < R.Origin);
+
+end Alire.Index_On_Disk;

--- a/src/alire/alire-toml_keys.ads
+++ b/src/alire/alire-toml_keys.ads
@@ -33,6 +33,8 @@ package Alire.TOML_Keys with Preelaborate is
 
    --  Constants used elsewhere
 
-   Index_URL : constant String := "url";
+   Index_URL      : constant String := "url";
+   Index_Name     : constant String := "name";
+   Index_Priority : constant String := "priority";
 
 end Alire.TOML_Keys;

--- a/src/alire/alire-toml_keys.ads
+++ b/src/alire/alire-toml_keys.ads
@@ -30,9 +30,9 @@ package Alire.TOML_Keys with Preelaborate is
    Target         : constant String := "target";
    Website        : constant String := "website";
    Word_Size      : constant String := "word-size";
-   
+
    --  Constants used elsewhere
-   
+
    Index_URL : constant String := "url";
 
 end Alire.TOML_Keys;

--- a/src/alire/alire-toml_keys.ads
+++ b/src/alire/alire-toml_keys.ads
@@ -30,5 +30,9 @@ package Alire.TOML_Keys with Preelaborate is
    Target         : constant String := "target";
    Website        : constant String := "website";
    Word_Size      : constant String := "word-size";
+   
+   --  Constants used elsewhere
+   
+   Index_URL : constant String := "url";
 
 end Alire.TOML_Keys;

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -51,6 +51,13 @@ package Alire with Preelaborate is
      Project (Project'Last) /= Extension_Separator and then
      (for all C of Project => C in Project_Character);
 
+   subtype Restricted_Name is String with Dynamic_Predicate =>
+     Restricted_Name'Length >= Min_Name_Length and then
+     Restricted_Name (Restricted_Name'First) /= '_' and then
+     (for all C of Restricted_Name => C in Project_Character);
+   --  A type used to limit some things that are given names by the user
+   --  (e.g., remote index names).
+
    function "+" (P : Project) return String  is (String (P));
    function "+" (P : String)  return Project is (Project (P));
 

--- a/src/alr/alr-commands-index.adb
+++ b/src/alr/alr-commands-index.adb
@@ -71,6 +71,7 @@ package body Alr.Commands.Index is
    -- Execute --
    -------------
 
+   overriding
    procedure Execute (Cmd : in out Command) is
       Enabled : Natural := 0;
    begin
@@ -140,11 +141,11 @@ package body Alr.Commands.Index is
       end if;
    end List;
 
-
    --------------------
    -- Setup_Switches --
    --------------------
 
+   overriding
    procedure Setup_Switches
      (Cmd    : in out Command;
       Config : in out GNAT.Command_Line.Command_Line_Configuration) is

--- a/src/alr/alr-commands-index.adb
+++ b/src/alr/alr-commands-index.adb
@@ -1,4 +1,53 @@
+with AAA.Table_IO;
+
+with Alire.Config;
+with Alire.Features.Index;
+with Alire.Utils;
+
 package body Alr.Commands.Index is
+
+   --  Forward declarations
+
+   procedure List;
+
+   -------------
+   -- Execute --
+   -------------
+
+   procedure Execute (Cmd : in out Command) is
+   begin
+      if Cmd.List then
+         List;
+      else
+         Reportaise_Wrong_Arguments ("Specify an index subcommand");
+      end if;
+   end Execute;
+
+   ----------
+   -- List --
+   ----------
+
+   procedure List is
+      use Alire;
+
+      Table : AAA.Table_IO.Table;
+      Count : Natural := 0;
+   begin
+      Table.Append ("#").Append ("Name").Append ("URL").Append ("Path");
+
+      for Index of Features.Index.Find_All (Config.Indexes_Directory) loop
+         Count := Count + 1;
+         Table.New_Row;
+         Table
+           .Append (Utils.Trim (Count'Img))
+           .Append (Index.Name)
+           .Append (Index.Origin)
+           .Append (Index.Index_Directory);
+      end loop;
+
+      Table.Print;
+   end List;
+
 
    --------------------
    -- Setup_Switches --

--- a/src/alr/alr-commands-index.adb
+++ b/src/alr/alr-commands-index.adb
@@ -2,6 +2,7 @@ with AAA.Table_IO;
 
 with Alire.Config;
 with Alire.Features.Index;
+with Alire.Index_On_Disk;
 with Alire.Utils;
 
 package body Alr.Commands.Index is
@@ -10,13 +11,55 @@ package body Alr.Commands.Index is
 
    procedure List;
 
+   ------------
+   -- Delete --
+   ------------
+
+   procedure Delete (Name : String) is
+      Indexes : constant Alire.Features.Index.Index_On_Disk_Set :=
+                  Alire.Features.Index.Find_All
+                    (Alire.Config.Indexes_Directory);
+      Cursor  : Alire.Features.Index.Sets.Cursor := Indexes.First;
+      Found   : Boolean := False;
+   begin
+      --  Find matching index and delete
+      for I in 1 .. Natural (Indexes.Length) loop
+         if Indexes (Cursor).Name = Name then
+            Found := True;
+            declare
+               Result : constant Alire.Outcome := Indexes (Cursor).Delete;
+            begin
+               if Result.Success then
+                  exit;
+               else
+                  Reportaise_Command_Failed (Alire.Message (Result));
+               end if;
+            end;
+         end if;
+
+         Cursor := Alire.Features.Index.Sets.Next (Cursor);
+      end loop;
+
+      if not Found then
+         Reportaise_Command_Failed ("Given index not found: " & Name);
+      end if;
+   end Delete;
+
    -------------
    -- Execute --
    -------------
 
    procedure Execute (Cmd : in out Command) is
    begin
-      if Cmd.List then
+      --  Check no multi-action
+      if Cmd.Del.all /= "" and then Cmd.List then
+         Reportaise_Wrong_Arguments ("Specify exactly one index subcommand");
+      end if;
+
+      --  Dispatch to selected action
+      if Cmd.Del.all /= "" then
+         Delete (Cmd.Del.all);
+      elsif Cmd.List then
          List;
       else
          Reportaise_Wrong_Arguments ("Specify an index subcommand");
@@ -57,6 +100,13 @@ package body Alr.Commands.Index is
      (Cmd    : in out Command;
       Config : in out GNAT.Command_Line.Command_Line_Configuration) is
    begin
+      GNAT.Command_Line.Define_Switch
+        (Config      => Config,
+         Output      => Cmd.Del'Access,
+         Long_Switch => "--del=",
+         Argument    => "id",
+         Help        => "Remove an index");
+
       GNAT.Command_Line.Define_Switch
         (Config      => Config,
          Output      => Cmd.List'Access,

--- a/src/alr/alr-commands-index.adb
+++ b/src/alr/alr-commands-index.adb
@@ -88,7 +88,11 @@ package body Alr.Commands.Index is
            .Append (Index.Index_Directory);
       end loop;
 
-      Table.Print;
+      if Count > 0 then
+         Table.Print;
+      else
+         Trace.Info ("No index configured.");
+      end if;
    end List;
 
 

--- a/src/alr/alr-commands-index.adb
+++ b/src/alr/alr-commands-index.adb
@@ -1,0 +1,18 @@
+package body Alr.Commands.Index is
+
+   --------------------
+   -- Setup_Switches --
+   --------------------
+
+   procedure Setup_Switches
+     (Cmd    : in out Command;
+      Config : in out GNAT.Command_Line.Command_Line_Configuration) is
+   begin
+      GNAT.Command_Line.Define_Switch
+        (Config      => Config,
+         Output      => Cmd.List'Access,
+         Long_Switch => "--list",
+         Help        => "List configured indexes");
+   end Setup_Switches;
+
+end Alr.Commands.Index;

--- a/src/alr/alr-commands-index.ads
+++ b/src/alr/alr-commands-index.ads
@@ -4,17 +4,22 @@ package Alr.Commands.Index is
 
    type Command is new Commands.Command with private;
 
+   overriding
    procedure Display_Help_Details (Cmd : Command) is null;
 
+   overriding
    procedure Execute (Cmd : in out Command);
 
+   overriding
    procedure Setup_Switches
      (Cmd    : in out Command;
       Config : in out GNAT.Command_Line.Command_Line_Configuration);
 
+   overriding
    function Short_Description (Cmd : Command) return String is
       ("Manage indexes used by current configuration");
 
+   overriding
    function Usage_Custom_Parameters (Cmd : Command) return String is
      ("--add <url> --name <name> [--before <name>] | --del <name> | --list");
 

--- a/src/alr/alr-commands-index.ads
+++ b/src/alr/alr-commands-index.ads
@@ -1,3 +1,5 @@
+private with GNAT.Strings;
+
 package Alr.Commands.Index is
 
    type Command is new Commands.Command with private;
@@ -13,11 +15,13 @@ package Alr.Commands.Index is
    function Short_Description (Cmd : Command) return String is
       ("Manage indexes used by current configuration");
 
-   function Usage_Custom_Parameters (Cmd : Command) return String is ("");
+   function Usage_Custom_Parameters (Cmd : Command) return String is
+     ("--del <name> | --list");
 
 private
 
    type Command is new Commands.Command with record
+      Del  : aliased GNAT.Strings.String_Access;
       List : aliased Boolean := False;
    end record;
 

--- a/src/alr/alr-commands-index.ads
+++ b/src/alr/alr-commands-index.ads
@@ -1,0 +1,19 @@
+package Alr.Commands.Index is
+
+   type Command is new Commands.Command with null record;
+
+   procedure Display_Help_Details (Cmd : Command) is null;
+
+   procedure Execute (Cmd : in out Command) is null; -- TODO
+
+   procedure Setup_Switches
+     (Cmd    : in out Command;
+      Config : in out GNAT.Command_Line.Command_Line_Configuration)
+   is null;
+
+   function Short_Description (Cmd : Command) return String is
+      ("Manage indexes used by current configuration");
+
+   function Usage_Custom_Parameters (Cmd : Command) return String is ("");
+
+end Alr.Commands.Index;

--- a/src/alr/alr-commands-index.ads
+++ b/src/alr/alr-commands-index.ads
@@ -4,7 +4,7 @@ package Alr.Commands.Index is
 
    procedure Display_Help_Details (Cmd : Command) is null;
 
-   procedure Execute (Cmd : in out Command) is null; -- TODO
+   procedure Execute (Cmd : in out Command);
 
    procedure Setup_Switches
      (Cmd    : in out Command;

--- a/src/alr/alr-commands-index.ads
+++ b/src/alr/alr-commands-index.ads
@@ -26,6 +26,8 @@ private
       Del  : aliased GNAT.Strings.String_Access;
       Name : aliased GNAT.Strings.String_Access;
       List : aliased Boolean := False;
+
+      Update_All : aliased Boolean := False;
    end record;
 
 end Alr.Commands.Index;

--- a/src/alr/alr-commands-index.ads
+++ b/src/alr/alr-commands-index.ads
@@ -21,7 +21,9 @@ package Alr.Commands.Index is
 private
 
    type Command is new Commands.Command with record
+      Add  : aliased GNAT.Strings.String_Access;
       Del  : aliased GNAT.Strings.String_Access;
+      Name : aliased GNAT.Strings.String_Access;
       List : aliased Boolean := False;
    end record;
 

--- a/src/alr/alr-commands-index.ads
+++ b/src/alr/alr-commands-index.ads
@@ -1,6 +1,6 @@
 package Alr.Commands.Index is
 
-   type Command is new Commands.Command with null record;
+   type Command is new Commands.Command with private;
 
    procedure Display_Help_Details (Cmd : Command) is null;
 
@@ -8,12 +8,17 @@ package Alr.Commands.Index is
 
    procedure Setup_Switches
      (Cmd    : in out Command;
-      Config : in out GNAT.Command_Line.Command_Line_Configuration)
-   is null;
+      Config : in out GNAT.Command_Line.Command_Line_Configuration);
 
    function Short_Description (Cmd : Command) return String is
       ("Manage indexes used by current configuration");
 
    function Usage_Custom_Parameters (Cmd : Command) return String is ("");
+
+private
+
+   type Command is new Commands.Command with record
+      List : aliased Boolean := False;
+   end record;
 
 end Alr.Commands.Index;

--- a/src/alr/alr-commands-index.ads
+++ b/src/alr/alr-commands-index.ads
@@ -16,12 +16,13 @@ package Alr.Commands.Index is
       ("Manage indexes used by current configuration");
 
    function Usage_Custom_Parameters (Cmd : Command) return String is
-     ("--del <name> | --list");
+     ("--add <url> --name <name> [--before <name>] | --del <name> | --list");
 
 private
 
    type Command is new Commands.Command with record
       Add  : aliased GNAT.Strings.String_Access;
+      Bfr  : aliased GNAT.Strings.String_Access;
       Del  : aliased GNAT.Strings.String_Access;
       Name : aliased GNAT.Strings.String_Access;
       List : aliased Boolean := False;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -394,12 +394,19 @@ package body Alr.Commands is
             end;
          end if;
 
-         Alire.Features.Index.Load_All
-           (Platform =>
-              (OS       => Platform.Operating_System,
-               Distro   => Platform.Distribution,
-               Compiler => Platform.Compiler),
-            From     => Alire.Config.Indexes_Directory);
+         declare
+            Outcome : constant Alire.Outcome := Alire.Features.Index.Load_All
+              (Platform =>
+                 (OS       => Platform.Operating_System,
+                  Distro   => Platform.Distribution,
+                  Compiler => Platform.Compiler),
+               From     => Alire.Config.Indexes_Directory);
+         begin
+            if not Outcome.Success then
+               Reportaise_Command_Failed
+                 ("Could not load index: " & (+Outcome.Message));
+            end if;
+         end;
       end if;
    end Requires_Full_Index;
 

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -17,6 +17,7 @@ with Alr.Commands.Clean;
 with Alr.Commands.Compile;
 with Alr.Commands.Dev;
 with Alr.Commands.Get;
+with Alr.Commands.Index;
 with Alr.Commands.Init;
 with Alr.Commands.List;
 with Alr.Commands.Pin;
@@ -50,6 +51,7 @@ package body Alr.Commands is
                        Cmd_Compile  => new Compile.Command,
                        Cmd_Dev      => new Dev.Command,
                        Cmd_Get      => new Get.Command,
+                       Cmd_Index    => new Index.Command,
                        Cmd_Init     => new Init.Command,
                        Cmd_List     => new List.Command,
                        Cmd_Pin      => new Pin.Command,

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -6,6 +6,7 @@ with Ada.Text_IO; use Ada.Text_IO;
 with Alire_Early_Elaboration;
 with Alire;
 with Alire.Config;
+with Alire.Defaults;
 with Alire.Features.Index;
 with Alire.Index;
 with Alire.Roots;
@@ -368,20 +369,37 @@ package body Alr.Commands is
    ---------------------------
 
    procedure Requires_Full_Index (Force_Reload : Boolean := False) is
-      use Alr.Paths;
    begin
       if not Alire.Index.Catalog.Is_Empty and then not Force_Reload then
          Trace.Detail ("Index already loaded, loading skipped");
+         return;
       else
-         Requires_Sources;
+         if Alire.Features.Index.Find_All
+           (Alire.Config.Indexes_Directory).Is_Empty
+         then
+            Trace.Detail
+              ("No indexes configured, adding default community index");
+            declare
+               Outcome : constant Alire.Outcome :=
+                           Alire.Features.Index.Add
+                             (Origin => Alire.Defaults.Community_Index,
+                              Name   => Alire.Defaults.Community_Index_Name,
+                              Under  => Alire.Config.Indexes_Directory);
+            begin
+               if not Outcome.Success then
+                  Reportaise_Command_Failed
+                    ("Could not add community index: " & (+Outcome.Message));
+                  return;
+               end if;
+            end;
+         end if;
 
          Alire.Features.Index.Load_All
            (Platform =>
               (OS       => Platform.Operating_System,
                Distro   => Platform.Distribution,
                Compiler => Platform.Compiler),
-            From     => Paths.Alr_Config_Folder /
-                          "alire" / "deps" / "alire-index" / "index");
+            From     => Alire.Config.Indexes_Directory);
       end if;
    end Requires_Full_Index;
 

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -99,6 +99,7 @@ package Alr.Commands is
                       Cmd_Compile,
                       Cmd_Dev,
                       Cmd_Get,
+                      Cmd_Index,
                       Cmd_Init,
                       Cmd_List,
                       Cmd_Pin,

--- a/src/alr/alr-os_lib.adb
+++ b/src/alr/alr-os_lib.adb
@@ -2,33 +2,6 @@ with Ada.Command_Line;
 
 package body Alr.OS_Lib is
 
-   -------------------
-   -- Create_Folder --
-   -------------------
-
-   procedure Create_Folder (Path : String) is
-
-      procedure Create_Parent (Path : String) is
-         use Ada.Directories;
-      begin
-         if Exists (Path) then
-            return;
-         else
-            begin
-               Create_Parent (Containing_Directory (Path));
-            exception
-               when Use_Error =>
-                  null; -- We reached root at worst, and start digging down...
-            end;
-
-            Create_Directory (Path); -- Parent must exist at this point
-         end if;
-      end Create_Parent;
-
-   begin
-      Create_Parent (Path);
-   end Create_Folder;
-
    --------------------------
    -- Current_Command_Line --
    --------------------------

--- a/src/alr/alr-os_lib.ads
+++ b/src/alr/alr-os_lib.ads
@@ -14,7 +14,8 @@ package Alr.OS_Lib is
 
    --  Environment
 
-   procedure Create_Folder (Path : String);
+   procedure Create_Folder (Path : String)
+     renames Alire.Directories.Create_Directory;
    --  Able to create full given path, permissions permitting
 
    function Getenv (Var : String; Default : String := "") return String;


### PR DESCRIPTION
Implements #69 

- [x] Auto-add default index if none found
- [x] List indexes (alr index --list)
- [x] Add indexes (alr index --add git+https://url/of/index/repo [--before INDEX_ID])
- [x] Remove indexes (alr index --del INDEX_ID)
- [x] Support local indexes (alr index --add file:///path/to/index)
- [x] Update indexes (alr index --update-all)

Implementation notes:

Three packages are mainly affected here:
- `Alire.Index_On_Disk`: encapsulates internal implementation of single index actions
- `Alire.Features.Index`: provides the public Alire API for clients
- `Alr.Commands.Index`: implements command-line parsing and uses Alire.Features.Index

Index are loaded in their listing order; if a crate milestone is duplicated, only first one is kept (which is the whole point of priorities; we could err on duplicates, but I fear this can be too restrictive if several public indexes were to exist. This is similar to how `apt` works).

With this set of patches, alr sources and subrepos are no longer checked out for operations requiring an index (instead the default public index is configured when first needed -- we could check it out unconditionally on first run).