### PR TITLE
Set up gnatelim for future use

### DIFF
--- a/elim/ajunitgen.gpr
+++ b/elim/ajunitgen.gpr
@@ -1,0 +1,25 @@
+with "../deps/xmlezout/xml_ez_out";
+
+project Ajunitgen is
+
+   for Source_Dirs use ("../deps/ajunitgen/src");
+   for Object_Dir use "obj";
+
+   package Builder is
+      for Switches ("ada") use ("-j0", "-g");
+   end Builder;
+
+   package Compiler is
+      for Switches ("ada") use ("-gnatVa", "-gnatwa", "-g", "-O2", "-gnato", "-fstack-check", "-gnata", "-gnat12");
+   end Compiler;
+
+   package Binder is
+      for Switches ("ada") use ("-Es");
+   end Binder;
+
+   package Linker is
+      for Switches ("ada") use ("-g");
+   end Linker;
+
+end Ajunitgen;
+

--- a/elim/alire.gpr
+++ b/elim/alire.gpr
@@ -1,0 +1,26 @@
+with "../deps/aaa/aaa";
+with "../deps/ada-toml/ada_toml";
+with "../alire_common";
+with "ajunitgen";
+with "../deps/gnatcoll-slim/gnatcoll";
+with "../deps/semantic_versioning/semantic_versioning";
+with "../deps/simple_logging/simple_logging";
+with "../deps/xmlezout/xml_ez_out";
+
+library project Alire is
+
+   for Library_Name use "alire";
+
+   for Source_Dirs use ("../src/alire", "../src/alire/os_linux");
+
+   for Library_Dir use "lib";
+   for Object_Dir use "obj";
+
+   for Languages use ("Ada");
+
+   package Compiler renames Alire_Common.Compiler;
+   package Builder renames Alire_Common.Builder;
+   package Binder renames Alire_Common.Binder;
+   package Ide renames Alire_Common.Ide;
+
+end Alire;

--- a/elim/alr.gpr
+++ b/elim/alr.gpr
@@ -1,0 +1,30 @@
+with "../deps/aaa/aaa";
+with "../deps/ada-toml/ada_toml";
+with "alire";
+with "../alire_common";
+with "ajunitgen";
+with "../deps/semantic_versioning/semantic_versioning";
+with "../deps/simple_logging/simple_logging";
+with "../deps/xmlezout/xml_ez_out";
+
+project Alr is
+
+   for Source_Dirs use ("../src/alr", "../src/alr/os_linux");
+
+   for Object_Dir use "obj";
+   for Exec_Dir use "bin";
+   for Main use ("alr-main.adb");
+
+   for Languages use ("Ada", "C");
+
+   package Compiler renames Alire_Common.Compiler;
+
+   package Builder is
+      for Switches ("Ada") use Alire_Common.Builder'Switches ("Ada");
+      for Executable ("alr-main.adb") use "alr";
+   end Builder;
+
+   package Binder renames Alire_Common.Binder;
+   package Ide renames Alire_Common.Ide;
+
+end Alr;

--- a/elim/run.sh
+++ b/elim/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gnatelim -Palr -main=alr-main.adb -XBUILD=DEBUG -XLIBRARY_TYPE=static


### PR DESCRIPTION
I expect it will be useful to locate scattered dead code from the removal of the old index.

The PR adds a few mock project files since it seems gnatelim does not yet understand aggregate projects.