### PR TITLE
Extend `alr help` to support non-command topics

### DIFF
--- a/src/alr/alr-commands-help.adb
+++ b/src/alr/alr-commands-help.adb
@@ -1,0 +1,129 @@
+with AAA.Enum_Tools;
+with AAA.Table_IO;
+with AAA.Text_IO;
+
+package body Alr.Commands.Help is
+
+   type Help_Topics is (Identifiers);
+   --  Enumeration used to index available help topics.
+
+   -----------------------
+   -- One_Liner_Summary --
+   -----------------------
+
+   function One_Liner_Summary (Topic : Help_Topics) return String
+   is (case Topic is
+          when Identifiers => "Naming rules for crate and index names"
+      );
+
+   -----------------
+   -- Description --
+   -----------------
+   --  Descriptions are given as string vectors so they can be reformatted into
+   --  paragraphs.
+
+   function Description (Topic : Help_Topics) return Alire.Utils.String_Vector
+   is
+     (case Topic is
+         when Identifiers =>
+            Alire.Utils.Empty_Vector
+              .Append ("Identifiers for crates and indexes must use "
+                       & "lowercase alphanumeric characters from the latin "
+                       & "alphabet. Underscores can also be used except as "
+                       & "the first character.")
+              .New_Line
+              .Append ("Length must be of at least" & Alire.Min_Name_Length'Img
+                       & " characters.")
+     );
+
+   ------------------
+   -- Display_Help --
+   ------------------
+
+   procedure Display_Help (Keyword : String) is
+
+      ------------
+      -- Format --
+      ------------
+
+      procedure Format (Text : Alire.Utils.String_Vector) is
+      begin
+         for Line of Text loop
+            AAA.Text_IO.Put_Paragraph (Line,
+                                       Line_Prefix => " ");
+         end loop;
+         New_Line;
+      end Format;
+
+      --------------
+      -- Is_Topic --
+      --------------
+
+      function Is_Topic is new AAA.Enum_Tools.Is_Valid (Help_Topics);
+
+   begin
+      if Is_Command (Keyword) then
+         Display_Usage (What_Command (Keyword));
+
+      elsif Is_Topic (Keyword) then
+         New_Line;
+         Put_Line (Help_Topics'Value (Keyword)'Img);
+         New_Line;
+         Format (Description (Identifiers));
+
+      else
+         Trace.Error ("No help found for: " & Keyword);
+         Display_Valid_Keywords;
+         OS_Lib.Bailout (1);
+      end if;
+   end Display_Help;
+
+   ----------------------------
+   -- Display_Valid_Keywords --
+   ----------------------------
+
+   procedure Display_Valid_Keywords is
+   begin
+      New_Line;
+      Display_Valid_Commands;
+      New_Line;
+      Display_Valid_Topics;
+   end Display_Valid_Keywords;
+
+   --------------------------
+   -- Display_Valid_Topics --
+   --------------------------
+
+   procedure Display_Valid_Topics is
+      Tab   : constant String (1 .. 6) := (others => ' ');
+      Table : AAA.Table_IO.Table;
+   begin
+      Put_Line ("Help topics: ");
+      New_Line;
+      for Topic in Help_Topics'Range loop
+         Table.New_Row;
+         Table.Append (Tab);
+         Table.Append (Alire.Utils.To_Lower_Case (Topic'Img));
+         Table.Append (One_Liner_Summary (Topic));
+      end loop;
+      Table.Print (Separator => "  ");
+   end Display_Valid_Topics;
+
+   -------------
+   -- Execute --
+   -------------
+
+   overriding
+   procedure Execute (Cmd : in out Command) is
+      pragma Unreferenced (Cmd);
+   begin
+      if Num_Arguments /= 1 then
+         Trace.Error ("Please specific a single help keyword:");
+         Display_Valid_Keywords;
+         OS_Lib.Bailout (1);
+      end if;
+
+      Display_Help (Argument (1));
+   end Execute;
+
+end Alr.Commands.Help;

--- a/src/alr/alr-commands-help.ads
+++ b/src/alr/alr-commands-help.ads
@@ -1,0 +1,45 @@
+package Alr.Commands.Help is
+
+   --  Help command. While commands provide their own help text, other topics
+   --  can be defined here.
+
+   type Command is new Commands.Command with private;
+
+   procedure Display_Help (Keyword : String);
+   --  Display the help for this keyword, be it command or topic.
+
+   procedure Display_Valid_Keywords;
+   --  List a summary of both commands and other topics.
+
+   procedure Display_Valid_Topics;
+   --  List a summary of topics which are not commands.
+
+   overriding
+   procedure Execute (Cmd : in out Command);
+
+   overriding
+   function Long_Description (Cmd : Command)
+                              return Alire.Utils.String_Vector
+   is (Alire.Utils.Empty_Vector
+       .Append ("Shows information about commands and topics.")
+       .Append ("See available commands with 'alr help commands'")
+       .Append ("See available topics with 'alr help topics'."));
+
+   overriding
+   procedure Setup_Switches
+     (Cmd    : in out Command;
+      Config : in out GNAT.Command_Line.Command_Line_Configuration) is null;
+
+   overriding
+   function Short_Description (Cmd : Command) return String
+   is ("Shows help on the given command/topic");
+
+   overriding
+   function Usage_Custom_Parameters (Cmd : Command) return String
+   is ("[command|topic]");
+
+private
+
+   type Command is new Commands.Command with null record;
+
+end Alr.Commands.Help;

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -119,6 +119,7 @@ package Alr.Commands is
                       Cmd_Compile,
                       Cmd_Dev,
                       Cmd_Get,
+                      Cmd_Help,
                       Cmd_Index,
                       Cmd_Init,
                       Cmd_List,
@@ -160,8 +161,14 @@ private
    Raw_Arguments : Utils.String_Vector;
    --  Raw arguments, first one is the command
 
+   function Is_Command (Str : String) return Boolean;
+   --  Say if string matches an alr command
+
    function What_Command return String;
-   function What_Command return Cmd_Names;
+   function What_Command (Str : String := "") return Cmd_Names;
+   --  Return the command for the given string, or use the first non-switch
+   --  command-line argument if Str = "".
+
    function Num_Arguments return Natural;
    --  Actual arguments besides the command
    function Argument (I : Positive) return String; -- May raise if not existing

--- a/testsuite/tests/help/equivalent_help/test.py
+++ b/testsuite/tests/help/equivalent_help/test.py
@@ -26,8 +26,8 @@ assert p1.out == p2.out, "Mismatch in outputs: {} != {}".format(p1.out, p2.out)
 p1 = run_alr('-h', 'non_existing_command',   complain_on_error=False, quiet=False)
 p2 = run_alr('help', 'non_existing_command', complain_on_error=False, quiet=False)
 
-# Verify we got the expected help
-assert_match("ERROR: Unrecognized help topic: non_existing_command", p1.out)
+# Verify we got the expected error message
+assert_match(".*o help found for:.*", p1.out)
 
 # Verify equality
 assert p1.out == p2.out, "Mismatch in outputs: {} != {}".format(p1.out, p2.out)


### PR DESCRIPTION
We have several instances (#242, probably more) where errors are detected but no further information is provided. Besides providing better information on the spot, with this patch we can define more general topics that the user can check for help.

Also the help support becomes a bit better structured, with some parts being moved from Alr.Commands to Alr.Commands.Help.

A minimal new topic is included: `identifiers` describes the rules for crate/index names.