### PR TITLE
Document use of log levels and corresponding output tweaks.

### DIFF
--- a/ISSUES.txt
+++ b/ISSUES.txt
@@ -1,1 +1,0 @@
-* Remove the Alr.Root package and fix dependent functionality

--- a/pending_libs.txt
+++ b/pending_libs.txt
@@ -1,2 +1,0 @@
-https://github.com/jrcarter/PragmARC
-https://github.com/LionelDraghi/List_Image

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -498,7 +498,7 @@ package body Alire.Releases is
                        return Outcome
    is
    begin
-      Trace.Detail ("Loading release " & This.Milestone.Image);
+      Trace.Debug ("Loading release " & This.Milestone.Image);
 
       --  Origin
       declare

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -170,7 +170,18 @@ package Alire with Preelaborate is
    package Trace renames Simple_Logging;
 
    Log_Level : Simple_Logging.Levels renames Simple_Logging.Level;
-   --  This one selects the verbosity level of the logging library.
+   --  This one selects the verbosity level of the logging library. The usage
+   --  of log levels in Alire is as follows. By default, no output is produced
+   --  unless in case of warning or error. The log levels supported are:
+   --  * ERROR:   for fatal situations that preclude further operation.
+   --  * Warning: for suspicious situations, but where alr continues normally.
+   --             Hidden with '-q' switch.
+   --  * Info:    messages that are shown by default. Output that is the result
+   --             of user requests in normal situations.
+   --  * Detail:  not shown by default, enabled with '-v' switch, that
+   --             may be interesting to and intended for regular users.
+   --  * Debug:   not shown by default, enabled with '-vv' switch, messages
+   --             intended for developers or curious users, not user friendly.
 
    Log_Debug : aliased Boolean := False;
    --  This one enables special debug output, irrespectively of the log level.

--- a/src/alr/alr-templates.adb
+++ b/src/alr/alr-templates.adb
@@ -139,11 +139,11 @@ package body Alr.Templates is
    begin
       if Query.Exists (Root.Release.Project, Root.Release.Version) then
          Log ("Generating GPR for release " & Root.Release.Milestone.Image &
-                " with" & Instance.Length'Img & " dependencies", Detail);
+                " with" & Instance.Length'Img & " dependencies", Debug);
       else
          Log ("Generating GPR for unreleased project "
               & Root.Release.Milestone.Image & " with" & Instance.Length'Img
-              & " dependencies", Detail);
+              & " dependencies", Debug);
       end if;
 
       GPR_Files := Root.Release.Project_Files
@@ -259,9 +259,9 @@ package body Alr.Templates is
       use GNATCOLL.VFS;
       F : constant Virtual_File := Create (+Filename, Normalize => True);
    begin
-      Trace.Detail ("Generating " & Release.Project_Str & ".toml file for "
-                    & Release.Milestone.Image & " with"
-                    & Release.Dependencies.Leaf_Count'Img & " dependencies");
+      Trace.Debug ("Generating " & Release.Project_Str & ".toml file for "
+                   & Release.Milestone.Image & " with"
+                   & Release.Dependencies.Leaf_Count'Img & " dependencies");
 
       --  Ensure working folder exists (might not upon first get)
       F.Get_Parent.Make_Dir;


### PR DESCRIPTION
Foreseeing that at some point we may want nicer output, perhaps with colorization, I have explicitly commented what is the intended use of logging levels. This has not always been adhered to strictly, but by putting it in writing it should be easier to be consistent moving forward.

This should appear at some point wherever we put the information for wannabe contributors.