### PR TITLE
Fix case insensitivity for crate names

### DIFF
--- a/src/alire/alire-dependencies.adb
+++ b/src/alire/alire-dependencies.adb
@@ -10,7 +10,7 @@ package body Alire.Dependencies is
       package SV renames Semantic_Versioning;
       Version_Str : constant String := Value.As_String;
    begin
-      return New_Dependency (+Key,
+      return New_Dependency (+Utils.To_Lower_Case (Key),
                              SV.To_Set (Version_Str));
       --  TODO: if no operator appears the version, this results in strict
       --  match. Rust, for example, assumes caret (^) in this case. Do we want

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -322,7 +322,8 @@ package body Alire.TOML_Index is
 
       declare
          Crate  : Projects.With_Releases.Crate :=
-                    Projects.With_Releases.New_Crate (+Package_Name);
+                    Projects.With_Releases.New_Crate
+                      (+Utils.To_Lower_Case (Package_Name));
       begin
          Result := Crate.From_TOML (TOML_Adapters.From
                                     (Value,
@@ -357,7 +358,8 @@ package body Alire.TOML_Index is
       --  Parse the TOML structure
       declare
          Crate  : Projects.With_Releases.Crate :=
-                    Projects.With_Releases.New_Crate (+Name);
+                    Projects.With_Releases.New_Crate
+                      (+Utils.To_Lower_Case (Name));
          Result : constant Load_Result :=
                     Crate.From_TOML
                       (TOML_Adapters.From

--- a/src/alire/alire.adb
+++ b/src/alire/alire.adb
@@ -1,6 +1,24 @@
+with Alire.Utils;
+
 with GNAT.IO;
 
 package body Alire is
+
+   ---------
+   -- "=" --
+   ---------
+
+   overriding
+   function "=" (L, R : Project) return Boolean is
+     (Utils.To_Lower_Case (+L) = Utils.To_Lower_Case (+R));
+
+   ---------
+   -- "<" --
+   ---------
+
+   overriding
+   function "<" (L, R : Project) return Boolean is
+     (Utils.To_Lower_Case (+L) < Utils.To_Lower_Case (+R));
 
    -------------
    -- Err_Log --

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -58,7 +58,7 @@ package Alire with Preelaborate is
 
    subtype Project_Character is Character
       with Static_Predicate => Project_Character in
-         'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | Extension_Separator;
+         'a' .. 'z' | '0' .. '9' | '_' | Extension_Separator;
 
    type Project is new String with Dynamic_Predicate =>
      Project'Length >= Min_Name_Length and then

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -67,6 +67,14 @@ package Alire with Preelaborate is
      Project (Project'Last) /= Extension_Separator and then
      (for all C of Project => C in Project_Character);
 
+   overriding
+   function "=" (L, R : Project) return Boolean;
+   --  Project names are case preserving but insensitive when compared.
+
+   overriding
+   function "<" (L, R : Project) return Boolean;
+   --  Likewise, we do not want capitalization to influence ordering.
+
    subtype Restricted_Name is String with Dynamic_Predicate =>
      Restricted_Name'Length >= Min_Name_Length and then
      Restricted_Name (Restricted_Name'First) /= '_' and then

--- a/testsuite/tests/show/crate-name-casing/test.py
+++ b/testsuite/tests/show/crate-name-casing/test.py
@@ -1,0 +1,14 @@
+"""
+Test lowercaseness of crate names.
+"""
+
+from glob import glob
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq
+
+assert_eq("ERROR: A project/version string was invalid\n"
+          "ERROR: alr show unsuccessful\n",
+          run_alr('show', 'HELLO', complain_on_error=False).out)
+
+print('SUCCESS')

--- a/testsuite/tests/show/crate-name-casing/test.yaml
+++ b/testsuite/tests/show/crate-name-casing/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
This was manifesting in some dependencies being reported as unavailable.

We might go even further and force all crate names to be lowercase upon loading. For now, following the Ada example, case is preserved.