### PR TITLE
[RFC] Add a Jekyll format option to the show command

### DIFF
--- a/src/alire/alire-actions.ads
+++ b/src/alire/alire-actions.ads
@@ -54,8 +54,15 @@ private
       Working_Folder        : Platform_Independent_Path (1 .. Folder_Len);
    end record;
 
-   overriding function Image (This : Run) return String is
-     (Utils.To_Mixed_Case (This.Moment'Img) & " run: <project>" &
+   overriding
+   function Image (This : Run) return String
+   is (Utils.To_Mixed_Case (This.Moment'Img) & " run: <project>" &
+        (if This.Working_Folder /= "" then "/" else "") &
+        This.Working_Folder & "/" & This.Relative_Command_Line);
+
+   overriding
+   function To_YAML (This : Run) return String
+   is (Utils.To_Mixed_Case (This.Moment'Img) & " run: <project>" &
         (if This.Working_Folder /= "" then "/" else "") &
         This.Working_Folder & "/" & This.Relative_Command_Line);
 

--- a/src/alire/alire-conditional_trees.adb
+++ b/src/alire/alire-conditional_trees.adb
@@ -14,6 +14,16 @@ package body Alire.Conditional_Trees is
                       This  : Inner_Node'Class;    -- The next node to flatten
                       Conj  : Conjunctions);       -- To prevent mixing
 
+   -------------
+   -- To_YAML --
+   -------------
+
+   overriding
+   function To_YAML (This : Tree) return String
+   is (if This.Is_Empty
+       then ""
+       else This.Constant_Reference.To_YAML);
+
    ----------
    -- Kind --
    ----------
@@ -23,21 +33,36 @@ package body Alire.Conditional_Trees is
       return This.Constant_Reference.Kind;
    end Kind;
 
-   overriding function Image (V : Value_Inner) return String is
+   overriding
+   function Image (V : Value_Inner) return String is
      (Image (V.Value.Constant_Reference));
+
+   overriding
+   function To_YAML (V : Value_Inner) return String is
+     (V.Value.Constant_Reference.To_YAML);
 
    function Conjunction (This : Vector_Inner) return Conjunctions is
      (This.Conjunction);
 
-   overriding function Image (V : Vector_Inner) return String is
+   overriding
+   function Image (V : Vector_Inner) return String is
      ("(" & (if V.Conjunction = Anded
              then Non_Primitive.One_Liner_And (V.Values)
              else Non_Primitive.One_Liner_Or (V.Values)) & ")");
 
-   overriding function Image (V : Conditional_Inner) return String is
+   overriding
+   function To_YAML (V : Vector_Inner) return String is
+     (Non_Primitive.To_YAML (V.Values));
+
+   overriding
+   function Image (V : Conditional_Inner) return String is
      ("if " & V.Condition.Image &
         " then " & V.Then_Value.Image_One_Line &
         " else " & V.Else_Value.Image_One_Line);
+
+   overriding
+   function To_YAML (V : Conditional_Inner) return String is
+     (raise Program_Error with "TODO YAML output to be defined");
 
    --------------------
    -- As_Conditional --

--- a/src/alire/alire-interfaces.ads
+++ b/src/alire/alire-interfaces.ads
@@ -1,4 +1,4 @@
-with Alire.Utils;
+limited with Alire.Utils;
 
 with TOML;
 
@@ -38,5 +38,14 @@ package Alire.Interfaces with Preelaborate is
    --  This can be recursive (trees, arrays...)
 
    function To_TOML (This : Tomifiable) return TOML.TOML_Value is abstract;
+
+   --------------
+   -- Yamlable --
+   --------------
+
+   type Yamlable is limited interface;
+
+   function To_YAML (This : Yamlable) return String is abstract;
+   --  Return a YAML text repsentation of the object
 
 end Alire.Interfaces;

--- a/src/alire/alire-properties-labeled.ads
+++ b/src/alire/alire-properties-labeled.ads
@@ -57,7 +57,11 @@ package Alire.Properties.Labeled with Preelaborate is
    function Filter (LV : Vector; Name : Labels) return Vector;
    --  Return only Label'Class with matching name
 
-   overriding function Image (L : Label) return String;
+   overriding
+   function Image (L : Label) return String;
+
+   overriding
+   function To_YAML (L : Label) return String;
 
    function Key (L : Labels) return String;
 
@@ -114,6 +118,10 @@ private
    overriding
    function Image (L : Label) return String
    is (Utils.To_Mixed_Case (L.Name'Img) & ": " & L.Value);
+
+   overriding
+   function To_YAML (L : Label) return String
+   is (Utils.YAML_Stringify (L.Value));
 
    function Key (L : Labels) return String
    is  (case L is

--- a/src/alire/alire-properties-licenses.ads
+++ b/src/alire/alire-properties-licenses.ads
@@ -7,6 +7,8 @@ package Alire.Properties.Licenses with Preelaborate is
 
    function Image (L : Licensing.Licenses) return String;
 
+   function To_YAML (L : Licensing.Licenses) return String;
+
    function Key (Dummy_L : Licensing.Licenses) return String
    is (TOML_Keys.License);
 
@@ -14,6 +16,7 @@ package Alire.Properties.Licenses with Preelaborate is
 
    package Values is new Properties.Values (Alire.Licensing.Licenses,
                                             Image,
+                                            To_YAML,
                                             Key,
                                             To_TOML);
 
@@ -21,6 +24,9 @@ private
 
    function Image (L : Licensing.Licenses) return String is
      ("License: " & L'Image);
+
+   function To_YAML (L : Licensing.Licenses) return String is
+     (Alire.Utils.YAML_Stringify (L'Image));
 
    function To_TOML (L : Licensing.Licenses) return TOML.TOML_Value is
       (TOML.Create_String (Licensing.License_Labels (L)));

--- a/src/alire/alire-properties-platform.ads
+++ b/src/alire/alire-properties-platform.ads
@@ -15,6 +15,7 @@ package Alire.Properties.Platform with Preelaborate is
    function Tomify is new TOML_Adapters.Tomify (Platforms.Compilers);
    package Compilers is new Values (Platforms.Compilers,
                                     Platforms.Compilers'Image,
+                                    Platforms.Compilers'Image,
                                     Compiler_Key,
                                     Tomify);
 
@@ -23,6 +24,7 @@ package Alire.Properties.Platform with Preelaborate is
 
    function Tomify is new TOML_Adapters.Tomify (Platforms.Distributions);
    package Distributions is new Values (Platforms.Distributions,
+                                        Platforms.Distributions'Image,
                                         Platforms.Distributions'Image,
                                         Distro_Key,
                                         Tomify);
@@ -33,6 +35,7 @@ package Alire.Properties.Platform with Preelaborate is
    function Tomify is new TOML_Adapters.Tomify (Platforms.Operating_Systems);
    package Operating_Systems is new Values (Platforms.Operating_Systems,
                                             Platforms.Operating_Systems'Image,
+                                            Platforms.Operating_Systems'Image,
                                             OS_Key,
                                             Tomify);
 
@@ -40,6 +43,7 @@ package Alire.Properties.Platform with Preelaborate is
    is (TOML_Keys.Target);
    function Tomify is new TOML_Adapters.Tomify (Platforms.Targets);
    package Targets is new Values (Platforms.Targets,
+                                  Platforms.Targets'Image,
                                   Platforms.Targets'Image,
                                   Target_Key,
                                   Tomify);
@@ -49,6 +53,7 @@ package Alire.Properties.Platform with Preelaborate is
    function Tomify is new TOML_Adapters.Tomify (Platforms.Versions);
    package Versions is new Values (Platforms.Versions,
                                    Platforms.Versions'Image,
+                                   Platforms.Versions'Image,
                                    Version_Key,
                                    Tomify);
 
@@ -56,6 +61,7 @@ package Alire.Properties.Platform with Preelaborate is
    is (TOML_Keys.Word_Size);
    function Tomify is new TOML_Adapters.Tomify (Platforms.Word_Sizes);
    package Word_Sizes is new Values (Platforms.Word_Sizes,
+                                     Platforms.Word_Sizes'Image,
                                      Platforms.Word_Sizes'Image,
                                      Word_Size_Key,
                                      Tomify);

--- a/src/alire/alire-properties-scenarios.ads
+++ b/src/alire/alire-properties-scenarios.ads
@@ -9,11 +9,16 @@ package Alire.Properties.Scenarios with Preelaborate is
 
    function New_Property (V : GPR.Variable) return Property;
 
-   overriding function Image (V : Property) return String;
+   overriding
+   function Image (V : Property) return String;
+
+   overriding
+   function To_YAML (V : Property) return String;
 
    function Value (V : Property) return GPR.Variable;
 
-   overriding function Key (V : Property) return String;
+   overriding
+   function Key (V : Property) return String;
 
 private
 
@@ -24,12 +29,20 @@ private
       Var : Holders.Holder;
    end record;
 
-   overriding function To_TOML (V : Property) return TOML.TOML_Value;
+   overriding
+   function To_TOML (V : Property) return TOML.TOML_Value;
 
    function New_Property (V : GPR.Variable) return Property is
       (Var => Holders.To_Holder (V));
 
-   overriding function Image (V : Property) return String is
+   overriding
+   function Image (V : Property) return String is
+     ((case V.Var.Element.Kind is
+          when GPR.External => "GPR External: ",
+          when others       => "GPR Scenario: ") & V.Var.Element.Image);
+
+   overriding
+   function To_YAML (V : Property) return String is
      ((case V.Var.Element.Kind is
           when GPR.External => "GPR External: ",
           when others       => "GPR Scenario: ") & V.Var.Element.Image);

--- a/src/alire/alire-properties.adb
+++ b/src/alire/alire-properties.adb
@@ -16,6 +16,22 @@ package body Alire.Properties is
       return Result;
    end Filter;
 
+   ------------
+   -- Filter --
+   ------------
+
+   function Filter (V : Vector; Key : String) return Vector is
+      Result : Vector := No_Properties;
+   begin
+      for Prop of V loop
+         if Prop.Key = Key then
+            Result.Append (Prop);
+         end if;
+      end loop;
+
+      return Result;
+   end Filter;
+
    -------------
    -- To_TOML --
    -------------

--- a/src/alire/alire-properties.ads
+++ b/src/alire/alire-properties.ads
@@ -17,9 +17,11 @@ package Alire.Properties with Preelaborate is
    --  design. Instead, a first check of matching tags is done and then the
    --  checks can proceed.
 
-   type Property is abstract new
-     Interfaces.Classificable and
-     Interfaces.Tomifiable with null record;
+   type Property is abstract
+     new Interfaces.Classificable
+     and Interfaces.Tomifiable
+     and Interfaces.Yamlable
+   with null record;
 
    overriding function Key (P : Property) return String is abstract;
 
@@ -33,6 +35,9 @@ package Alire.Properties with Preelaborate is
 
    function To_TOML_Classwide (P : Property'Class) return TOML.TOML_Value
    is (P.To_TOML);
+
+   overriding
+   function To_YAML (P : Property) return String is abstract;
 
    package Vectors
    is new Ada.Containers.Indefinite_Vectors (Positive, Property'Class);
@@ -53,6 +58,9 @@ package Alire.Properties with Preelaborate is
    function Filter (V : Vector; Ancestor : Ada.Tags.Tag) return Vector;
    --  Filter properties by ancestor class
 
+   function Filter (V : Vector; Key : String) return Vector;
+   --  Filter properties by key
+
    function Image_One_Line (V : Vector) return String;
 
    overriding function To_TOML (V : Vector) return TOML.TOML_Value
@@ -62,6 +70,7 @@ package Alire.Properties with Preelaborate is
    generic
       type Value is private;
       with function Image (V : Value) return String is <>;
+      with function Yamlify (V : Value) return String is <>;
       with function Key (V : Value) return String is <>;
       with function Tomify (V : Value) return TOML.TOML_Value;
    package Values is
@@ -83,6 +92,9 @@ package Alire.Properties with Preelaborate is
       function Image (P : Property) return String;
 
       overriding
+      function To_YAML (P : Property) return String;
+
+      overriding
       function To_TOML (P : Property) return TOML.TOML_Value;
 
       type Property is new Properties.Property with record
@@ -97,6 +109,9 @@ package Alire.Properties with Preelaborate is
 
       overriding
       function Image (P : Property) return String is (Image (P.V));
+
+      overriding
+      function To_YAML (P : Property) return String is (Yamlify (P.V));
 
       overriding
       function Key (P : Property) return String is (Key (P.V));

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -5,7 +5,6 @@ with Alire.Defaults;
 with Alire.Platforms;
 with Alire.Requisites.Booleans;
 with Alire.TOML_Adapters;
-with Alire.TOML_Keys;
 
 with GNAT.IO; -- To keep preelaborable
 
@@ -583,6 +582,29 @@ package body Alire.Releases is
 
       return Root;
    end To_TOML;
+
+   -------------
+   -- To_YAML --
+   -------------
+
+   overriding
+   function To_YAML (R : Release) return String is
+
+      function Props_To_YAML
+      is new Utils.To_YAML (Alire.Properties.Property'Class,
+                            Alire.Properties.Vectors,
+                            Alire.Properties.Vector);
+
+   begin
+      return
+        "crate: " & Utils.YAML_Stringify (R.Project_Str) & ASCII.LF &
+        "authors: " & Props_To_YAML (R.Author) & ASCII.LF &
+        "maintainers: " & Props_To_YAML (R.Maintainer) & ASCII.LF &
+        "licenses: " & Props_To_YAML (R.License) & ASCII.LF &
+        "websites: " & Props_To_YAML (R.Website) & ASCII.LF &
+        "version: " & Utils.YAML_Stringify (R.Version_Image) & ASCII.LF &
+        "dependencies: " & R.Dependencies.To_YAML;
+   end To_YAML;
 
    -------------
    -- Version --

--- a/src/alire/alire-releases.ads
+++ b/src/alire/alire-releases.ads
@@ -13,6 +13,7 @@ with Alire.Properties.Licenses;
 with Alire.Requisites;
 with Alire.Utils;
 with Alire.Versions;
+with Alire.TOML_Keys;
 
 with Semantic_Versioning;
 
@@ -27,6 +28,7 @@ package Alire.Releases with Preelaborate is
    type Release (<>) is
      new Versions.Versioned
      and Interfaces.Tomifiable
+     and Interfaces.Yamlable
    with private;
 
    function "<" (L, R : Release) return Boolean;
@@ -207,6 +209,12 @@ package Alire.Releases with Preelaborate is
 
    function License (R : Release) return Alire.Properties.Vector;
 
+   function Author (R : Release) return Alire.Properties.Vector;
+
+   function Maintainer (R : Release) return Alire.Properties.Vector;
+
+   function Website (R : Release) return Alire.Properties.Vector;
+
    function Milestone (R : Release) return Milestones.Milestone;
 
    procedure Print (R : Release; Private_Too : Boolean := False);
@@ -224,7 +232,11 @@ package Alire.Releases with Preelaborate is
                        return Boolean;
    --  Ascertain if this release is a valid candidate for Dep
 
-   overriding function To_TOML (R : Release) return TOML.TOML_Value;
+   overriding
+   function To_TOML (R : Release) return TOML.TOML_Value;
+
+   overriding
+   function To_YAML (R : Release) return String;
 
    function Version_Image (R : Release) return String;
 
@@ -252,6 +264,7 @@ private
                  Notes_Len : Natural) is
      new Versions.Versioned
      and Interfaces.Tomifiable
+     and Interfaces.Yamlable
    with record
       Project      : Alire.Project (1 .. Prj_Len);
       Alias        : UString; -- I finally gave up on constraints
@@ -332,6 +345,15 @@ private
    function License (R : Release) return Alire.Properties.Vector
    is (Enumerate (R.Properties).Filter
        (Alire.Properties.Licenses.Values.Property'Tag));
+
+   function Author (R : Release) return Alire.Properties.Vector
+   is (Enumerate (R.Properties).Filter (Alire.TOML_Keys.Author));
+
+   function Maintainer (R : Release) return Alire.Properties.Vector
+   is (Enumerate (R.Properties).Filter (Alire.TOML_Keys.Maintainer));
+
+   function Website (R : Release) return Alire.Properties.Vector
+   is (Enumerate (R.Properties).Filter (Alire.TOML_Keys.Website));
 
    use all type Origins.Kinds;
    function Unique_Folder (R : Release) return Folder_String

--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -304,4 +304,94 @@ package body Alire.Utils is
       Close (F);
    end Write;
 
+   -------------
+   -- To_YAML --
+   -------------
+
+   function To_YAML (V : Vector) return String is
+
+      use all type Vectors.Index_Type;
+
+      function Image (V : Vector; Pos : Vectors.Index_Type) return String is
+        (T'Class (V.Element (Pos)).To_YAML &
+         (if Pos = V.Last_Index
+          then ""
+          else ", " & Image (V, Pos + 1)));
+
+   begin
+      if V.Is_Empty then
+         return "[]";
+      else
+         return "[" & Image (V, V.First_Index) & "]";
+      end if;
+   end To_YAML;
+
+   --------------------
+   -- YAML_Stringify --
+   --------------------
+
+   function YAML_Stringify (Input : String) return String is
+      --  Inspired by AdaYaml, (c) 2017 Felix Krause
+
+      Result : String (1 .. Input'Length * 4 + 2);
+      --  Worst case is all input characters are escaped to hexadecimal, e.g.
+      --  \xff. We also add leading and trailing double quotes.
+
+      Last : Positive := Result'First;
+      --  Index of the last character of result string
+
+      ------------
+      -- Escape --
+      ------------
+
+      procedure Escape (C : Character) is
+      begin
+         Last := Last + 2;
+         Result (Last - 1) := '\';
+         Result (Last) := C;
+      end Escape;
+
+      -------------------
+      -- Escape_To_Hex --
+      -------------------
+
+      procedure Escape_To_Hex (C : Character) is
+
+         function To_Hex (X : Natural) return Character
+         is (case X is
+                when 0  .. 9  => Character'Val (Character'Pos ('0') + X),
+                when 10 .. 15 => Character'Val (Character'Pos ('a') + X - 10),
+                when others   => 'x')
+              with Pre  => X <= 15;
+
+      begin
+         Escape ('x');
+         Last := Last + 2;
+         Result (Last - 1) := To_Hex (Character'Pos (C) / 16);
+         Result (Last)     := To_Hex (Character'Pos (C) mod 16);
+      end Escape_To_Hex;
+
+   begin
+
+      Result (Last) := '"';
+      for C of Input loop
+         case C is
+            when ASCII.LF              => Escape ('l');
+            when ASCII.CR              => Escape ('c');
+            when '"' | ''' | '\'       => Escape (C);
+            when ASCII.HT              => Escape ('t');
+            when ASCII.NUL .. ASCII.BS
+               | ASCII.VT  .. ASCII.FF
+               | ASCII.SO  .. ASCII.US => Escape_To_Hex (C);
+
+            when others =>
+               Last := Last + 1;
+               Result (Last) := C;
+         end case;
+      end loop;
+      Last := Last + 1;
+      Result (Last) := '"';
+      return Result (Result'First .. Last);
+   end YAML_Stringify;
+
 end Alire.Utils;

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -3,6 +3,8 @@ with Ada.Containers.Indefinite_Ordered_Sets;
 with Ada.Containers.Indefinite_Vectors;
 with Ada.Finalization;
 
+with Alire.Interfaces;
+
 private with Ada.Strings.Fixed;
 
 package Alire.Utils with Preelaborate is
@@ -130,6 +132,22 @@ package Alire.Utils with Preelaborate is
                     Filename  : Platform_Independent_Path;
                     Separator : String := ASCII.LF & "");
    --  Dump contents to a given file
+
+   ----------
+   -- YAML --
+   ----------
+
+   generic
+      type T (<>) is new Alire.Interfaces.Yamlable with private;
+      with package Vectors is new Ada.Containers.Indefinite_Vectors
+        (Index_Type => <>, Element_Type => T);
+      type Vector is new Vectors.Vector with private;
+   function To_YAML (V : Vector) return String;
+   --  Turn a vector of Yamlable into a YAML array
+
+   function YAML_Stringify (Input : String) return String;
+   --  Turn String data into YAML string, including enclosing double-quotes and
+   --  escape characters.
 
    -----------------
    -- XXX_XXX_XXX --

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -1,6 +1,7 @@
 with Alire.Index;
 with Alire.Origins.Deployers;
 with Alire.Roots;
+with Alire.Utils;
 
 with Alr.Dependency_Graphs;
 with Alr.Parsers;
@@ -8,6 +9,7 @@ with Alr.Platform;
 with Alr.Root;
 
 with Semantic_Versioning;
+with Alire.Projects;
 
 package body Alr.Commands.Show is
 
@@ -115,6 +117,33 @@ package body Alr.Commands.Show is
          Trace.Info ("Not found: " & Query.Dependency_Image (Name, Versions));
    end Report;
 
+   -------------------
+   -- Report_Jekyll --
+   -------------------
+
+   procedure Report_Jekyll (Name     : Alire.Project;
+                            Versions : Semver.Version_Set;
+                            Current  : Boolean)
+   is
+   begin
+      declare
+         Rel : constant Types.Release  :=
+           (if Current
+            then Root.Current.Release
+            else Query.Find (Name, Versions, Query_Policy));
+      begin
+         Put_Line ("---");
+         Put_Line ("layout: crate");
+         Put_Line (Rel.To_YAML);
+         Put_Line ("---");
+         Put_Line (Alire.Projects.Descriptions (Rel.Project));
+         Put_Line (Rel.Notes);
+      end;
+   exception
+      when Alire.Query_Unsuccessful =>
+         Trace.Info ("Not found: " & Query.Dependency_Image (Name, Versions));
+   end Report_Jekyll;
+
    -------------
    -- Execute --
    -------------
@@ -151,10 +180,16 @@ package body Alr.Commands.Show is
               (Root.Current.Release.Milestone.Image));
       begin
          --  Execute
-         Report (Allowed.Project,
-                 Allowed.Versions,
-                 Num_Arguments = 0,
-                 Cmd);
+         if Cmd.Jekyll then
+            Report_Jekyll (Allowed.Project,
+                           Allowed.Versions,
+                           Num_Arguments = 0);
+         else
+            Report (Allowed.Project,
+                    Allowed.Versions,
+                    Num_Arguments = 0,
+                    Cmd);
+         end if;
       exception
          when Alire.Query_Unsuccessful =>
             Trace.Info ("Project [" & Argument (1) &
@@ -183,6 +218,10 @@ package body Alr.Commands.Show is
       Define_Switch (Config,
                      Cmd.Solve'Access,
                      "", "--solve", "Solve dependencies and report");
+
+      Define_Switch (Config,
+                     Cmd.Jekyll'Access,
+                     "", "--jekyll", "Enable Jekyll output format");
    end Setup_Switches;
 
 end Alr.Commands.Show;

--- a/src/alr/alr-commands-show.ads
+++ b/src/alr/alr-commands-show.ads
@@ -19,9 +19,10 @@ package Alr.Commands.Show is
 private
 
    type Command is new Commands.Command with record
-      Native  : aliased Boolean := False;
-      Priv    : aliased Boolean := False;
-      Solve   : aliased Boolean := False;
+      Native : aliased Boolean := False;
+      Priv   : aliased Boolean := False;
+      Solve  : aliased Boolean := False;
+      Jekyll : aliased Boolean := False;
    end record;
 
 end Alr.Commands.Show;

--- a/testsuite/fixtures/basic_index/he/hello.toml
+++ b/testsuite/fixtures/basic_index/he/hello.toml
@@ -1,7 +1,9 @@
 [general]
 description = """"Hello, world!" demonstration project"""
-licenses = []
-maintainers = ["alejandro@mosteo.com"]
+licenses = ["GPL 3.0", "MIT"]
+website = "example.com"
+maintainers = ["alejandro@mosteo.com", "bob@example.com"]
+authors = ["Bob", "Alice"]
 
 ['1.0.1']
 origin = "file://../../crates/hello_1.0.1"

--- a/testsuite/tests/show/jekyll/test.py
+++ b/testsuite/tests/show/jekyll/test.py
@@ -1,0 +1,24 @@
+"""
+Test Jekyll static website framework output.
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq
+
+
+p = run_alr('show', '--jekyll', 'hello', complain_on_error=True, quiet=False)
+assert_eq(
+      '---\n'
+      'layout: crate\n'
+      'crate: "hello"\n'
+      'authors: ["Bob", "Alice"]\n'
+      'maintainers: ["alejandro@mosteo.com", "bob@example.com"]\n'
+      'licenses: ["GPL_3_0", "MIT"]\n'
+      'websites: ["example.com"]\n'
+      'version: "1.0.1"\n'
+      'dependencies: [{crate: "libhello", version: "Within_Major (1.0.0)"}]\n'
+      '---\n'
+      '"Hello, world!" demonstration project\n'
+      '\n', p.out)
+
+print('SUCCESS')

--- a/testsuite/tests/show/jekyll/test.yaml
+++ b/testsuite/tests/show/jekyll/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
Jekyll is a static site generator based on YAML and markdown.  This
output can be used to generate crate pages for a simple Alire website.

The main change of this patch is to introduce a "Yamlable" interface to
describe objects that can produce a text YAML representation, and then
implement this interface for the required types.