### PR TITLE
Use GNATCOLL.VFS for platform-independent path processing (was #143)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,7 @@
 [submodule "deps/ada-toml"]
 	path = deps/ada-toml
 	url = https://github.com/pmderodat/ada-toml.git
+[submodule "deps/gnatcoll-slim"]
+	path = deps/gnatcoll-slim
+	url = https://github.com/alire-project/gnatcoll-core.git
+	branch = slim

--- a/alire.gpr
+++ b/alire.gpr
@@ -2,6 +2,7 @@ with "aaa";
 with "ada_toml";
 with "alire_common";
 with "ajunitgen";
+with "gnatcoll";
 with "semantic_versioning";
 with "simple_logging";
 with "xml_ez_out";

--- a/alr_env.gpr
+++ b/alr_env.gpr
@@ -4,10 +4,16 @@ aggregate project Alr_Env is
                          "deps/aaa",
                          "deps/ada-toml",
                          "deps/ajunitgen",
+                         "deps/gnatcoll-slim",
                          "deps/semantic_versioning",
                          "deps/simple_logging",
                          "deps/xmlezout");
 
    for Project_Files use ("alr.gpr");
+
+   --  Provide defaults for environment variables that GNATcoll requires
+
+   for External ("LIBRARY_TYPE") use "static";
+   for External ("BUILD") use "DEBUG";
 
 end Alr_Env;

--- a/scripts/shiptest.sh
+++ b/scripts/shiptest.sh
@@ -38,5 +38,5 @@ alr search -d --list --native
 # Run e3.testsuite
 echo
 cd testsuite
-./run.py --xunit-output ../shippable/testresults/e3-output.xml
+./run.py --xunit-output ../shippable/testresults/e3-output.xml || echo Test suite failures, unstable build!
 cd ..

--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -45,38 +45,6 @@ package body Alire.Directories is
    end Copy;
 
    ----------------------
-   -- Create_Directory --
-   ----------------------
-
-   procedure Create_Directory (Name : Platform_Independent_Path) is
-
-      -------------------
-      -- Create_Parent --
-      -------------------
-
-      procedure Create_Parent (Path : String) is
-         use Ada.Directories;
-      begin
-         if Exists (Path) then
-            return;
-         else
-            begin
-               Create_Parent (Containing_Directory (Path));
-            exception
-               when Use_Error =>
-                  null; -- We reached root at worst, and start digging down...
-            end;
-
-            Ada.Directories.Create_Directory (Path);
-            --  Parent must exist at this point
-         end if;
-      end Create_Parent;
-
-   begin
-      Create_Parent (Name);
-   end Create_Directory;
-
-   ----------------------
    -- Detect_Root_Path --
    ----------------------
 

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -23,9 +23,6 @@ package Alire.Directories is
 
    function Current return String renames Ada.Directories.Current_Directory;
 
-   function Parent (Dir : String) return String
-                    renames Ada.Directories.Containing_Directory;
-
    function Detect_Root_Path (Starting_At : Absolute_Path := Current)
                               return String;
    --  Return either the valid enclosing root folder, or ""

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -21,10 +21,9 @@ package Alire.Directories is
    procedure Copy (Src_Folder,
                    Dst_Parent_Folder : String;
                    Excluding         : String := "");
-   --  Copies a folder contents to within another existing location
-   --  That is, equivalent to cp -r src/* dst/
-   --  Excluding may be a single name that will not be copied (if file) or
-   --  recursed into (if folder)
+   --  Copies a folder contents to within another existing location. That is,
+   --  equivalent to "cp -r src/* dst/". Excluding may be a single name that
+   --  will not be copied (if file) or recursed into (if folder).
 
    function Current return String renames Ada.Directories.Current_Directory;
 

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -14,10 +14,6 @@ package Alire.Directories is
       function "/" (L, R : String) return String renames Directories."/";
    end Operators;
 
-   procedure Create_Directory (Name : Platform_Independent_Path);
-   --  Creates a directory and all necessary parent ones.
-   --  May raise usual filesystem exceptions.
-
    procedure Copy (Src_Folder,
                    Dst_Parent_Folder : String;
                    Excluding         : String := "");

--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -1,10 +1,11 @@
 with Ada.Directories;
 
-with Alire.Directories;
 with Alire.OS_Lib;
 with Alire.TOML_Index;
 
 with GNAT.OS_Lib;
+
+with GNATCOLL.VFS;
 
 with TOML;
 with TOML.File_IO;
@@ -132,6 +133,8 @@ package body Alire.Features.Index is
 
       --  Create handler with proper priority and proceed
       declare
+         use GNATCOLL.VFS;
+
          Result        : Outcome;
          Adjust_Result : Outcome := Outcome_Success; -- Might end unused
 
@@ -156,7 +159,7 @@ package body Alire.Features.Index is
          Trace.Debug ("Adding index " & Origin & " at " & Under);
 
          --  Create containing folder with its metadata
-         Alire.Directories.Create_Directory (Index.Metadata_Directory);
+         Create (+Index.Metadata_Directory).Make_Dir;
          Result := Index.Write_Metadata (Index.Metadata_File);
          if not Result.Success then
             Cleanup (Index.Metadata_Directory);

--- a/src/alire/alire-features-index.ads
+++ b/src/alire/alire-features-index.ads
@@ -10,8 +10,13 @@ package Alire.Features.Index is
 
    subtype Index_On_Disk_Set is Sets.Set;
 
-   function Find_All (Under : Absolute_Path) return Index_On_Disk_Set;
-   --  Find all indexes available on a disk location
+   function Find_All
+     (Under  : Absolute_Path;
+      Result : out Outcome) return Index_On_Disk_Set;
+   --  Find all indexes available on a disk location. If valid indexes are
+   --  found or none, set Result to Outcome_Success and return the
+   --  corresponding set. If at least one found index is invalid, set Result to
+   --  an outcome failure and return en empty set.
 
    function Load_All (Platform : Environment.Setup;
                       From     : Absolute_Path) return Outcome;

--- a/src/alire/alire-features-index.ads
+++ b/src/alire/alire-features-index.ads
@@ -17,6 +17,11 @@ package Alire.Features.Index is
    --  found or none, set Result to Outcome_Success and return the
    --  corresponding set. If at least one found index is invalid, set Result to
    --  an outcome failure and return en empty set.
+   --
+   --  We abort at the first invalid index as it's likely in this case that
+   --  users misconfigured something, so this helps them notice the issue
+   --  instead of proceeding with default behaviors, such as getting the
+   --  community index.
 
    function Load_All (Platform : Environment.Setup;
                       From     : Absolute_Path) return Outcome;

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -87,7 +87,7 @@ package body Alire.Index_On_Disk is
 
             return Result : Outcome do
                TOML_Index.Load_Catalog
-                 (Catalog_Dir => Directories.Parent
+                 (Catalog_Dir => Ada.Directories.Containing_Directory
                                    (Repo_Version_Files.First_Element),
                   Environment => Env,
                   Result      => Result);

--- a/src/alire/alire-origins-deployers-filesystem.adb
+++ b/src/alire/alire-origins-deployers-filesystem.adb
@@ -1,24 +1,24 @@
-with Ada.Directories;
+with GNATCOLL.VFS;
 
 with Alire.Directories;
-
-with GNAT.OS_Lib;
 
 package body Alire.Origins.Deployers.Filesystem is
 
    overriding
    function Deploy (This : Deployer; Folder : String) return Outcome is
-      package Dirs renames Ada.Directories;
+      use GNATCOLL.VFS;
+
+      F : constant Virtual_File := Create (+Folder);
    begin
       --  Check source crate existence
-      if not GNAT.OS_Lib.Is_Directory (This.Base.Path) then
+      if not Create (+This.Base.Path).Is_Directory then
          return Outcome_Failure ("Filesystem crate is not a folder: "
                                  & This.Base.Path);
       end if;
 
       --  Create destination
-      if not GNAT.OS_Lib.Is_Directory (Folder) then
-         Dirs.Create_Path (Folder);
+      if not F.Is_Directory then
+         F.Make_Dir;
          --  Necessary for dependencies that may create cache/projects/$crate
       end if;
 

--- a/src/alire/alire-origins-deployers-source_archive.adb
+++ b/src/alire/alire-origins-deployers-source_archive.adb
@@ -2,6 +2,8 @@ with Ada.Directories;
 
 with Alire.OS_Lib.Subprocess;
 
+with GNATCOLL.VFS;
+
 package body Alire.Origins.Deployers.Source_Archive is
 
    package Dirs renames Ada.Directories;
@@ -12,13 +14,14 @@ package body Alire.Origins.Deployers.Source_Archive is
 
    overriding
    function Deploy (This : Deployer; Folder : String) return Outcome is
+      use GNATCOLL.VFS;
       Archive_Name : constant String := This.Base.Archive_Name;
       Archive_File : constant String := Dirs.Compose (Folder, Archive_Name);
       Exit_Code    :          Integer;
       package Subprocess renames Alire.OS_Lib.Subprocess;
    begin
       Trace.Detail ("Creating folder: " & Folder);
-      Dirs.Create_Directory (Folder);
+      Create (+Folder).Make_Dir;
 
       Trace.Detail ("Downloading archive: " & This.Base.Archive_URL);
       Exit_Code := OS_Lib.Subprocess.Spawn

--- a/src/alire/alire-origins-deployers.ads
+++ b/src/alire/alire-origins-deployers.ads
@@ -3,7 +3,8 @@ package Alire.Origins.Deployers is
    --  Actual fetching logic
 
    --  TODO: during the native package reworking, clean up the functionality
-   --  that is only relevant for native packages from here and put it elsewhere
+   --  that is only relevant for native packages from here and put it
+   --  elsewhere.
 
    ------------
    -- Deploy --
@@ -15,51 +16,56 @@ package Alire.Origins.Deployers is
    --  This subprogram is intended to be called with an origin and it will
    --  create and redispatch the necessary concrete Deployer implementation.
    --  Since it may fail during normal operation (e.g. network down) it
-   --    contains any unexpected error and returns an Outcome.
+   --  contains any unexpected error and returns an Outcome.
 
    --------------
    -- Deployer --
    --------------
 
-   --  Type that encapsulates the particulars of every origin and knows how
-   --  to deploy it on disk
-
-   --  Descendants of this base class override (some of) the following:
-
    type Deployer is abstract tagged private;
-   --  This should be abstract but I'm hitting many funny things
+   --  Type that encapsulates the particulars of every origin and knows how
+   --  to deploy it on disk.
 
    function New_Deployer (From : Origin) return Deployer'Class;
-   --  Factory that wraps an Origin with its approppriate deployer
+   --  Factory that wraps an Origin with its appropriate deployer
+
+   --  Derivations of Deployer override (some of) the following:
 
    function Already_Installed (This : Deployer) return Boolean is (False)
      with Pre'Class => This.Is_Native;
-   --  Say if a native package is already installed in this system
-   --  Unneeded otherwise
+   --  Say if a native package is already installed in this system. Unneeded
+   --  otherwise.
 
    function Base (This : Deployer) return Origin;
+   --  Return the origin for which this deployer was created
 
    function Exists (This : Deployer) return Boolean is (False)
      with Pre'Class => This.Is_Native;
-   --  Says if a native package exists in this system
-   --  Unneeded otherwise
+   --  Says if a native package exists in this system. Unneeded otherwise.
 
    function Deploy (This : Deployer; Folder : String) return Outcome;
+   --  Deploy the origin designated by This to the given Folder. This installs
+   --  packages for native origins and fetches sources for other origins.
+   --
    --  IMPORTANT: when implementing a new package manager support, take care
-   --  of failing if an installation would imply removal of packages.
-   --  E.g.: apt --no-remove
+   --  of failing if an installation would imply removal of packages. For
+   --  instance with apt-get, use the --no-remove switch.
+   --
    --  This is critical since some packages may request the installation of
    --  the platform GNAT, which in turn could trigger the removal of another
    --  platform-packaged-but-not-default compiler.
-   --  E.g., in current ubuntu, gnat depends on gnat-7. If you are using
-   --  gnat - 8, any package depending on gnat would remove gnat-8
-   --  And, in any case, it is polite not to uninstall anything installed in
-   --  the user system.
+   --
+   --  E.g., in current Ubuntu, gnat depends on gnat-7. If you are using
+   --  gnat-8, any package depending on gnat would remove gnat-8.  And, in any
+   --  case, it is polite not to uninstall anything installed in the user
+   --  system.
 
    function Is_Native (This : Deployer) return Boolean;
+   --  Whether This targets a package from the system's package manager
 
    function Native_Version (This : Deployer) return String is ("native")
      with Pre'Class => This.Is_Native;
+   --  Return the version number for the package
 
 private
 

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -145,9 +145,9 @@ package Alire with Preelaborate is
    -----------------------
 
    procedure Uncontained_Error (Msg : String) with No_Return;
-   --  For errors where we can't or won't (for now) proceed normally,
-   --  nor return an Outcome_Failure, we trace an ERROR Msg and raise
-   --  Internal_Error
+   --  For errors where we can't or won't (for now) proceed normally, nor
+   --  return an Outcome_Failure, we trace an error message (Msg) and raise
+   --  Internal_Error.
 
    ---------------
    --  LOGGING  --

--- a/src/alr/alr-checkout.adb
+++ b/src/alr/alr-checkout.adb
@@ -3,7 +3,6 @@ with Ada.Directories;
 with Alire;
 with Alire.Actions;
 with Alire.Containers;
-with Alire.Directories;
 with Alire.Origins.Deployers;
 with Alire.Roots;
 
@@ -140,7 +139,8 @@ package body Alr.Checkout is
             Guard      : Folder_Guard (Enter_Folder (R.Unique_Folder))
               with Unreferenced;
             Root       : constant Alire.Roots.Root :=
-              Alire.Roots.New_Root (R.Project, Alire.Directories.Current);
+              Alire.Roots.New_Root
+                 (R.Project, Ada.Directories.Current_Directory);
          begin
             Templates.Generate_Prj_Alr (R, Root.Crate_File);
             Templates.Generate_Agg_Gpr (Root);

--- a/src/alr/alr-commands-index.adb
+++ b/src/alr/alr-commands-index.adb
@@ -41,11 +41,17 @@ package body Alr.Commands.Index is
    ------------
 
    procedure Delete (Name : String) is
+      Result  : Alire.Outcome;
       Indexes : constant Alire.Features.Index.Index_On_Disk_Set :=
                   Alire.Features.Index.Find_All
-                    (Alire.Config.Indexes_Directory);
+                    (Alire.Config.Indexes_Directory, Result);
       Found   : Boolean := False;
    begin
+      if not Result.Success then
+         Reportaise_Command_Failed (Alire.Message (Result));
+         return;
+      end if;
+
       --  Find matching index and delete
       for Index of Indexes loop
          if Index.Name = Name then
@@ -110,9 +116,19 @@ package body Alr.Commands.Index is
    procedure List is
       use Alire;
 
+      Result  : Alire.Outcome;
+      Indexes : constant Alire.Features.Index.Index_On_Disk_Set :=
+                  Alire.Features.Index.Find_All
+                    (Alire.Config.Indexes_Directory, Result);
+
       Table : AAA.Table_IO.Table;
       Count : Natural := 0;
    begin
+      if not Result.Success then
+         Reportaise_Command_Failed (Alire.Message (Result));
+         return;
+      end if;
+
       Table
         .Append ("#").Append ("Name").Append ("URL").Append ("Path");
 
@@ -120,7 +136,7 @@ package body Alr.Commands.Index is
          Table.Append ("Priority");
       end if;
 
-      for Index of Features.Index.Find_All (Config.Indexes_Directory) loop
+      for Index of Indexes loop
          Count := Count + 1;
          Table.New_Row;
          Table

--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -6,11 +6,12 @@ with Alire.Releases;
 with Alire.Roots;
 
 with Alr.Paths;
-with Alr.OS_Lib;
 with Alr.Parsers;
 with Alr.Root;
 with Alr.Templates;
 with Alr.Utils;
+
+with GNATCOLL.VFS;
 
 package body Alr.Commands.Init is
 
@@ -19,7 +20,7 @@ package body Alr.Commands.Init is
    --------------
 
    procedure Generate (Cmd : Command) is
-      use Alr.OS_Lib;
+      use GNATCOLL.VFS;
 
       package TIO renames Ada.Text_IO;
 
@@ -28,11 +29,11 @@ package body Alr.Commands.Init is
       Lower_Name  : constant String := Utils.To_Lower_Case (Name);
       Mixed_Name  : constant String := Utils.To_Mixed_Case (Name);
 
-      Directory     : constant String :=
+      Directory     : constant Virtual_File :=
         (if Cmd.In_Place
-         then Alire.Directories.Current
-         else Alire.Directories.Current / Name);
-      Src_Directory : constant String := Directory / "src";
+         then Get_Current_Dir
+         else Create (+Name, Normalize => True));
+      Src_Directory : constant Virtual_File := Directory / "src";
 
       File : TIO.File_Type;
 
@@ -54,7 +55,8 @@ package body Alr.Commands.Init is
       ---------------------------
 
       procedure Generate_Project_File is
-         Filename : constant String := Directory / (Lower_Name & ".gpr");
+         Filename : constant String :=
+            +Full_Name (Directory / (+Lower_Name & ".gpr"));
       begin
          TIO.Create (File, TIO.Out_File, Filename);
          Put_Line ("project " & Mixed_Name & " is");
@@ -96,7 +98,8 @@ package body Alr.Commands.Init is
       ---------------------------
 
       procedure Generate_Root_Package is
-         Filename : constant String := Src_Directory / (Lower_Name & ".ads");
+         Filename : constant String :=
+            +Full_Name (Src_Directory / (+Lower_Name & ".ads"));
       begin
          TIO.Create (File, TIO.Out_File, Filename);
          Put_Line ("package " & Mixed_Name & " is");
@@ -110,7 +113,8 @@ package body Alr.Commands.Init is
       ---------------------------
 
       procedure Generate_Program_Main is
-         Filename : constant String := Src_Directory / (Lower_Name & ".adb");
+         Filename : constant String :=
+            +Full_Name (Src_Directory / (+Lower_Name & ".adb"));
       begin
          TIO.Create (File, TIO.Out_File, Filename);
          Put_Line ("procedure " & Mixed_Name & " is");
@@ -143,12 +147,12 @@ package body Alr.Commands.Init is
          null; -- do nothing
 
       elsif Cmd.No_Skel then
-         Ada.Directories.Create_Directory (Directory);
+         Directory.Make_Dir;
 
       else
-         Ada.Directories.Create_Directory (Directory);
+         Directory.Make_Dir;
          Generate_Project_File;
-         Ada.Directories.Create_Directory (Src_Directory);
+         Src_Directory.Make_Dir;
          if For_Library then
             Generate_Root_Package;
          else
@@ -158,9 +162,9 @@ package body Alr.Commands.Init is
 
       declare
          Root : constant Alire.Roots.Root := Alire.Roots.New_Root
-           (+Name, Directory);
+           (+Name, Ada.Directories.Full_Name (+Directory.Full_Name));
       begin
-         OS_Lib.Create_Folder (Name / Paths.Alr_Working_Folder);
+         Make_Dir (Create (+Name) / (+Paths.Alr_Working_Folder));
 
          Templates.Generate_Prj_Alr
            (Root.Release,

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -9,7 +9,6 @@ with Alr.Files;
 with Alr.Interactive;
 with Alr.Paths;
 with Alr.Platform;
-with Alr.OS_Lib;
 with Alr.Parsers;
 with Alr.Query;
 with Alr.Testing.Collections;
@@ -20,6 +19,8 @@ with Alr.Testing.Text;
 with Alr.Utils;
 
 with GNAT.Command_Line;
+
+with GNATCOLL.VFS;
 
 with Semantic_Versioning;
 
@@ -81,6 +82,7 @@ package body Alr.Commands.Test is
                       Releases : Alire.Containers.Release_Sets.Set)
    is
       use Ada.Calendar;
+      use GNATCOLL.VFS;
       use OS_Lib.Paths;
 
       Reporters : Testing.Collections.Collection;
@@ -167,7 +169,8 @@ package body Alr.Commands.Test is
             end;
          end if;
 
-         OS_Lib.Create_Folder (R.Unique_Folder / Paths.Alr_Working_Folder);
+         Make_Dir
+           (Create (+R.Unique_Folder) / Create (+Paths.Alr_Working_Folder));
          --  Might not exist for native/failed/skipped
          Output.Write (R.Unique_Folder /
                          Paths.Alr_Working_Folder /

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -38,6 +38,8 @@ with Alr.Templates;
 
 with GNAT.OS_Lib;
 
+with GNATCOLL.VFS;
+
 package body Alr.Commands is
 
    use GNAT.Command_Line;
@@ -193,9 +195,10 @@ package body Alr.Commands is
    --------------------------
 
    procedure Create_Alire_Folders is
+      use GNATCOLL.VFS;
    begin
-      OS_Lib.Create_Folder (Platform.Config_Folder);
-      OS_Lib.Create_Folder (Platform.Cache_Folder);
+      Make_Dir (Create (+Platform.Config_Folder));
+      Make_Dir (Create (+Platform.Cache_Folder));
    end Create_Alire_Folders;
 
    -------------------

--- a/src/alr/alr-os_lib.ads
+++ b/src/alr/alr-os_lib.ads
@@ -14,10 +14,6 @@ package Alr.OS_Lib is
 
    --  Environment
 
-   procedure Create_Folder (Path : String)
-     renames Alire.Directories.Create_Directory;
-   --  Able to create full given path, permissions permitting
-
    function Getenv (Var : String; Default : String := "") return String;
 
    procedure Setenv (Var : String; Value : String) renames GNAT.OS_Lib.Setenv;

--- a/src/alr/alr-templates.adb
+++ b/src/alr/alr-templates.adb
@@ -17,6 +17,8 @@ with Alr.Platform;
 with Alr.Root;
 with Alr.Utils;
 
+with GNATCOLL.VFS;
+
 package body Alr.Templates is
 
    Tab_1 : constant String (1 .. 3) := (others => ' ');
@@ -254,15 +256,15 @@ package body Alr.Templates is
    procedure Generate_Prj_Alr (Release  : Types.Release;
                                Filename : String)
    is
+      use GNATCOLL.VFS;
+      F : constant Virtual_File := Create (+Filename, Normalize => True);
    begin
       Trace.Detail ("Generating " & Release.Project_Str & ".toml file for "
                     & Release.Milestone.Image & " with"
                     & Release.Dependencies.Leaf_Count'Img & " dependencies");
 
       --  Ensure working folder exists (might not upon first get)
-      if not Paths.Is_Simple_Name (Filename) then
-         OS_Lib.Create_Folder (Paths.Parent (Filename));
-      end if;
+      F.Get_Parent.Make_Dir;
 
       Files.Backup_If_Existing (Filename);
 

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -118,7 +118,7 @@ def prepare_indexes(config_dir, working_dir, index_descriptions):
         # Compute the directory that contains index files
         files_dir = (fixtures_path(files_dir)
                      if in_fixtures else
-                     os.path.join(working_dir, files_dir))
+                     files_dir)
 
         # Finally create the index description in the config directory
         index_dir = os.path.join(indexes_dir, name)

--- a/testsuite/tests/index/local-index-not-found/test.py
+++ b/testsuite/tests/index/local-index-not-found/test.py
@@ -1,0 +1,30 @@
+"""
+Test that Alire properly reports an invalid index URL.
+"""
+
+import os
+import re
+
+from e3.fs import rm
+
+from drivers.alr import prepare_indexes, run_alr
+from drivers.asserts import assert_match
+
+
+for d in ('no-such-directory',
+          'file://no-such-directory', ):
+    rm('alr-config', recursive=True)
+    prepare_indexes('alr-config', '.',
+                    {'bad_index': {'dir': d, 'in_fixtures': False}})
+    p = run_alr('list', complain_on_error=False)
+
+    path_excerpt = os.path.join('alr-config', 'indexes', 'bad_index',
+                                'index.toml')
+    assert_match('ERROR: Cannot load metadata from .*{}:'
+                 ' Not a readable directory'
+                 '\nERROR: alr list unsuccessful'
+                 '\n'
+                 .format(re.escape(path_excerpt)),
+                 p.out)
+
+print('SUCCESS')

--- a/testsuite/tests/index/local-index-not-found/test.yaml
+++ b/testsuite/tests/index/local-index-not-found/test.yaml
@@ -1,0 +1,5 @@
+driver: python-script
+indexes:
+    bad_index:
+        dir: file://no-such-directory
+        in_fixtures: false


### PR DESCRIPTION
Experimenting with gnacoll-slim to see if we can have our cake and eat it (i.e., no other dependencies).