### PR TITLE
Enhance -d/--debug with optional debugging scopes

### DIFF
--- a/src/alr/alr-commands-dev.adb
+++ b/src/alr/alr-commands-dev.adb
@@ -30,6 +30,10 @@ package body Alr.Commands.Dev is
          Custom;
       end if;
 
+      if Cmd.Filtering then
+         Trace.Debug ("In dev --filter");
+      end if;
+
       if Cmd.Raise_Except then
          raise Program_Error with "Raising forcibly";
       end if;
@@ -64,6 +68,11 @@ package body Alr.Commands.Dev is
                      Cmd.Custom'Access,
                      "", "--custom",
                      "Execute current custom code");
+
+      Define_Switch (Config,
+                     Cmd.Filtering'Access,
+                     "", "--filter",
+                     "Used by scope filtering test");
 
       Define_Switch (Config,
                      Cmd.Raise_Except'Access,

--- a/src/alr/alr-commands-dev.ads
+++ b/src/alr/alr-commands-dev.ads
@@ -26,6 +26,7 @@ private
 
    type Command is new Commands.Command with record
       Custom       : aliased Boolean := False; -- Custom code to run instead
+      Filtering    : aliased Boolean := False; -- Runs debug scope filtering
       Raise_Except : aliased Boolean := False;
       Self_Test    : aliased Boolean := False;
    end record;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -179,8 +179,8 @@ package body Alr.Commands is
 
       Define_Switch (Config,
                      Debug_Channel'Access,
-                     "-d",
-                     Long_Switch => "--debug",
+                     "-d?",
+                     Long_Switch => "--debug?",
                      Help =>
                        "Enable debug-specific log messages");
    end Set_Global_Switches;

--- a/src/alr/alr-os_lib.adb
+++ b/src/alr/alr-os_lib.adb
@@ -50,7 +50,7 @@ package body Alr.OS_Lib is
       end Go_Down;
 
    begin
-      Log ("Traversing folder: " & Folder, Debug);
+      Trace.Debug ("Traversing folder: " & Folder);
 
       Search (Folder,
               "",
@@ -65,10 +65,10 @@ package body Alr.OS_Lib is
    procedure Delete_File (Name : String) is
    begin
       if GNAT.OS_Lib.Is_Regular_File (Name) then
-         Log ("Deleting file: " & Name, Debug);
+         Trace.Debug ("Deleting file: " & Name);
          Ada.Directories.Delete_File (Name);
       else
-         Log ("Skipping deletion of non-existent file: " & Name, Debug);
+         Trace.Debug ("Skipping deletion of non-existent file: " & Name);
       end if;
    end Delete_File;
 
@@ -119,7 +119,7 @@ package body Alr.OS_Lib is
          end if;
 
          if Contains (Simple_Name (Item), Pattern) then
-            Log ("Filename match: " & Simple_Name (Item), Debug);
+            Trace.Debug ("Filename match: " & Simple_Name (Item));
             Rename (Full_Name (Item),
                     Containing_Directory (Full_Name (Item)) /
                       Utils.Replace (Simple_Name (Item),
@@ -136,7 +136,7 @@ package body Alr.OS_Lib is
          use Alire.Directories;
          G : Guard (Enter (Folder)) with Unreferenced;
       begin
-         Log ("sed-ing project name in files...", Debug);
+         Trace.Debug ("sed-ing project name in files...");
          Spawn ("find", ". -type f -exec sed -i s/" &
                   Pattern & "/" & Replace & "/g {} \;",
                 Force_Quiet => True);
@@ -144,7 +144,7 @@ package body Alr.OS_Lib is
 
       --  This is not OS dependent
       --  File names
-      Log ("sed-ing project in file names...", Debug);
+      Trace.Debug ("sed-ing project in file names...");
       Traverse_Folder (Folder, Rename'Access);
    end Sed_Folder;
 

--- a/src/alr/alr.ads
+++ b/src/alr/alr.ads
@@ -16,15 +16,11 @@ package Alr with Preelaborate is
    --  Signals "normal" command completion with failure (i.e., no need to print
    --  stack trace).
 
+   --  Use some general types for the benefit of all child packages:
    pragma Warnings (Off);
    use all type Alire.Project;
-   pragma Warnings (On);
-
    use all type Simple_Logging.Levels;
-
-   procedure Log (S : String;
-                  Level : Simple_Logging.Levels := Info)
-   renames Simple_Logging.Log;
+   pragma Warnings (On);
 
    package Trace renames Simple_Logging;
 

--- a/testsuite/tests/debug/logging-scopes/test.py
+++ b/testsuite/tests/debug/logging-scopes/test.py
@@ -1,0 +1,48 @@
+"""
+Test the fidelity of various logging scopes
+"""
+
+from glob import glob
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq
+from drivers.asserts import assert_match
+
+# Check invalid syntax detection
+p = run_alr('dev', '-d--', complain_on_error=False, quiet=False)
+assert p.status == 1, "alr should have error code 1"
+assert_eq('Filtering mode: BLACKLIST\n'
+          'Invalid logging scope separator: --\n'
+          'ERROR: Invalid logging filters.',
+          p.out.strip())
+
+# Check empty whitelist lets nothing through
+p = run_alr('dev', '-vv', '-d+', quiet=False)
+assert_eq('Filtering mode: WHITELIST', p.out.strip())
+
+# Check whitelisting
+p = run_alr('dev', '--filter', '-vv', '-d+dev', quiet=False)
+assert_match('Filtering mode: WHITELIST\n'
+             'Filtering substring: dev\n'
+             '\[Alr.Commands.Dev.Execute\] \(alr-commands-dev.adb:[0-9]* \)'
+             ' -->> In dev --filter',
+             p.out.strip())
+
+# Check whitelisting with exception
+p = run_alr('dev', '--filter', '-vv', '-d+dev-exec', quiet=False)
+assert_eq('Filtering mode: WHITELIST\n'
+          'Filtering substring: dev\n'
+          'Filtering exception: exec',
+          p.out.strip())
+
+# Check blacklisting with exception
+p = run_alr('dev', '-vv', '-d-a+main', quiet=False)
+assert_match('Filtering mode: BLACKLIST\n'
+             'Filtering substring: a\n'
+             'Filtering exception: main\n'
+             '\[Alr.Main                \] \(alr-main.adb:.*',
+             # Remaining output is likely to change in the future so lets just
+             # stop here the matching.
+             p.out.strip())
+
+print('SUCCESS')

--- a/testsuite/tests/debug/logging-scopes/test.yaml
+++ b/testsuite/tests/debug/logging-scopes/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
This patch allows passing optional filters to `-d/--debug`, which are substrings that will be matched against the enclosing entity and source file of regular verbosity logging messages.

By passing e.g. `-d+main`, `-d-alr`, etc, the logging output can be filtered out in both blacklist/whitelist mode. Several filters can be given: `-d+main+commands`. 

Using the contrary sign acts as an exception to the filtering: `-d+alr-commands` will whitelist all `alr` messages, but will filter out `commands` messages.

The first sign in the argument puts the filtering in whitelist (+) or blacklist (-) mode. As special cases, giving no substrings illustrate these modes: `-d-` will use an empty blacklist, thus allowing all logging messages to pass through. Contrarily, `-d+` will use an empty whitelist, blocking all messages.

These filters act on the normal verbosity logging, so one most likely wants `-vv -d[something]` in practice.

See example testcase therein for other examples.