### PR TITLE
Detect duplicate definition of switches

### DIFF
--- a/src/alr/alr-commands-dev.adb
+++ b/src/alr/alr-commands-dev.adb
@@ -1,5 +1,7 @@
 pragma Warnings (Off);
 
+with Ada.Command_Line;
+
 with Alr.Bootstrap;
 with Alr.Code;
 with Alr.Parsers;
@@ -49,6 +51,27 @@ package body Alr.Commands.Dev is
    is
       use GNAT.Command_Line;
    begin
+      --  Special case to enable a simple test for switch redefinition.
+      --  If exactly the second argument is "--check-switch-redefinition"
+      --  (e.g., calling alr dev --check-switch-redefinition), this will result
+      --  in alr erroring as expected. Two -1 and -2 variants are checked so
+      --  both long and short switch clashes can be tested separately.
+      if Ada.Command_Line.Argument_Count = 2 then
+         if Ada.Command_Line.Argument (2) = "--check-switch-redefinition-1"
+         then
+            Define_Switch (Config,
+                           Cmd.Custom'Access,
+                           "-h", "",
+                           "Check for redefined switch");
+         elsif Ada.Command_Line.Argument (2) = "--check-switch-redefinition-2"
+         then
+            Define_Switch (Config,
+                           Cmd.Custom'Access,
+                           "", "--help",
+                           "Check for redefined switch");
+         end if;
+      end if;
+
       Define_Switch (Config,
                      Cmd.Custom'Access,
                      "", "--custom",

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -36,6 +36,7 @@ with Alr.Platform;
 with Alr.Root;
 with Alr.Templates;
 
+with GNAT.Command_Line.Extra;
 with GNAT.OS_Lib;
 
 with GNATCOLL.VFS;
@@ -549,8 +550,13 @@ package body Alr.Commands is
          --  Specific to command
          Dispatch_Table (Cmd).Setup_Switches (Command_Config);
 
-         --  Validate command + global configuration:
+         --  Ensure Command has not set a switch that is already global:
+         if not GNAT.Command_Line.Extra.Verify_No_Duplicates (Command_Config)
+         then
+            raise Program_Error with "Duplicate switch definition detected";
+         end if;
 
+         --  Validate combined command + global configuration:
          Fill_For_Real := True;
 
          Initialize_Option_Scan;

--- a/src/alr/alr-main.adb
+++ b/src/alr/alr-main.adb
@@ -25,6 +25,7 @@ exception
    --  Ensure we do not show an exception trace to unsuspecting users
    when E : others =>
       Alire.Log_Exception (E);
-      Trace.Error ("alr encountered an unexpected error");
+      Trace.Error ("alr encountered an unexpected error,"
+                   & " re-run with -d for details.");
       OS_Lib.Bailout (1);
 end Alr.Main;

--- a/src/alr/gnat-command_line-extra.adb
+++ b/src/alr/gnat-command_line-extra.adb
@@ -1,0 +1,50 @@
+with Alire.Utils;
+
+with GNAT.Strings;
+
+package body GNAT.Command_Line.Extra is
+
+   function Verify_No_Duplicates (Config : Command_Line_Configuration)
+                                  return Boolean
+   is
+      Seen : Alire.Utils.String_Sets.Set;
+      --  We track already set switches in this set; any re-appearance is
+      --  reported.
+
+      function Insert (Switch : String) return Boolean is
+         --  Return True if OK; False otherwise.
+      begin
+         Seen.Insert (Switch);
+         --  Raises Constraint_Error when element already exists.
+
+         return True;
+      exception
+         when Constraint_Error =>
+            Alire.Trace.Error ("Redefined switch: " & Switch);
+            return False;
+      end Insert;
+
+      use all type GNAT.Strings.String_Access;
+   begin
+      for Switch of Config.Switches.all loop
+         --  Short version
+         if Switch.Switch /= null and then
+           Switch.Switch.all /= "" and then
+           not Insert (Switch.Switch.all)
+         then
+            return False;
+         end if;
+         --  Long version
+         if Switch.Long_Switch /= null and then
+           Switch.Long_Switch.all /= "" and then
+           not Insert (Switch.Long_Switch.all)
+         then
+            return False;
+         end if;
+      end loop;
+
+      --  No duplication detected
+      return True;
+   end Verify_No_Duplicates;
+
+end GNAT.Command_Line.Extra;

--- a/src/alr/gnat-command_line-extra.ads
+++ b/src/alr/gnat-command_line-extra.ads
@@ -1,0 +1,11 @@
+package GNAT.Command_Line.Extra is
+
+   function Verify_No_Duplicates (Config : Command_Line_Configuration)
+                                  return Boolean;
+   --  Returns True if there are no duplicates.
+   --  Check that no switch is given twice in Config. This is used to ensure
+   --  that command switches are not stepping on global switches, which would
+   --  lead to some undefined behavior. This manual check is necessary because
+   --  the GNAT library does not perform it.
+
+end GNAT.Command_Line.Extra;

--- a/testsuite/tests/switch-redefinition/test.py
+++ b/testsuite/tests/switch-redefinition/test.py
@@ -1,0 +1,28 @@
+"""
+Check that a command redefining a global switch is detected.
+"""
+
+import os
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq
+
+# Run internal dev command with specific option for this test, first check:
+p = run_alr('dev', '--check-switch-redefinition-1',
+            quiet=False, # For this check, alr expects the exact above line
+            complain_on_error=False)
+assert p.status != 0, "alr should have errored"
+assert_eq('ERROR: Redefined switch: -h\n' \
+          + 'ERROR: alr encountered an unexpected error,' \
+          + ' re-run with -d for details.\n', p.out)
+
+# Run internal dev command with specific option for this test, second check:
+p = run_alr('dev', '--check-switch-redefinition-2',
+            quiet=False, # For this check, alr expects the exact above line
+            complain_on_error=False)
+assert p.status != 0, "alr should have errored"
+assert_eq('ERROR: Redefined switch: --help\n' \
+          + 'ERROR: alr encountered an unexpected error,' \
+          + ' re-run with -d for details.\n', p.out)
+
+print('SUCCESS')

--- a/testsuite/tests/switch-redefinition/test.yaml
+++ b/testsuite/tests/switch-redefinition/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
Ensure that a command does not redefine a previously defined global switch. More generally, check that the same switch is not defined twice, in either short or long form.

Fixes #111 