### PR TITLE
Use previous working e3-testsuite commit

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -28,7 +28,7 @@ build:
         image_tag: $IMAGE_TAG
         pull: true
     ci:
-        - pip install git+https://github.com/pmderodat/e3-testsuite.git
+        - pip install git+https://github.com/pmderodat/e3-testsuite.git@98e6847
         - scripts/shiptest.sh
     on_success:
         - shipctl put_resource_state branchInfo branch "none"


### PR DESCRIPTION
yaml.safe_load causes an exception. This is a temporal workaround
until the Python expert is back.