### PR TITLE
Allow detection of build mode from Ada code.

### DIFF
--- a/alire.gpr
+++ b/alire.gpr
@@ -11,7 +11,9 @@ library project Alire is
 
    for Library_Name use "alire";
 
-   for Source_Dirs use ("src/alire", "src/alire/os_linux");
+   for Source_Dirs use ("src/alire",
+                        "src/alire/build_" & Alire_Common.Build_Mode,
+                        "src/alire/os_linux");
 
    for Library_Dir use "lib";
    for Object_Dir use "obj";

--- a/src/alire/alire-build.ads
+++ b/src/alire/alire-build.ads
@@ -1,0 +1,5 @@
+package Alire.Build with Preelaborate is
+
+   type Modes is (Debug, Release);
+
+end Alire.Build;

--- a/src/alire/build_debug/alire-build-config.ads
+++ b/src/alire/build_debug/alire-build-config.ads
@@ -1,0 +1,5 @@
+package Alire.Build.Config with Preelaborate is
+
+   Mode : constant Modes := Debug;
+
+end Alire.Build.Config;

--- a/src/alire/build_release/alire-build-config.ads
+++ b/src/alire/build_release/alire-build-config.ads
@@ -1,0 +1,5 @@
+package Alire.Build.Config with Preelaborate is
+
+   Mode : constant Modes := Release;
+
+end Alire.Build.Config;


### PR DESCRIPTION
This is intended to turn some errors into warnings during development. For example, when dealing with changes in the index it is quite cumbersome to test partial changes with older commits.