### PR TITLE
Add handling for recent FSF and Community GNAT releases

### DIFF
--- a/src/alire/alire-platforms.ads
+++ b/src/alire/alire-platforms.ads
@@ -6,12 +6,22 @@ package Alire.Platforms with Preelaborate is
 
                       GNAT_FSF_Old,
                       GNAT_FSF_7_2, -- Has known bugs compared to 2017
-                      GNAT_FSF_7_3_Or_Newer,
+                      GNAT_FSF_7_3,
+                      GNAT_FSF_7_4,
+                      GNAT_FSF_7_5,
+                      GNAT_FSF_8_0,
+                      GNAT_FSF_8_1,
+                      GNAT_FSF_8_2,
+                      GNAT_FSF_8_3,
+                      GNAT_FSF_9_0,
+                      GNAT_FSF_9_1,
+                      GNAT_FSF_9_2_Or_Newer,
 
                       GNAT_GPL_Old,
                       GNAT_GPL_2017,
 
-                      GNAT_Community_2018);
+                      GNAT_Community_2018,
+                      GNAT_Community_2019);
    --  We do a minimum of future proofing. Unless newer version have known
    --  problems we don't need to isolate their versions.
 


### PR DESCRIPTION
Hello,

While trying to add the 2019 release of GNATCOLL using my local GCC 9.2.0 toolchain, I could not express properly compiler depedencies. This commit does what’s necessary short term, but I guess we would need a more scalable way to handle GNAT releases in the future. Anyway, I hope this helps in the meantime. :-) Cheers!