### PR TITLE
Use -d/--debug for specific debug logging

### DIFF
--- a/src/alire/alire.adb
+++ b/src/alire/alire.adb
@@ -1,4 +1,17 @@
+with GNAT.IO;
+
 package body Alire is
+
+   -------------
+   -- Err_Log --
+   -------------
+   --  Write given string to Standard_Error
+
+   procedure Err_Log (S : String) is
+      use GNAT.IO;
+   begin
+      Put_Line (Standard_Error, "stderr: " & S);
+   end Err_Log;
 
    -------------------
    -- Log_Exception --
@@ -14,6 +27,12 @@ package body Alire is
       Log (Exception_Message (E), Level);
       Log (Exception_Information (E), Level);
       Log ("--->8--- Exception dump end ----->8---", Level);
+
+      if Log_Debug then
+         Err_Log (Exception_Name (E));
+         Err_Log (Exception_Message (E));
+         Err_Log (Exception_Information (E));
+      end if;
    end Log_Exception;
 
    ----------------------------

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -162,9 +162,10 @@ package Alire with Preelaborate is
    package Trace renames Simple_Logging;
 
    Log_Level : Simple_Logging.Levels renames Simple_Logging.Level;
+   --  This one selects the verbosity level of the logging library.
 
-   procedure Log (S : String; Level : Simple_Logging.Levels := Info)
-                  renames Simple_Logging.Log;
+   Log_Debug : aliased Boolean := False;
+   --  This one enables special debug output, irrespectively of the log level.
 
    procedure Log_Exception (E     : Ada.Exceptions.Exception_Occurrence;
                             Level : Simple_Logging.Levels := Debug);

--- a/src/alire/alire_early_elaboration.ads
+++ b/src/alire/alire_early_elaboration.ads
@@ -7,10 +7,19 @@ package Alire_Early_Elaboration with Elaborate_Body is
 
    --  Not directly a child of Alire to avoid circularity
 
-   Switch_D,
+   --  Logging in alire works in two separate channels:
+   --  The -q, (none), -v and -vv switches allow to select one of the normal
+   --  verbosity levels: quiet, normal, verbose, detail.
+   --  OTOH, the -d/--debug switch enables logging of all unexpected exceptions
+   --  to stderr independently of the verbosity level.
+
+   Switch_D  : aliased Boolean := False;
+   --  For the debugging channel.
+
    Switch_Q,
-   Switch_V : aliased Boolean := False;
-   --  Verbosity switches detected during early elaboration
+   Switch_V,
+   Switch_VV : aliased Boolean := False;
+   --  For the verbosity level.
 
    Start : constant Ada.Calendar.Time := Ada.Calendar.Clock;
    --  Out of curiosity

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -104,12 +104,6 @@ package Alr.Commands is
    --  command-line helpers --
    ---------------------------
 
-   function Global_Switches return String;
-   --  This is exported only to be reachable from Spawn, but there's no reason
-   --  to use it from commands.
-   --  Returns the in use global switches (-d -q -v).
-   --  Useful e.g. to pass along on respawning a custom command.
-
    function Is_Quiet return Boolean;
    --  Says if -q was in the command line
 

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -37,16 +37,22 @@ def run_alr(*args, **kwargs):
         debugging) and raise a CalledProcessError (to abort the test).
     :param bool quiet: If true (which is the default), append "-q" to the
         command line.
+    :param bool debug: If true (which is the default), append "-d" to the
+        command line. This ensures uncaught exceptions are logged instead
+        of presenting a sanitized error intended for final users.
     :rtype: Run
     """
 
     complain_on_error = kwargs.pop('complain_on_error', True)
+    debug = kwargs.pop('debug', True)
     quiet = kwargs.pop('quiet', True)
     if kwargs:
         first_unknown_kwarg = sorted(kwargs)[0]
         raise ValueError('Invalid argument: {}'.format(first_unknown_kwarg))
 
     argv = ['alr']
+    if debug:
+        argv.append('-d')
     if quiet:
         argv.append('-q')
     argv.extend(args)

--- a/testsuite/tests/debug/enabled-dump-exception/test.py
+++ b/testsuite/tests/debug/enabled-dump-exception/test.py
@@ -1,0 +1,30 @@
+"""
+Test that -d/--debug enable dumping of unexpected exceptions
+"""
+
+import os
+
+from drivers.alr import prepare_env, prepare_indexes, run_alr
+from drivers.asserts import assert_eq, assert_match
+
+
+def check_output(dump):
+    assert_match(
+	'''stderr: PROGRAM_ERROR
+stderr: Raising forcibly
+stderr: raised PROGRAM_ERROR : Raising forcibly.*
+''', dump)
+
+
+# Check debug dump (we intentionally disable debug flag in run_alr)
+check_output(run_alr('dev', '--raise', '-d',
+                     debug=False, complain_on_error=False).out)
+# Long flag version
+check_output(run_alr('dev', '--raise', '--debug',
+                     debug=False, complain_on_error=False).out)
+
+# Check ordinary non-debug output:
+assert_eq(run_alr('dev', '--raise', debug=False, complain_on_error=False).out,
+          "ERROR: alr encountered an unexpected error\n")
+
+print('SUCCESS')

--- a/testsuite/tests/debug/enabled-dump-exception/test.yaml
+++ b/testsuite/tests/debug/enabled-dump-exception/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
This patch slightly reworks the verbosity system in `alr` to enable both quiet testing without losing important diagnostic messages. To do so, there are now two separate logging "channels"

1. The previous, normal logging facilities, with 4 verbosity levels that go to stdout:
   - `-q` (quiet, only error messages)
   - `(none)` (only error and warning messages)
   - `-v` (verbose)
   - `-vv` (extra verbose) (what was `-d` previously)

2. A new debug mode (`-d/--debug`) which will print debug information bypassing any verbosity levels, to stderr.