### PR TITLE
Minimal `publish` command

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -6,9 +6,9 @@ on:
       - 'doc/**'
 
 env:
-  alire_index: "git+https://github.com/mosteo/alire-index@22a13d9" 
+  alire_index: ""
   # Empty index: test with master of community index
-  # Otherwise: test with particular commit
+  # Otherwise: test with particular commit/branch
   # e.g.: index: "git+https://github.com/alire-project/alire-index@deadbeef" 
 
 jobs:

--- a/doc/publishing.md
+++ b/doc/publishing.md
@@ -1,0 +1,3 @@
+# Publishing your projects in Alire
+
+Coming soon! Please stay tuned.

--- a/src/alr/alr-commands-dev.adb
+++ b/src/alr/alr-commands-dev.adb
@@ -1,7 +1,5 @@
 with Ada.Command_Line;
 
-with Alire.Features.Index;
-with Alire.Hashes;
 with Alire.Selftest;
 
 package body Alr.Commands.Dev is
@@ -15,15 +13,6 @@ package body Alr.Commands.Dev is
       null;
    end Custom;
 
-   procedure Hash is
-   begin
-      Trace.Info
-        (String
-           (Alire.Features.Index.Hash_Origin
-                (Alire.Hashes.Default,
-                 Argument (1)).Value.Ptr.all));
-   end Hash;
-
    -------------
    -- Execute --
    -------------
@@ -36,11 +25,6 @@ package body Alr.Commands.Dev is
 
       if Cmd.Filtering then
          Trace.Debug ("In dev --filter");
-      end if;
-
-      if Cmd.Hash then
-         Hash;
-         return;
       end if;
 
       if Cmd.Raise_Except then
@@ -104,11 +88,6 @@ package body Alr.Commands.Dev is
                      Cmd.Filtering'Access,
                      "", "--filter",
                      "Used by scope filtering test");
-
-      Define_Switch (Config,
-                     Cmd.Hash'Access,
-                     "", "--hash",
-                     "Compute hash of given origin URL");
 
       Define_Switch (Config,
                      Cmd.Raise_Except'Access,

--- a/src/alr/alr-commands-dev.ads
+++ b/src/alr/alr-commands-dev.ads
@@ -27,7 +27,6 @@ private
    type Command is new Commands.Command with record
       Custom       : aliased Boolean := False; -- Custom code to run instead
       Filtering    : aliased Boolean := False; -- Runs debug scope filtering
-      Hash         : aliased Boolean := False; -- Compute hash of given origin
       Raise_Except : aliased Boolean := False;
       Self_Test    : aliased Boolean := False;
    end record;

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -1,0 +1,57 @@
+with Alire.Features.Index;
+with Alire.Hashes;
+
+package body Alr.Commands.Publish is
+
+   procedure Hash;
+
+   -------------
+   -- Execute --
+   -------------
+
+   overriding
+   procedure Execute (Cmd : in out Command) is
+   begin
+      if Cmd.Hash then
+         Hash;
+         return;
+      else
+         Trace.Error ("No publishing subcommand given.");
+      end if;
+   end Execute;
+
+   ----------
+   -- Hash --
+   ----------
+
+   procedure Hash is
+   begin
+      if Num_Arguments /= 1 then
+         Reportaise_Wrong_Arguments ("hash subcommand expects one argument");
+      end if;
+
+      Trace.Info
+        (String
+           (Alire.Features.Index.Hash_Origin
+                (Alire.Hashes.Default,
+                 Argument (1)).Value.Ptr.all));
+   end Hash;
+
+   --------------------
+   -- Setup_Switches --
+   --------------------
+
+   overriding
+   procedure Setup_Switches
+     (Cmd    : in out Command;
+      Config : in out GNAT.Command_Line.Command_Line_Configuration)
+   is
+      use GNAT.Command_Line;
+   begin
+      Define_Switch (Config,
+                     Cmd.Hash'Access,
+                     "", "--hash",
+                     "Compute hash of given origin");
+   end Setup_Switches;
+
+end Alr.Commands.Publish;

--- a/src/alr/alr-commands-publish.ads
+++ b/src/alr/alr-commands-publish.ads
@@ -1,0 +1,40 @@
+package Alr.Commands.Publish is
+
+   --  Publish lends a helping hand to automate submission of crates/releases.
+
+   type Command is new Commands.Command with private;
+
+   overriding
+   procedure Execute (Cmd : in out Command);
+
+   overriding
+   function Long_Description (Cmd : Command)
+                              return Alire.Utils.String_Vector
+   is (Alire.Utils.Empty_Vector
+       .Append ("Work in progress, manual instructions available at:")
+       .New_Line
+       .Append ("   https://github.com/alire-project/alire/blob/master/"
+                & "doc/publishing.md")
+       .New_Line
+       .Append ("<origin> is a tarball URL or local path."));
+
+   overriding
+   procedure Setup_Switches
+     (Cmd    : in out Command;
+      Config : in out GNAT.Command_Line.Command_Line_Configuration);
+
+   overriding
+   function Short_Description (Cmd : Command) return String
+   is ("Helps with the publication of new crates and releases");
+
+   overriding
+   function Usage_Custom_Parameters (Cmd : Command) return String
+   is ("--hash <origin>");
+
+private
+
+   type Command is new Commands.Command with record
+      Hash         : aliased Boolean := False; -- Compute hash of given origin
+   end record;
+
+end Alr.Commands.Publish;

--- a/src/alr/alr-commands-skeleton.ads
+++ b/src/alr/alr-commands-skeleton.ads
@@ -1,0 +1,40 @@
+package Alr.Commands.Skeleton is
+
+   --  Empty command that you can rename to provide a new command. See also
+   --  subprogram documentation in Alr.Commands spec. You need also to add its
+   --  entry in the Alr.Commands.Dispatch_Table (in the body).
+
+   type Command is new Commands.Command with private;
+
+   overriding
+   procedure Execute (Cmd : in out Command) is null;
+   --  This is called once the command-line is parsed.
+
+   overriding
+   function Long_Description (Cmd : Command)
+                              return Alire.Utils.String_Vector
+   is (Alire.Utils.Empty_Vector
+       .Append ("Replace this description with yours.")
+       .Append ("Every single line will be reformatted into 79-column-wide"
+                & " paragraphs.")
+       .New_Line
+       .Append ("You can use empty lines for structure with New_Line"));
+
+   overriding
+   procedure Setup_Switches
+     (Cmd    : in out Command;
+      Config : in out GNAT.Command_Line.Command_Line_Configuration) is null;
+
+   overriding
+   function Short_Description (Cmd : Command) return String
+   is ("Your one-liner description of the command");
+
+   overriding
+   function Usage_Custom_Parameters (Cmd : Command) return String
+   is ("Parameters expected after the command name");
+
+private
+
+   type Command is new Commands.Command with null record;
+
+end Alr.Commands.Skeleton;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -23,6 +23,7 @@ with Alr.Commands.Index;
 with Alr.Commands.Init;
 with Alr.Commands.List;
 with Alr.Commands.Pin;
+with Alr.Commands.Publish;
 with Alr.Commands.Run;
 with Alr.Commands.Search;
 with Alr.Commands.Show;
@@ -58,6 +59,7 @@ package body Alr.Commands is
                        Cmd_Init     => new Init.Command,
                        Cmd_List     => new List.Command,
                        Cmd_Pin      => new Pin.Command,
+                       Cmd_Publish  => new Publish.Command,
                        Cmd_Run      => new Run.Command,
                        Cmd_Search   => new Search.Command,
                        Cmd_Show     => new Show.Command,

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -123,6 +123,7 @@ package Alr.Commands is
                       Cmd_Init,
                       Cmd_List,
                       Cmd_Pin,
+                      Cmd_Publish,
                       Cmd_Run,
                       Cmd_Search,
                       Cmd_Show,

--- a/testsuite/tests/publish/hash/test.py
+++ b/testsuite/tests/publish/hash/test.py
@@ -1,0 +1,39 @@
+"""
+Check the `alr publish --hash` subcommand
+"""
+
+import re
+
+from glob import glob
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq
+
+# Test vectors from https://www.di-mgt.com.au/sha_testvectors.html
+filenames = ["empty.tgz",
+             "abc.tgz",
+             "bits448.tgz"]
+contents = ["",
+            "abc",
+            "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"]
+hashes = [
+    "sha512:cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47"
+    "d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+
+    "sha512:ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a21"
+    "92992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f",
+
+    "sha512:204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c33596"
+    "fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445"]
+
+# Generate a test "crate" in the current folder with known contents and hash:
+for i in range(len(filenames)):
+    with open(filenames[i], "wb") as file:
+        file.write(contents[i])
+
+    # Hash and check
+    p = run_alr('publish', '--hash', 'file://' + filenames[i], quiet=False)
+    assert_eq(hashes[i] + '\n', p.out)
+
+
+print('SUCCESS')

--- a/testsuite/tests/publish/hash/test.yaml
+++ b/testsuite/tests/publish/hash/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
Intended to eventually automate the publication of crates/releases, for now:

- It allows hashing an origin (`dev --hash` has been moved to `publish --hash`)
- Its help redirects users to detailed instructions that we'll put up in [doc/publishing.md]