### PR TITLE
Flush junit log after each test

### DIFF
--- a/src/alr/alr-testing-junit.adb
+++ b/src/alr/alr-testing-junit.adb
@@ -25,11 +25,8 @@ package body Alr.Testing.JUnit is
    -------------
 
    overriding procedure End_Run   (This : in out Reporter) is
-      File : File_Type;
    begin
-      Create (File, Out_File, This.Name.all & ".xml");
-      This.Jsuite.To_Collection.Write (File);
-      Close (File);
+      This.Flush;
 
       --  TODO: free name
    end End_Run;
@@ -87,6 +84,21 @@ package body Alr.Testing.JUnit is
                   Message => Outcome'Img,
                   Output  => Commands.Version.Fingerprint));
       end case;
+
+      This.Flush;
    end End_Test;
+
+   -----------
+   -- Flush --
+   -----------
+
+   not overriding
+   procedure Flush (This : Reporter) is
+      File : File_Type;
+   begin
+      Create (File, Out_File, This.Name.all & ".xml");
+      This.Jsuite.To_Collection.Write (File);
+      Close (File);
+   end Flush;
 
 end Alr.Testing.JUnit;

--- a/src/alr/alr-testing-junit.ads
+++ b/src/alr/alr-testing-junit.ads
@@ -33,6 +33,10 @@ private
       Jsuite : Test_Suite_Access;
    end record;
 
+   not overriding
+   procedure Flush (This : Reporter);
+   --  Ensure partial test results are dumped to file
+
    overriding
    function New_Reporter return Reporter is (others => <>);
 


### PR DESCRIPTION
This corrects the issue that, when interrupting `alr test` (or in case of internal error), no junit log was produced at all.