### PR TITLE
Refactor Supports_Hashing as a member function

### DIFF
--- a/src/alire/alire-origins-deployers-filesystem.adb
+++ b/src/alire/alire-origins-deployers-filesystem.adb
@@ -99,4 +99,15 @@ package body Alire.Origins.Deployers.Filesystem is
      (Path.Is_Directory or else
       Archive_Format (Path.Display_Base_Name) in Known_Source_Archive_Format);
 
+   ----------------------
+   -- Supports_Hashing --
+   ----------------------
+
+   overriding
+   function Supports_Hashing (This : Deployer) return Boolean is
+      use GNATCOLL.VFS;
+   begin
+      return Create (+This.Base.Path).Is_Regular_File;
+   end Supports_Hashing;
+
 end Alire.Origins.Deployers.Filesystem;

--- a/src/alire/alire-origins-deployers-filesystem.ads
+++ b/src/alire/alire-origins-deployers-filesystem.ads
@@ -21,6 +21,11 @@ package Alire.Origins.Deployers.Filesystem is
    --  in-progress crate).
    --  For files : hash the origin file.
 
+   overriding
+   function Supports_Hashing (This : Deployer) return Boolean;
+   --  Filesystem origins that point to a tarball must verify it, while ones
+   --  that point to a directory must not.
+
    function Is_Valid_Local_Crate (Path : VFS.Virtual_File) return Boolean;
    --  True if Path is a folder or a file with known source archive extension.
 

--- a/src/alire/alire-origins-deployers-source_archive.ads
+++ b/src/alire/alire-origins-deployers-source_archive.ads
@@ -10,6 +10,9 @@ package Alire.Origins.Deployers.Source_Archive is
                           Folder : String;
                           Kind   : Hashes.Kinds) return Hashes.Any_Digest;
 
+   overriding
+   function Supports_Hashing (This : Deployer) return Boolean is (True);
+
    procedure Unpack (Src_File : String;
                      Dst_Dir  : String;
                      Move_Up  : Boolean);

--- a/src/alire/alire-origins-deployers.adb
+++ b/src/alire/alire-origins-deployers.adb
@@ -166,7 +166,7 @@ package body Alire.Origins.Deployers is
    function Verify_Hashes (This   : Deployer'Class;
                            Folder : String) return Outcome is
    begin
-      if Supports_Hashing (This.Base.Kind) then
+      if This.Supports_Hashing then
 
          --  Emit a note if we might profit from hashes:
          if This.Base.Data.Hashes.Is_Empty then

--- a/src/alire/alire-origins-deployers.ads
+++ b/src/alire/alire-origins-deployers.ads
@@ -66,12 +66,14 @@ package Alire.Origins.Deployers is
    function Compute_Hash (This   : Deployer;
                           Folder : String;
                           Kind   : Hashes.Kinds) return Hashes.Any_Digest with
-     Pre'Class =>
-       Supports_Hashing (This.Base.Kind) or else raise Program_Error;
+     Pre'Class => This.Supports_Hashing or else raise Program_Error;
    --  Called immediately after deploy for each hash in the origin, Should
    --  be overriden by all deployers that support hashing; it won't be called
    --  otherwise. This function may raise exceptions that will be properly
    --  dealt with.
+
+   function Supports_Hashing (This : Deployer) return Boolean is (False);
+   --  Deployers that support hashing must override and return True.
 
    function Is_Native (This : Deployer) return Boolean;
    --  Whether This targets a package from the system's package manager

--- a/src/alire/alire-origins.ads
+++ b/src/alire/alire-origins.ads
@@ -38,11 +38,6 @@ package Alire.Origins with Preelaborate is
       Native          -- Native platform package
      );
 
-   Supports_Hashing : constant array (Kinds) of Boolean :=
-                        (Filesystem     => True,
-                         Source_Archive => True,
-                         others         => False);
-
    type String_Access is access constant String;
    type Prefix_Array is array (Kinds) of String_Access;
    Prefixes : constant Prefix_Array;


### PR DESCRIPTION
This is done to allow a Filesystem origin to report True/False depending on its two use cases: deploying a local tarball (True) or a local folder (False) -- the later is a working copy that is expected to change.

An alternative would be to separate Filesystem into two origin kinds, but that is much more work for no other practical benefit than this check.