### PR TITLE
Add hash to source archives for integrity verification.

### DIFF
--- a/doc/catalog-format-spec.rst
+++ b/doc/catalog-format-spec.rst
@@ -358,6 +358,10 @@ following entries:
    [origin.'case(distribution)']
    'debian|ubuntu' = "native:make"
 
+* ``archive-hash``: mandatory string for source archives. A "kind:digest" field
+  that specifies a hash kind and its value. The only accepted kind is SHA512 at
+  this time.
+
 * ``archive-name``: optional string. If ``origin`` points to a source archive,
   this can specifiy the name of the file to download, which is needed in order
   to properly extract the sources. For instance:
@@ -366,6 +370,7 @@ following entries:
 
    origin = "https://example.org/0123456789"
    archive-name = "archive.tar.gz"
+   archive-hash = "sha512:bf6082573dc537836ea8506a2c9a75dc7837440c35c5b02a52add52e38293640d99e90a9706690591f8899b8b4935824b195f230b3aa1c4da10911e3caf954c04ac"
 
 * ``available``: optional dynamic boolean expression. It is used the following
   way:

--- a/scripts/shiptest.sh
+++ b/scripts/shiptest.sh
@@ -28,9 +28,9 @@ echo GNAT VERSION:
 gnatls -v
 echo ............................
 
-# This is temporary addition for this PR to pass CI tests with the new index.
-# Remove once merged
-alr index --name pro --add git+https://github.com/alire-project/alire-index@06ce3ef
+# This is temporary addition for this PR to pass CI tests with the updated index.
+# Remove once merged.
+alr index --name pro --add git+https://github.com/alire-project/alire-index@cb6c920
 
 echo ALR VERSION:
 alr version

--- a/src/alire/alire-hashes-common.adb
+++ b/src/alire/alire-hashes-common.adb
@@ -1,0 +1,37 @@
+with Ada.Streams.Stream_IO;
+
+package body Alire.Hashes.Common is
+
+   ---------------
+   -- Hash_File --
+   ---------------
+
+   function Hash_File (Path : Platform_Independent_Path) return Any_Hash is
+      use Ada.Streams;
+      use Ada.Streams.Stream_IO;
+
+      Ctxt : Context;
+      File : File_Type;
+      Buff : Stream_Element_Array (1 .. 1024 * 1024); -- 1MiB
+      Last : Stream_Element_Offset;
+   begin
+      Open (File, In_File, Path);
+      while not End_Of_File (File) loop
+         Read (File, Buff, Last);
+         Update (Ctxt, Buff (Buff'First .. Last));
+      end loop;
+      Close (File);
+
+      return Utils.To_Lower_Case (Kind'Img) & ":" & Digest (Ctxt);
+
+   exception
+      when others =>
+         if Is_Open (File) then
+            Close (File);
+         end if;
+         raise;
+   end Hash_File;
+
+begin
+   Hashes.Hash_Functions (Kind) := Hash_File'Access;
+end Alire.Hashes.Common;

--- a/src/alire/alire-hashes-common.ads
+++ b/src/alire/alire-hashes-common.ads
@@ -1,0 +1,27 @@
+with Ada.Streams;
+
+generic
+   Kind : Kinds; -- The Kind to be computed.
+
+   --  Following types are provided by GNAT.Secure_Hashes.H. Since that is an
+   --  internal unit, we extract here the needed types/subprograms instead of
+   --  getting a package formal.
+   type Context is private;
+   with procedure Update (C     : in out Context;
+                          Input : Ada.Streams.Stream_Element_Array) is <>;
+   with function Digest (C : Context) return String is <>;
+package Alire.Hashes.Common is
+
+   function Hash_File (Path : Platform_Independent_Path) return Any_Hash;
+   --  This function does not need to be visible (it is not used directly), but
+   --  hiding it in the body results in the following error in FSF compilers:
+   --
+   --     Bind
+   --     [gprbind]      alr-main.bexch
+   --     [Ada]          alr-main.ali
+   --
+   --  raised SYSTEM.ASSERTIONS.ASSERT_FAILURE : binde.adb:1117
+   --  gprbind: invocation of gnatbind failed
+   --  gprbuild: unable to bind alr-main.adb
+
+end Alire.Hashes.Common;

--- a/src/alire/alire-hashes-sha512_impl.ads
+++ b/src/alire/alire-hashes-sha512_impl.ads
@@ -1,0 +1,9 @@
+with Alire.Hashes.Common;
+
+with GNAT.SHA512;
+
+package Alire.Hashes.SHA512_Impl is new Alire.Hashes.Common
+  (Kind    => SHA512,
+   Context => GNAT.SHA512.Context,
+   Update  => GNAT.SHA512.Update,
+   Digest  => GNAT.SHA512.Digest);

--- a/src/alire/alire-hashes.ads
+++ b/src/alire/alire-hashes.ads
@@ -1,0 +1,84 @@
+with Alire.Utils;
+
+package Alire.Hashes with Preelaborate is
+
+   --  To allow use of various hashes, we expect that any string in the index
+   --  providing a hash has the format: "kind:value" where kind is the hash
+   --  type and value is the actual hash representation emitted by the GNAT.*
+   --  hashing functions. E.g.: "sha1:5c16c1c74ae8236770644b69f2e4cf1ccc88adad"
+
+   type Kinds is (SHA512);
+   --  Recognized hashes that we are able to compute/verify.
+   --  To add a new kind, instance the Alire.Hashes.Common generic and with it
+   --  in Alire.TOML_Index body.
+
+   subtype Any_Hash is String with
+     Dynamic_Predicate => Is_Well_Formed (Any_Hash);
+
+   function Digest (Hash : Any_Hash) return String;
+   --  Return the actual fingerprint without the kind prefix.
+
+   function Hash_File (Kind : Kinds;
+                       Path : Platform_Independent_Path) return Any_Hash;
+   --  Compute a particular hash kind. May raise usual file exceptions.
+
+   function Is_Known (Kind_Img : String) return Boolean;
+   --  Check if a string is one of our understood hash types.
+
+   function Is_Well_Formed (Hash_Img : String) return Boolean;
+   --  Check if a string follows proper syntax ("kind:digest").
+
+   function Kind (Hash : Any_Hash) return Kinds;
+   --  Given a well-formed Hash, extract its typed kind.
+
+private
+
+   ------------
+   -- Digest --
+   ------------
+
+   function Digest (Hash : Any_Hash) return String is
+     (Utils.Tail (Hash, ':'));
+
+   --------------------
+   -- Hash_Functions --
+   --------------------
+
+   --  The following function array is initialized by each instance of a
+   --  known hash in child packages.
+
+   Hash_Functions : array (Kinds) of access
+     function (File : Platform_Independent_Path) return Any_Hash;
+
+   ---------------
+   -- Hash_File --
+   ---------------
+
+   function Hash_File (Kind : Kinds;
+                       Path : Platform_Independent_Path) return Any_Hash is
+     (Hash_Functions (Kind) (Path)); -- Dispatch to a particular implementation
+
+   --------------
+   -- Is_Known --
+   --------------
+
+   function Is_Known (Kind_Img : String) return Boolean is
+     (for some Kind in Kinds =>
+         Utils.To_Lower_Case (Kind'Img) = Utils.To_Lower_Case (Kind_Img));
+
+   --------------------
+   -- Is_Well_Formed --
+   --------------------
+
+   function Is_Well_Formed (Hash_Img : String) return Boolean is
+     (for some Char of Hash_Img => Char = ':' and then
+      Is_Known (Utils.Head (Hash_Img, ':')));
+
+   ----------
+   -- Kind --
+   ----------
+
+   function Kind (Hash : Any_Hash) return Kinds is
+     (Kinds'Value (Utils.Head (Hash, ':')));
+
+end Alire.Hashes;

--- a/src/alire/alire-index.ads
+++ b/src/alire/alire-index.ads
@@ -198,11 +198,6 @@ package Alire.Index is
    function Native (Distros : Origins.Native_Packages) return Origins.Origin
    renames Origins.New_Native;
 
-   function Source_Archive (URL : Alire.URL;
-                            Name : String := "")
-                            return Origins.Origin
-                            renames Origins.New_Source_Archive;
-
    ------------------
    -- Dependencies --
    ------------------

--- a/src/alire/alire-origins-deployers-source_archive.adb
+++ b/src/alire/alire-origins-deployers-source_archive.adb
@@ -17,10 +17,11 @@ package body Alire.Origins.Deployers.Source_Archive is
       use GNATCOLL.VFS;
       Archive_Name : constant String := This.Base.Archive_Name;
       Archive_File : constant String := Dirs.Compose (Folder, Archive_Name);
+      Archive_Hash : constant String := This.Base.Archive_Hash;
       Exit_Code    :          Integer;
       package Subprocess renames Alire.OS_Lib.Subprocess;
    begin
-      Trace.Detail ("Creating folder: " & Folder);
+      Trace.Debug ("Creating folder: " & Folder);
       Create (+Folder).Make_Dir;
 
       Trace.Detail ("Downloading archive: " & This.Base.Archive_URL);
@@ -29,6 +30,22 @@ package body Alire.Origins.Deployers.Source_Archive is
       if Exit_Code /= 0 then
          return Outcome_Failure ("wget call failed with code" & Exit_Code'Img);
       end if;
+
+      declare
+         Down_Hash : constant Hashes.Any_Hash :=
+                       Hashes.Hash_File (Kind => Hashes.Kind (Archive_Hash),
+                                         Path => Archive_File);
+      begin
+         if Archive_Hash /= Down_Hash then
+            return Outcome_Failure
+              ("Archive integrity test failed. "
+               & "Expected [" & Archive_Hash
+               & "] but got [" & Down_Hash & "]");
+         else
+            Trace.Debug
+              ("Retrieved file " & Archive_File & " integrity verified.");
+         end if;
+      end;
 
       Trace.Detail ("Extracting source archive...");
       case This.Base.Archive_Format is

--- a/src/alire/alire-releases.ads
+++ b/src/alire/alire-releases.ads
@@ -370,12 +370,8 @@ private
        (case R.Origin.Kind is
            when Filesystem     => "filesystem",
            when Native         => "native",
-           when Source_Archive => "archive",
-           when Git | Hg       => (if R.Origin.Commit'Length <= 8
-                                   then R.Origin.Commit
-                                   else R.Origin.Commit
-                                     (R.Origin.Commit'First ..
-                                        R.Origin.Commit'First + 7)),
+           when Source_Archive => R.Origin.Short_Unique_Id,
+           when Git | Hg       => R.Origin.Short_Unique_Id,
            when SVN            => R.Origin.Commit));
 
    function On_Platform_Actions (R : Release;

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -4,6 +4,13 @@ with Ada.Text_IO;
 
 with Alire.Errors;
 with Alire.GPR;
+
+with Alire.Hashes.SHA512_Impl; pragma Unreferenced (Alire.Hashes.SHA512_Impl);
+--  Hash implementation generics are not directly withed anywhere. Since they
+--  are not Preelaborate, and the index loader is one of the few in Alire also
+--  not Preelaborate, and retrieving a file will always occur after loading the
+--  index, this seems a decent place to force inclusion in the build closure.
+
 with Alire.Index;
 with Alire.Origins.Tweaks;
 with Alire.Utils;

--- a/src/alire/alire-toml_keys.ads
+++ b/src/alire/alire-toml_keys.ads
@@ -6,6 +6,7 @@ package Alire.TOML_Keys with Preelaborate is
    Action_Type    : constant String := "type";
    Action_Command : constant String := "command";
    Action_Folder  : constant String := "directory";
+   Archive_Hash   : constant String := "archive-hash";
    Archive_Name   : constant String := "archive-name";
    Author         : constant String := "authors";
    Available      : constant String := "available";

--- a/testsuite/tests/index/origin-no-archive-name/my_index/index/he/hello_world.toml
+++ b/testsuite/tests/index/origin-no-archive-name/my_index/index/he/hello_world.toml
@@ -5,3 +5,4 @@ maintainers = ["user@example.com"]
 
 ['0.1']
 origin = "http://example.com/"
+archive-hash = "sha512:deadbeef"

--- a/testsuite/tests/index/origin-no-archive-name/test.py
+++ b/testsuite/tests/index/origin-no-archive-name/test.py
@@ -5,11 +5,10 @@ Test that origins lacking archive names in indexes are properly reported.
 from drivers.alr import run_alr
 from drivers.asserts import assert_match
 
+import re
 
 p = run_alr('show', 'hello_world', complain_on_error=False, quiet=False)
-assert_match(
-    'ERROR:.*missing mandatory archive-name'
-    '\nERROR: alr show unsuccessful'
-    '\n', p.out)
+assert_match('.*unable to determine archive name from URL.*',
+             p.out, flags=re.S)
 
 print('SUCCESS')


### PR DESCRIPTION
Fixes #66 (note that there is wider-scoped discussion there).

We add a hash field (`archive-hash`) to releases that are provided by source files not under version control, hence lacking any form of integrity verification. This hash is recomputed and verified after download. This can be tested e.g. with `alr get --only gnatcoll`.

There is a matching update for this PR in the alire-index repository that provides this hash for existing source file crates.