### PR TITLE
Out-of-tree building

### DIFF
--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -125,8 +125,12 @@ package body Alire.Directories is
          End_Search (Search);
       end Locate;
 
+      use Ada.Directories;
    begin
-      Locate (Folder, 0, Max_Depth);
+      if Exists (Folder) and then Kind (Folder) = Directory then
+         Locate (Folder, 0, Max_Depth);
+      end if;
+
       return Found;
    end Find_Files_Under;
 

--- a/src/alire/alire-paths.ads
+++ b/src/alire/alire-paths.ads
@@ -1,14 +1,23 @@
+with Alire.OS_Lib; use Alire.OS_Lib.Operators;
+
 package Alire.Paths with Preelaborate is
 
    Crate_File_Extension_With_Dot : constant String;
    --  Until we decide a name, going to use crate per Amiard's suggesion
 
-   Working_Folder_Inside_Root : constant Relative_Path;
+   Working_Folder_Inside_Root    : constant Relative_Path;
+   --  This is the folder inside a crate where all alire products are created
+
+   function Build_Folder return Relative_Path;
+   --  The folder where the out-of-tree global build is performed
 
 private
 
    Crate_File_Extension_With_Dot : constant String := ".toml";
 
-   Working_Folder_Inside_Root : constant Relative_Path := "alire";
+   Working_Folder_Inside_Root    : constant Relative_Path := "alire";
+
+   function Build_Folder return Relative_Path is
+     (Working_Folder_Inside_Root / "build");
 
 end Alire.Paths;

--- a/src/alr/alr-commands-clean.adb
+++ b/src/alr/alr-commands-clean.adb
@@ -1,5 +1,7 @@
 with Ada.Directories;
 
+with Alire.Paths;
+
 with Alr.Paths;
 with Alr.Root;
 with Alr.Spawn;
@@ -16,9 +18,10 @@ package body Alr.Commands.Clean is
          Requires_Project;
 
          Trace.Detail ("Cleaning project and dependencies...");
-         Spawn.Command ("gprclean", "-r -P " &
-                          Root.Current.Build_File & " " &
-                          Scenario.As_Command_Line);
+         Spawn.Command ("gprclean", "-r -P " & Root.Current.Build_File
+                        & " --root-dir=."
+                        & " --relocate-build-tree=" & Alire.Paths.Build_Folder
+                        & " " & Scenario.As_Command_Line);
       end if;
 
       if Cmd.Cache then

--- a/src/alr/alr-commands-run.adb
+++ b/src/alr/alr-commands-run.adb
@@ -1,6 +1,7 @@
 with Ada.Containers;
 
 with Alire.OS_Lib;
+with Alire.Paths;
 
 with Alr.Commands.Compile;
 with Alr.Files;
@@ -11,6 +12,10 @@ with Alr.Utils;
 
 package body Alr.Commands.Run is
 
+   Max_Search_Depth : constant := 3;
+   --  How many levels to go down looking for built executables,
+   --  relative to the build folder of the root crate
+
    ------------------
    -- Check_Report --
    ------------------
@@ -19,8 +24,8 @@ package body Alr.Commands.Run is
       use Ada.Text_IO;
 
       Found_At : constant Utils.String_Vector :=
-        Files.Locate_File_Under (OS_Lib.Current_Folder,
-                                 Exe_Name, Max_Depth => 2);
+        Files.Locate_File_Under (Alire.Paths.Build_Folder,
+                                 Exe_Name, Max_Depth => Max_Search_Depth);
    begin
       Put ("   " & Exe_Name);
       case Found_At.Length is
@@ -62,9 +67,9 @@ package body Alr.Commands.Run is
       declare
          Name       : constant String := Root.Current.Release.Project_Str;
          Candidates : constant Utils.String_Vector := Files.Locate_File_Under
-           (OS_Lib.Current_Folder,
+           (Alire.Paths.Build_Folder,
             Root.Current.Release.Default_Executable,
-            Max_Depth => 2);
+            Max_Depth => Max_Search_Depth);
          --  We look at most in something like ./build/configuration
 
          Declared : Utils.String_Vector;
@@ -132,9 +137,9 @@ package body Alr.Commands.Run is
 
             Target_Exes : constant Utils.String_Vector :=
                             Files.Locate_File_Under
-                              (OS_Lib.Current_Folder,
+                              (Alire.Paths.Build_Folder,
                                Target,
-                               Max_Depth => 2);
+                               Max_Depth => Max_Search_Depth);
          begin
             if Target /= Name and then not Declared.Contains (Target) then
                Trace.Warning

--- a/src/alr/alr-spawn.adb
+++ b/src/alr/alr-spawn.adb
@@ -1,3 +1,5 @@
+with Alire.Paths;
+
 with Alr.OS_Lib;
 
 package body Alr.Spawn is
@@ -24,15 +26,16 @@ package body Alr.Spawn is
    -- Gprbuild --
    --------------
 
-   procedure Gprbuild (Project_File        : String;
-                       Extra_Args          : String := "")
-   is
+   procedure Gprbuild (Project_File : String;
+                       Extra_Args   : String := "") is
    begin
       Command ("gprbuild",
-               "-gnatwU -j0 -p " &
+               "-gnatwU -j0 -p "
                --  Supress warnings on unused (may happen in prj_alr.ads)
-                 Extra_Args & (if Extra_Args /= "" then " " else "") &
-                 "-P " & Project_File,
+               & Extra_Args & (if Extra_Args /= "" then " " else "")
+               & "-P " & Project_File
+               & " --root-dir=."
+               & " --relocate-build-tree=" & Alire.Paths.Build_Folder,
                Understands_Verbose => True);
    end Gprbuild;
 

--- a/src/alr/alr-spawn.ads
+++ b/src/alr/alr-spawn.ads
@@ -12,5 +12,9 @@ package Alr.Spawn is
 
    procedure Gprbuild (Project_File  : String;
                        Extra_Args    : String := "");
+   --  Launches gprbuild for the building of a crate.
+   --  Extra args can be -Xblah detected from command-line.
+   --  Out-of-tree build takes place in
+   --    $crate / Alire.Paths.Build_Folder ($crate/alire/build).
 
 end Alr.Spawn;

--- a/testsuite/tests/workflows/get-build-run-clean/test.py
+++ b/testsuite/tests/workflows/get-build-run-clean/test.py
@@ -26,8 +26,8 @@ p = run_alr('run')
 assert_eq('Hello, world!\n', p.out)
 
 # Clean it
-assert os.listdir('obj')
+assert os.listdir('alire/build/obj')
 run_alr('clean')
-assert not os.listdir('obj')
+assert not os.listdir('alire/build/obj')
 
 print('SUCCESS')


### PR DESCRIPTION
Instead of building in place, the $root_crate/alire/build folder is used.
Implements #95 