### PR TITLE
Developer feature to compute hashes of origins

### DIFF
--- a/src/alire/alire-features-index.ads
+++ b/src/alire/alire-features-index.ads
@@ -1,8 +1,14 @@
 with Ada.Containers.Indefinite_Ordered_Sets;
 
+with Alire.Hashes;
 with Alire.Index_On_Disk;
+with Alire.Outcomes.Indefinite;
 
 package Alire.Features.Index is
+
+   -------------------
+   -- Index loading --
+   -------------------
 
    package Sets is new Ada.Containers.Indefinite_Ordered_Sets
      (Index_On_Disk.Index'Class, Index_On_Disk."<", Index_On_Disk."=");
@@ -35,5 +41,18 @@ package Alire.Features.Index is
    --  Add a new remote index under a folder that possibly contains more
    --    indexes in child folders. That is, Under is the parent of all indexes
    --  Index will be set as last one, or before given index name
+
+   ------------------------
+   --  Hashing utilities --
+   ------------------------
+
+   package Hashing_Outcomes is new Outcomes.Indefinite (Hashes.Any_Hash);
+
+   function Hash_Origin (Kind       : Hashes.Kinds;
+                         Origin_Img : URL)
+                         return Hashing_Outcomes.Outcome;
+   --  Given a valid image of an origin, compute its hash as it would appear
+   --  in the index. The origin is retrieved into a temporary folder that is
+   --  deleted after use.
 
 end Alire.Features.Index;

--- a/src/alire/alire-hashes-common.adb
+++ b/src/alire/alire-hashes-common.adb
@@ -22,7 +22,7 @@ package body Alire.Hashes.Common is
       end loop;
       Close (File);
 
-      return Any_Hash (Utils.To_Lower_Case (Kind'Img) & ":" & Digest (Ctxt));
+      return New_Hash (Kind, Any_Digest (Digest (Ctxt)));
 
    exception
       when others =>

--- a/src/alire/alire-origins.adb
+++ b/src/alire/alire-origins.adb
@@ -118,7 +118,8 @@ package body Alire.Origins is
    function From_String
      (This   : out Origin;
       From   : String;
-      Parent : TOML_Adapters.Key_Queue := TOML_Adapters.Empty_Queue)
+      Parent : TOML_Adapters.Key_Queue := TOML_Adapters.Empty_Queue;
+      Hashed : Boolean := True)
       return Outcome
    is
 
@@ -153,7 +154,7 @@ package body Alire.Origins is
                   This.Add_Hash (Hashes.Any_Hash (Hash));
                end;
             end loop;
-         elsif Mandatory then
+         elsif Hashed and then Mandatory then
             return Parent.Failure
               ("missing mandatory " & TOML_Keys.Origin_Hashes & " field");
          end if;
@@ -192,8 +193,12 @@ package body Alire.Origins is
                   raise Program_Error with "can't happen";
             end case;
 
-            --  Add optional (for now) hashes:
-            return Add_Hashes (Mandatory => False);
+            if Hashed then
+               --  Add optional (for now) hashes:
+               return Add_Hashes (Mandatory => False);
+            else
+               return Outcome_Success;
+            end if;
          end if;
       end loop;
 

--- a/src/alire/alire-origins.ads
+++ b/src/alire/alire-origins.ads
@@ -141,11 +141,14 @@ package Alire.Origins with Preelaborate is
    function From_String
      (This   : out Origin;
       From   : String;
-      Parent : TOML_Adapters.Key_Queue := TOML_Adapters.Empty_Queue)
+      Parent : TOML_Adapters.Key_Queue := TOML_Adapters.Empty_Queue;
+      Hashed : Boolean := True)
       return Outcome;
    --  Parse a string and dispatch to the appropiate constructor.
    --  Parent is an optional parent TOML table that may contain extra fields
-   --  (e.g., source_archive in case of an https: origin)
+   --  (e.g., source_archive in case of an https: origin).
+   --  Hashed indicates if integrity hashes are expected, so this function can
+   --  be used to retrieve unhashed origins too (precisely for hashing).
 
    overriding
    function From_TOML (This : in out Origin;

--- a/src/alire/alire-toml_adapters.adb
+++ b/src/alire/alire-toml_adapters.adb
@@ -85,11 +85,16 @@ package body Alire.TOML_Adapters is
    is
       use TOML;
    begin
-      Value := Queue.Value.Get_Or_Null (Key);
-      if Value /= No_TOML_Value then
-         Queue.Value.Unset (Key);
+      if Queue.Value /= No_TOML_Value and then Queue.Value.Kind = TOML_Table
+      then
+         Value := Queue.Value.Get_Or_Null (Key);
+         if Value /= No_TOML_Value then
+            Queue.Value.Unset (Key);
+         end if;
+         return Value /= TOML.No_TOML_Value;
+      else
+         return False;
       end if;
-      return Value /= TOML.No_TOML_Value;
    end Pop;
 
    --------------

--- a/src/alr/alr-commands-dev.adb
+++ b/src/alr/alr-commands-dev.adb
@@ -1,5 +1,8 @@
 with Ada.Command_Line;
 
+with Alire.Features.Index;
+with Alire.Hashes;
+
 with Alr.Selftest;
 
 package body Alr.Commands.Dev is
@@ -13,6 +16,15 @@ package body Alr.Commands.Dev is
       null;
    end Custom;
 
+   procedure Hash is
+   begin
+      Trace.Info
+        (String
+           (Alire.Features.Index.Hash_Origin
+                (Alire.Hashes.Default,
+                 Argument (1)).Value.Ptr.all));
+   end Hash;
+
    -------------
    -- Execute --
    -------------
@@ -25,6 +37,11 @@ package body Alr.Commands.Dev is
 
       if Cmd.Filtering then
          Trace.Debug ("In dev --filter");
+      end if;
+
+      if Cmd.Hash then
+         Hash;
+         return;
       end if;
 
       if Cmd.Raise_Except then
@@ -88,6 +105,11 @@ package body Alr.Commands.Dev is
                      Cmd.Filtering'Access,
                      "", "--filter",
                      "Used by scope filtering test");
+
+      Define_Switch (Config,
+                     Cmd.Hash'Access,
+                     "", "--hash",
+                     "Compute hash of given origin URL");
 
       Define_Switch (Config,
                      Cmd.Raise_Except'Access,

--- a/src/alr/alr-commands-dev.ads
+++ b/src/alr/alr-commands-dev.ads
@@ -27,6 +27,7 @@ private
    type Command is new Commands.Command with record
       Custom       : aliased Boolean := False; -- Custom code to run instead
       Filtering    : aliased Boolean := False; -- Runs debug scope filtering
+      Hash         : aliased Boolean := False; -- Compute hash of given origin
       Raise_Except : aliased Boolean := False;
       Self_Test    : aliased Boolean := False;
    end record;


### PR DESCRIPTION
Salvage the commits in #212 that allow using `alr dev --hash`, which at this time works only for source archives.