### PR TITLE
Use Debian stable instead of testing for CI

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -19,7 +19,7 @@ env:
         - IMAGE_NAME="alire/gnat"
     matrix:
         - IMAGE_TAG="community-current"
-        - IMAGE_TAG="debian-testing"
+        - IMAGE_TAG="debian-stable"
         - IMAGE_TAG="ubuntu-lts"
 
 build:


### PR DESCRIPTION
Stretch couldn't compile alr, but now Buster is able. We can stick to Debian stable from now on as the Debian "supported" release.