### PR TITLE
Alr.Commands: Print command list when no help topic is specified

### DIFF
--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -535,6 +535,8 @@ package body Alr.Commands is
             OS_Lib.Bailout (0);
          else
             Trace.Error ("Please specific a help topic");
+            New_Line;
+            Display_Valid_Commands;
             OS_Lib.Bailout (1);
          end if;
       end if;


### PR DESCRIPTION
This makes the list more easy to find for users as the other way to get
the list is to run alr without argument, which is not necessarily
intuitive.