### PR TITLE
Re-enable using the master index in CI

### DIFF
--- a/scripts/shiptest.sh
+++ b/scripts/shiptest.sh
@@ -28,10 +28,6 @@ echo GNAT VERSION:
 gnatls -v
 echo ............................
 
-# This is temporary addition for this PR to pass CI tests with the updated index.
-# Remove once merged.
-alr index --name pro --add git+https://github.com/alire-project/alire-index@cb6c920
-
 echo ALR VERSION:
 alr version
 echo ............................


### PR DESCRIPTION
A concrete index commit was forced for CI during the addition of the `archive-hash` field. This PR reverts that temporary measure.