### PR TITLE
Remove obsolete private properties from Releases

### DIFF
--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -19,7 +19,7 @@ package body Alire.Releases is
    function All_Properties (R : Release;
                             P : Alire.Properties.Vector)
                             return Alire.Properties.Vector
-   is (Materialize (R.Properties and R.Priv_Props, P));
+   is (Materialize (R.Properties, P));
 
    ------------------------
    -- Default_Properties --
@@ -43,9 +43,6 @@ package body Alire.Releases is
       Properties         : Conditional.Properties   :=
         Conditional.For_Properties.Empty;
 
-      Private_Properties : Conditional.Properties   :=
-        Conditional.For_Properties.Empty;
-
       Available          : Alire.Requisites.Tree    :=
         Requisites.Trees.Empty_Tree
      )
@@ -58,7 +55,6 @@ package body Alire.Releases is
       return Extended : Release := Base do
          Extended.Dependencies := Base.Dependencies and Dependencies;
          Extended.Properties   := Base.Properties   and Properties;
-         Extended.Priv_Props   := Base.Priv_Props   and Private_Properties;
          Extended.Available    := Base.Available    and Available;
       end return;
    end Extending;
@@ -153,7 +149,6 @@ package body Alire.Releases is
          Dependencies => Base.Dependencies,
          Forbidden    => Base.Forbidden,
          Properties   => Base.Properties,
-         Priv_Props   => Base.Priv_Props,
          Available    => Base.Available)
       do
          null;
@@ -209,7 +204,6 @@ package body Alire.Releases is
       Dependencies => Dependencies,
       Forbidden    => Conditional.For_Dependencies.Empty,
       Properties   => Properties,
-      Priv_Props   => Private_Properties,
       Available    => Available);
 
    -------------------------
@@ -236,7 +230,6 @@ package body Alire.Releases is
       Properties   => (if Properties = Conditional.For_Properties.Empty
                        then Default_Properties
                        else Properties),
-      Priv_Props   => Conditional.For_Properties.Empty,
       Available    => Requisites.Booleans.Always_True);
 
    ----------------------------
@@ -252,9 +245,7 @@ package body Alire.Releases is
       use Ada.Tags;
    begin
       if Descendant_Of = No_Tag then
-         return Materialize (R.Properties, P)
-                  and
-                Materialize (R.Priv_Props, P);
+         return Materialize (R.Properties, P);
       else
          declare
             Props : constant Alire.Properties.Vector :=
@@ -394,7 +385,7 @@ package body Alire.Releases is
    -- Print --
    -----------
 
-   procedure Print (R : Release; Private_Too : Boolean := False) is
+   procedure Print (R : Release) is
       use GNAT.IO;
    begin
       --  MILESTONE
@@ -440,12 +431,6 @@ package body Alire.Releases is
          R.Properties.Print ("   ", False);
       end if;
 
-      --  PRIVATE PROPERTIES
-      if Private_Too and then not R.Properties.Is_Empty then
-         Put_Line ("Private properties:");
-         R.Priv_Props.Print ("   ", False);
-      end if;
-
       --  DEPENDENCIES
       if not R.Dependencies.Is_Empty then
          Put_Line ("Dependencies (direct):");
@@ -462,7 +447,7 @@ package body Alire.Releases is
 
       Search : constant String := To_Lower_Case (Str);
    begin
-      for P of Enumerate (R.Properties and R.Priv_Props) loop
+      for P of Enumerate (R.Properties) loop
          declare
             Text : constant String :=
                      To_Lower_Case
@@ -634,7 +619,6 @@ package body Alire.Releases is
          Dependencies => R.Dependencies.Evaluate (P),
          Forbidden    => R.Forbidden.Evaluate (P),
          Properties   => R.Properties.Evaluate (P),
-         Priv_Props   => R.Priv_Props.Evaluate (P),
          Available    => (if R.Available.Check (P)
                           then Requisites.Booleans.Always_True
                           else Requisites.Booleans.Always_False))

--- a/src/alire/alire-releases.ads
+++ b/src/alire/alire-releases.ads
@@ -66,9 +66,6 @@ package Alire.Releases with Preelaborate is
       Properties         : Conditional.Properties   :=
         Conditional.For_Properties.Empty;
 
-      Private_Properties : Conditional.Properties   :=
-        Conditional.For_Properties.Empty;
-
       Available          : Alire.Requisites.Tree    :=
         Requisites.Trees.Empty_Tree
      )
@@ -143,8 +140,6 @@ package Alire.Releases with Preelaborate is
 
    function Properties (R : Release) return Conditional.Properties;
 
-   function Private_Properties (R : Release) return Conditional.Properties;
-
    function Depends (R : Release;
                      P : Alire.Properties.Vector)
                      return Conditional.Dependencies;
@@ -217,7 +212,7 @@ package Alire.Releases with Preelaborate is
 
    function Milestone (R : Release) return Milestones.Milestone;
 
-   procedure Print (R : Release; Private_Too : Boolean := False);
+   procedure Print (R : Release);
    --  Dump info to console
 
 --     overriding function To_Code (R : Release) return Utils.String_Vector;
@@ -274,7 +269,6 @@ private
       Dependencies : Conditional.Dependencies;
       Forbidden    : Conditional.Dependencies;
       Properties   : Conditional.Properties;
-      Priv_Props   : Conditional.Properties;
       Available    : Requisites.Tree;
    end record;
 
@@ -326,9 +320,6 @@ private
 
    function Properties (R : Release) return Conditional.Properties
    is (R.Properties);
-
-   function Private_Properties (R : Release) return Conditional.Properties
-   is (R.Priv_Props);
 
    function Origin  (R : Release) return Origins.Origin
    is (R.Origin);

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -52,9 +52,9 @@ package body Alr.Commands.Show is
          New_Line;
 
          if Cmd.Native then
-            Rel.Whenever (Platform.Properties).Print (Private_Too => Cmd.Priv);
+            Rel.Whenever (Platform.Properties).Print;
          else
-            Rel.Print (Private_Too => Cmd.Priv);
+            Rel.Print;
          end if;
 
          if Rel.Origin.Is_Native then
@@ -215,10 +215,6 @@ package body Alr.Commands.Show is
       Define_Switch (Config,
                      Cmd.Native'Access,
                      "", "--native", "Show info relevant to current platform");
-
-      Define_Switch (Config,
-                     Cmd.Priv'Access,
-                     "", "--private", "Show also private properties");
 
       Define_Switch (Config,
                      Cmd.Solve'Access,

--- a/src/alr/alr-commands-show.ads
+++ b/src/alr/alr-commands-show.ads
@@ -21,9 +21,8 @@ package Alr.Commands.Show is
 private
 
    type Command is new Commands.Command with record
-      Native : aliased Boolean := False;
-      Priv   : aliased Boolean := False;
-      Solve  : aliased Boolean := False;
+      Native  : aliased Boolean := False;
+      Solve   : aliased Boolean := False;
       Jekyll : aliased Boolean := False;
    end record;
 


### PR DESCRIPTION
Private properties do not exist in the new TOML index format. Fixes #91 