### PR TITLE
Fix errors about native packages in unknown platforms.

### DIFF
--- a/src/alire/alire-origins-deployers.ads
+++ b/src/alire/alire-origins-deployers.ads
@@ -1,3 +1,5 @@
+with Alire.Releases;
+
 package Alire.Origins.Deployers is
 
    --  Actual fetching logic
@@ -10,9 +12,10 @@ package Alire.Origins.Deployers is
    -- Deploy --
    ------------
 
-   function Deploy (From : Origin; Folder : String := "") return Outcome with
-     Pre => From.Is_Native or else
-            (not From.Is_Native and then Folder /= "");
+   function Deploy (Release : Releases.Release;
+                    Folder  : String := "") return Outcome with
+     Pre => Release.Origin.Is_Native or else
+            (not Release.Origin.Is_Native and then Folder /= "");
    --  This subprogram is intended to be called with an origin and it will
    --  create and redispatch the necessary concrete Deployer implementation.
    --  Since it may fail during normal operation (e.g. network down) it

--- a/src/alire/alire-platform.ads
+++ b/src/alire/alire-platform.ads
@@ -15,9 +15,15 @@ package Alire.Platform is
    --  ${XDG_CONFIG_HOME:-.config}/alire
 
    function Distribution return Platforms.Distributions;
-   --  TODO: during ALR -> Alire refactorings move body from here to Linux body
 
    function Name return Supported;
    --  Self identify
+
+   --------------------------------
+   -- Portable derived utilities --
+   --------------------------------
+
+   function Distribution_Is_Known return Boolean is
+      (Platforms."/=" (Distribution, Platforms.Distro_Unknown));
 
 end Alire.Platform;

--- a/src/alire/os_linux/alire-platform.adb
+++ b/src/alire/os_linux/alire-platform.adb
@@ -37,7 +37,7 @@ package body Alire.Platform is
             if Subprocess.Spawn_And_Capture (Release,
                                              "lsb_release", "-is") /= 0
             then
-               Trace.Warning ("Unable to detect distribution");
+               Trace.Debug ("Unable to detect distribution");
                return Distro_Unknown;
             end if;
 

--- a/src/alire/os_linux/alire-platform.adb
+++ b/src/alire/os_linux/alire-platform.adb
@@ -35,21 +35,27 @@ package body Alire.Platform is
             Release : Utils.String_Vector;
          begin
             if Subprocess.Spawn_And_Capture (Release,
-                                             "lsb_release", "-is") /= 0
+                                             "cat", "/etc/os-release") /= 0
             then
                Trace.Debug ("Unable to detect distribution");
                return Distro_Unknown;
             end if;
 
-            for Known in Alire.Platforms.Distributions'Range loop
-               for Line of Release loop
-                  if Contains (To_Lower_Case (Known'Img), To_Lower_Case (Line))
-                  then
-                     Cached_Distro := Known;
+            for Line of Release loop
+               declare
+                  Normalized : constant String :=
+                                 To_Lower_Case (Replace (Line, " ", ""));
+               begin
+                  if Starts_With (Normalized, "id=") then
+                     Cached_Distro :=
+                       Platforms.Distributions'Value (Tail (Normalized, '='));
                      Distro_Cached := True;
-                     return Known;
+                     return Cached_Distro;
                   end if;
-               end loop;
+               exception
+                  when others =>
+                     exit; -- Not a known distro.
+               end;
             end loop;
 
             Trace.Debug ("Found unsupported distro: " & Release (1));

--- a/src/alr/alr-bootstrap.adb
+++ b/src/alr/alr-bootstrap.adb
@@ -19,15 +19,16 @@ package body Alr.Bootstrap is
    ---------------------
 
    procedure Check_Ada_Tools is
-      --  FIXME mini-leak (once per run)
+      procedure Check_Tool (Exec : String) is
+      begin
+         if not OS_Lib.Exists_In_Path (Exec) then
+            Trace.Error ("Required tool not detected: " & Exec);
+            Trace.Error ("alr cannot proceed");
+            OS_Lib.Bailout (1);
+         end if;
+      end Check_Tool;
    begin
-      if not OS_Lib.Exists_In_Path ("gprbuild")
-        or else
-         not OS_Lib.Exists_In_Path ("gnatmake")
-      then
-         Trace.Error ("Ada tools not detected, alr cannot proceed");
-         OS_Lib.Bailout (1);
-      end if;
+      Check_Tool ("gprbuild");
 
       if not OS_Lib.Exists_In_Path ("git") then
          Trace.Warning

--- a/src/alr/alr-checkout.adb
+++ b/src/alr/alr-checkout.adb
@@ -35,7 +35,7 @@ package body Alr.Checkout is
       else
          Was_There := False;
          Trace.Detail ("About to deploy " & R.Milestone.Image);
-         Result := Alire.Origins.Deployers.Deploy (R.Origin, Folder);
+         Result := Alire.Origins.Deployers.Deploy (R, Folder);
          if not Result.Success then
             Trace.Error (Alire.Message (Result));
             raise Command_Failed;

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -63,7 +63,7 @@ package body Alr.Commands.Get is
 
          --  Check if it's native first and thus we need not to check out.
          if R.Origin.Is_Native then
-            Result := Alire.Origins.Deployers.Deploy (R.Origin);
+            Result := Alire.Origins.Deployers.Deploy (R);
             if Result.Success then
                return;
             else

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -1,5 +1,6 @@
 with Alire.Index;
 with Alire.Origins.Deployers;
+with Alire.Platforms;
 with Alire.Roots;
 with Alire.Utils;
 
@@ -41,7 +42,9 @@ package body Alr.Commands.Show is
                      Versions : Semver.Version_Set;
                      Current  : Boolean;
                      --  session or command-line requested release
-                     Cmd      : Command) is
+                     Cmd      : Command)
+   is
+      use all type Alire.Platforms.Distributions;
    begin
       declare
          Rel     : constant Types.Release  :=
@@ -56,9 +59,13 @@ package body Alr.Commands.Show is
          end if;
 
          if Rel.Origin.Is_Native then
-            Put_Line ("Platform version: "
-                      & Alire.Origins.Deployers.New_Deployer
-                         (Rel.Origin).Native_Version);
+            if Platform.Distribution /= Alire.Platforms.Distro_Unknown then
+               Put_Line ("Platform version: "
+                         & Alire.Origins.Deployers.New_Deployer
+                           (Rel.Origin).Native_Version);
+            else
+               Put_Line ("Platform version unknown");
+            end if;
          end if;
 
          if Cmd.Solve then

--- a/src/alr/alr-os_lib.ads
+++ b/src/alr/alr-os_lib.ads
@@ -19,7 +19,8 @@ package Alr.OS_Lib is
    procedure Setenv (Var : String; Value : String) renames GNAT.OS_Lib.Setenv;
 
    function Exists_In_Path (File : String) return Boolean is
-      (GNAT.OS_Lib."/="  (GNAT.OS_Lib.Locate_Exec_On_Path (File), null));
+     (GNAT.OS_Lib."/="  (GNAT.OS_Lib.Locate_Exec_On_Path (File), null));
+   --  FIXME: memory leak in this call
 
    --  Process spawning
 

--- a/src/alr/alr-query.adb
+++ b/src/alr/alr-query.adb
@@ -3,6 +3,7 @@ with Ada.Containers.Doubly_Linked_Lists;
 
 with Alire.Conditional.Operations;
 with Alire.Origins.Deployers;
+with Alire.Platform;
 with Alire.Utils;
 
 with Alr.Commands;
@@ -121,8 +122,9 @@ package body Alr.Query is
 
    function Is_Available (R : Alire.Index.Release) return Boolean is
      (R.Available.Check (Platform.Properties) and then
-          (if R.Origin.Is_Native
-           then Origins.Deployers.New_Deployer (R.Origin).Exists));
+          (not R.Origin.Is_Native or else
+               (Alire.Platform.Distribution_Is_Known
+                and then Origins.Deployers.New_Deployer (R.Origin).Exists)));
 
    -------------------
    -- Is_Resolvable --
@@ -349,7 +351,9 @@ package body Alr.Query is
                                 and Remaining).Image_One_Line);
                   elsif -- First time we see this project
                     Semver.Satisfies (R.Version, Dep.Versions) and then
-                    Is_Available (R)
+                    Is_Available (R) and then
+                    (Alire.Platform.Distribution_Is_Known or else
+                     not R.Origin.Is_Native)
                   then
                      Trace.Debug
                        ("SOLVER: dependency FROZEN: " & R.Milestone.Image &

--- a/testsuite/fixtures/basic_index/ma/make.toml
+++ b/testsuite/fixtures/basic_index/ma/make.toml
@@ -1,0 +1,8 @@
+[general]
+description = "Utility for directing compilation"
+maintainers = ["alejandro@mosteo.com"]
+licenses = []
+
+[0]
+    [0.origin.'case(distribution)']
+    '...' = ""

--- a/testsuite/tests/get/native-unsupported/test.py
+++ b/testsuite/tests/get/native-unsupported/test.py
@@ -1,0 +1,28 @@
+"""
+Test two outcomes of requesting an unavailable native package:
+    1) In unknown distros, say that there is no support
+    2) In known distros, say the package is unavailable
+"""
+
+from glob import glob
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+
+import re
+
+# Ascertain first if we are in a known or unknown platform:
+p = run_alr('version')
+unknown = re.match('.*platform properties:.*DISTRO_UNKNOWN.*',
+                   p.out, flags=re.S)
+
+# Run get on a native package and see what happens depending on platform
+p = run_alr('get', '--non-interactive', 'make', complain_on_error=False)
+if unknown:
+    assert_match(".*Unknown distribution: cannot provide native package for.*",
+                 p.out, flags=re.S)
+else:
+    assert_match(".*The requested version \(make=.*\) is not available.*",
+                 p.out, flags=re.S)
+
+print('SUCCESS')

--- a/testsuite/tests/get/native-unsupported/test.yaml
+++ b/testsuite/tests/get/native-unsupported/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
As part of the effort to better deal with native packages, this is a minimal patch to avoid general exceptions in unsupported distributions, that fixes #181, #180, #177, #169 (in the sense that clearer errors are emitted instead of the general internal failure one).

My plan is to rework the native situation as seamlessly as possible pre/post beta along these lines:

- Do not assume the platform is known (this patch) so people don't get bizarre errors.
- Allow resolution/retrieval of crates that are only missing native packages (the "permissive mode" we talked in #65).
  - In that case (missing native dependencies), use current native crates to give the user a hint of what they should provide manually (and to warn that the build will likely fail otherwise).

That would be my minimum target for the beta, so pure Ada packages work everywhere and ones with native dependencies can be also retrieved/tested everywhere. For the medium/long term, I'd like to:

- Remove current native crates, which have some fundamental problems.
  - At that time (or before) introduce a simple way of tracking missing external dependencies so we can continue operating with the hinting system.
- Introduce a new native description system that can accommodate all the issues identified with the current one, minimizing maintenance burden and making support from the community more amenable. I will prepare a draft proposal about this that we can discuss when the time comes.