### PR TITLE
Reorganize retrieval/verification steps for origins

### DIFF
--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -361,10 +361,17 @@ package body Alire.Features.Index is
          Depl : constant Origins.Deployers.Deployer'Class :=
                   Origins.Deployers.New_Deployer (Origin);
          Tmp : Alire.Directories.Temp_File;
-         Deploy_Result : constant Outcome :=
-                           Depl.Deploy (Tmp.Filename);
       begin
-         Deploy_Result.Assert;
+         if not Depl.Supports_Hashing then
+            return Hashing_Outcomes.Outcome_Failure
+              ("The supplied origin does not support integrity verification");
+         end if;
+
+         declare
+            Result : constant Outcome := Depl.Fetch (Tmp.Filename);
+         begin
+            Result.Assert;
+         end;
 
          declare
             Hash : constant Hashes.Any_Hash :=

--- a/src/alire/alire-origins-deployers-apt.adb
+++ b/src/alire/alire-origins-deployers-apt.adb
@@ -87,6 +87,14 @@ package body Alire.Origins.Deployers.APT is
       return False;
    end Exists;
 
+   -----------
+   -- Fetch --
+   -----------
+
+   overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome is
+     (Outcome_Success);
+
    --------------------
    -- Native_Version --
    --------------------

--- a/src/alire/alire-origins-deployers-apt.ads
+++ b/src/alire/alire-origins-deployers-apt.ads
@@ -4,9 +4,13 @@ package Alire.Origins.Deployers.APT is
 
    overriding
    function Already_Installed (This : Deployer) return Boolean;
+   --  Does nothing for this origin kind.
 
    overriding
    function Exists (This : Deployer) return Boolean;
+
+   overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome;
 
    overriding
    function Deploy (This : Deployer; Folder : String) return Outcome;

--- a/src/alire/alire-origins-deployers-filesystem.adb
+++ b/src/alire/alire-origins-deployers-filesystem.adb
@@ -65,6 +65,7 @@ package body Alire.Origins.Deployers.Filesystem is
       begin
          Source_Archive.Unpack (Src_File => This.Base.Path,
                                 Dst_Dir  => Dst_Guard.Filename,
+                                Delete   => False,
                                 Move_Up  => True);
 
          Dst_Guard.Keep;
@@ -90,6 +91,14 @@ package body Alire.Origins.Deployers.Filesystem is
             & This.Base.Path);
       end if;
    end Deploy;
+
+   -----------
+   -- Fetch --
+   -----------
+
+   overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome is
+     (Outcome_Success);
 
    --------------------------
    -- Is_Valid_Local_Crate --

--- a/src/alire/alire-origins-deployers-filesystem.ads
+++ b/src/alire/alire-origins-deployers-filesystem.ads
@@ -5,6 +5,10 @@ package Alire.Origins.Deployers.Filesystem is
    type Deployer is new Deployers.Deployer with null record;
 
    overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome;
+   --  Does nothing for this origin kind.
+
+   overriding
    function Deploy (This : Deployer; Folder : String) return Outcome;
    --  For local crates that are folders, this function will:
    --  * Verify the source path exists

--- a/src/alire/alire-origins-deployers-git.adb
+++ b/src/alire/alire-origins-deployers-git.adb
@@ -12,4 +12,12 @@ package body Alire.Origins.Deployers.Git is
       return VCSs.Git.Handler.Clone (This.Base.URL_With_Commit, Folder);
    end Deploy;
 
+   -----------
+   -- Fetch --
+   -----------
+
+   overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome is
+     (Outcome_Success);
+
 end Alire.Origins.Deployers.Git;

--- a/src/alire/alire-origins-deployers-git.ads
+++ b/src/alire/alire-origins-deployers-git.ads
@@ -3,6 +3,10 @@ package Alire.Origins.Deployers.Git is
    type Deployer is new Deployers.Deployer with null record;
 
    overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome;
+   --  Does nothing for this origin kind.
+
+   overriding
    function Deploy (This : Deployer; Folder : String) return Outcome;
 
 end Alire.Origins.Deployers.Git;

--- a/src/alire/alire-origins-deployers-hg.adb
+++ b/src/alire/alire-origins-deployers-hg.adb
@@ -12,4 +12,12 @@ package body Alire.Origins.Deployers.Hg is
       return VCSs.Hg.Handler.Clone (This.Base.URL_With_Commit, Folder);
    end Deploy;
 
+   -----------
+   -- Fetch --
+   -----------
+
+   overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome is
+     (Outcome_Success);
+
 end Alire.Origins.Deployers.Hg;

--- a/src/alire/alire-origins-deployers-hg.ads
+++ b/src/alire/alire-origins-deployers-hg.ads
@@ -3,6 +3,10 @@ package Alire.Origins.Deployers.Hg is
    type Deployer is new Deployers.Deployer with null record;
 
    overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome;
+   --  Does nothing for this origin kind.
+
+   overriding
    function Deploy (This : Deployer; Folder : String) return Outcome;
 
 end Alire.Origins.Deployers.Hg;

--- a/src/alire/alire-origins-deployers-source_archive.adb
+++ b/src/alire/alire-origins-deployers-source_archive.adb
@@ -17,24 +17,13 @@ package body Alire.Origins.Deployers.Source_Archive is
 
    overriding
    function Deploy (This : Deployer; Folder : String) return Outcome is
-      use GNATCOLL.VFS;
       Archive_Name : constant String := This.Base.Archive_Name;
       Archive_File : constant String := Dirs.Compose (Folder, Archive_Name);
-      Exit_Code    :          Integer;
    begin
-      Trace.Debug ("Creating folder: " & Folder);
-      Create (+Folder).Make_Dir;
-
-      Trace.Detail ("Downloading archive: " & This.Base.Archive_URL);
-      Exit_Code := OS_Lib.Subprocess.Spawn
-        ("wget", This.Base.Archive_URL & " -q -O " & Archive_File);
-      if Exit_Code /= 0 then
-         return Outcome_Failure ("wget call failed with code" & Exit_Code'Img);
-      end if;
-
       Trace.Detail ("Extracting source archive...");
       Unpack (Src_File => Archive_File,
               Dst_Dir  => Folder,
+              Delete   => True,
               Move_Up  => True);
 
       return Outcome_Success;
@@ -54,12 +43,37 @@ package body Alire.Origins.Deployers.Source_Archive is
       return Hashes.Digest (Hashes.Hash_File (Kind, Archive_File));
    end Compute_Hash;
 
+   -----------
+   -- Fetch --
+   -----------
+
+   overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome is
+      use GNATCOLL.VFS;
+      Archive_Name : constant String := This.Base.Archive_Name;
+      Archive_File : constant String := Dirs.Compose (Folder, Archive_Name);
+      Exit_Code    :          Integer;
+   begin
+      Trace.Debug ("Creating folder: " & Folder);
+      Create (+Folder).Make_Dir;
+
+      Trace.Detail ("Downloading archive: " & This.Base.Archive_URL);
+      Exit_Code := OS_Lib.Subprocess.Spawn
+        ("wget", This.Base.Archive_URL & " -q -O " & Archive_File);
+      if Exit_Code /= 0 then
+         return Outcome_Failure ("wget call failed with code" & Exit_Code'Img);
+      end if;
+
+      return Outcome_Success;
+   end Fetch;
+
    ------------
    -- Unpack --
    ------------
 
    procedure Unpack (Src_File : String;
                      Dst_Dir  : String;
+                     Delete   : Boolean;
                      Move_Up  : Boolean)
    is
 
@@ -130,6 +144,11 @@ package body Alire.Origins.Deployers.Source_Archive is
             raise Checked_Error with Errors.Set
               ("Given packed archive has unknown format: " & Src_File);
       end case;
+
+      if Delete then
+         Trace.Debug ("Deleting source archive: " & Src_File);
+         Ada.Directories.Delete_File (Src_File);
+      end if;
 
       if Move_Up then
          Check_And_Move_Up;

--- a/src/alire/alire-origins-deployers-source_archive.ads
+++ b/src/alire/alire-origins-deployers-source_archive.ads
@@ -3,6 +3,9 @@ package Alire.Origins.Deployers.Source_Archive is
    type Deployer is new Deployers.Deployer with null record;
 
    overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome;
+
+   overriding
    function Deploy (This : Deployer; Folder : String) return Outcome;
 
    overriding
@@ -15,9 +18,11 @@ package Alire.Origins.Deployers.Source_Archive is
 
    procedure Unpack (Src_File : String;
                      Dst_Dir  : String;
+                     Delete   : Boolean;
                      Move_Up  : Boolean);
    --  Unpack a file in one of the known formats into the destination dir. If
-   --  Move_Up, then if Src contains a single root folder, its contents are
-   --  moved up one level into Dst_Dir. Otherwise, Checked_Error is raised.
+   --  Delete, remove the Src_File after unpacking. If Move_Up, then if Src
+   --  contains a single root folder, its contents are moved up one level
+   --  into Dst_Dir. Otherwise, Checked_Error is raised.
 
 end Alire.Origins.Deployers.Source_Archive;

--- a/src/alire/alire-origins-deployers-svn.adb
+++ b/src/alire/alire-origins-deployers-svn.adb
@@ -12,4 +12,12 @@ package body Alire.Origins.Deployers.SVN is
       return VCSs.SVN.Handler.Clone (This.Base.URL_With_Commit, Folder);
    end Deploy;
 
+   -----------
+   -- Fetch --
+   -----------
+
+   overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome is
+     (Outcome_Success);
+
 end Alire.Origins.Deployers.SVN;

--- a/src/alire/alire-origins-deployers-svn.ads
+++ b/src/alire/alire-origins-deployers-svn.ads
@@ -3,6 +3,10 @@ package Alire.Origins.Deployers.SVN is
    type Deployer is new Deployers.Deployer with null record;
 
    overriding
+   function Fetch (This   : Deployer; Folder : String) return Outcome;
+   --  Does nothing for this origin kind.
+
+   overriding
    function Deploy (This : Deployer; Folder : String) return Outcome;
 
 end Alire.Origins.Deployers.SVN;

--- a/src/alire/alire-origins-deployers.adb
+++ b/src/alire/alire-origins-deployers.adb
@@ -59,13 +59,23 @@ package body Alire.Origins.Deployers is
                                Folder : String) return Outcome
    is
       The_Deployer  : constant Deployer'Class := New_Deployer (From);
-      Deploy_Result : constant Outcome := The_Deployer.Deploy (Folder);
+      Result        : Outcome;
    begin
-      if Deploy_Result.Success then
-         return The_Deployer.Verify_Hashes (Folder);
-      else
-         return Deploy_Result;
+
+      --  1. Fetch sources
+      Result := The_Deployer.Fetch (Folder);
+      if not Result.Success then
+         return Result;
       end if;
+
+      --  2. Verify sources
+      Result := The_Deployer.Verify_Hashes (Folder);
+      if not Result.Success then
+         return Result;
+      end if;
+
+      --  3. Deploy final sources
+      return The_Deployer.Deploy (Folder);
    exception
       when E : others =>
          Log_Exception (E);
@@ -157,6 +167,13 @@ package body Alire.Origins.Deployers is
    ------------
 
    function Deploy (This : Deployer; Folder : String) return Outcome
+   is (raise Program_Error with "should never be called for base class");
+
+   -----------
+   -- Fetch --
+   -----------
+
+   function Fetch (This   : Deployer; Folder : String) return Outcome
    is (raise Program_Error with "should never be called for base class");
 
    -------------------


### PR DESCRIPTION
This patch adds an extra Fetch step to `Origins.Deployers`. This way, instead of (Fetch & Unpack) -> Verify, we Fetch -> Verify -> Unpack. This is more in line with the workflow for source archives.