### PR TITLE
Deprecate Internal_Error/Unconstrained_Error

### DIFF
--- a/src/alire/alire-origins-deployers-apt.adb
+++ b/src/alire/alire-origins-deployers-apt.adb
@@ -20,8 +20,8 @@ package body Alire.Origins.Deployers.APT is
            This.Base.Package_Name (Platform.Distribution));
 
       if Exit_Code /= 0 then
-         Trace.Error ("apt-cache policy exited with error:" & Exit_Code'Img);
-         raise Internal_Error;
+         Raise_Checked_Error
+           ("apt-cache policy exited with error:" & Exit_Code'Img);
       end if;
 
       for Line of Output loop
@@ -76,8 +76,8 @@ package body Alire.Origins.Deployers.APT is
            This.Base.Package_Name (Platform.Distribution));
 
       if Exit_Code /= 0 then
-         Trace.Error ("apt-cache policy exited with error:" & Exit_Code'Img);
-         raise Internal_Error;
+         Raise_Checked_Error
+           ("apt-cache policy exited with error:" & Exit_Code'Img);
       end if;
 
       for Line of Output loop
@@ -116,7 +116,7 @@ package body Alire.Origins.Deployers.APT is
            Name);
 
       if Exit_Code /= 0 then
-         Uncontained_Error
+         Raise_Checked_Error
            ("apt-cache policy exited with code:" & Exit_Code'Img);
       end if;
 

--- a/src/alire/alire.adb
+++ b/src/alire/alire.adb
@@ -67,6 +67,16 @@ package body Alire is
       end if;
    end Assert;
 
+   -------------------
+   -- Checked_Error --
+   -------------------
+
+   procedure Raise_Checked_Error (Msg : String) is
+   begin
+      Err_Log (Msg);
+      raise Checked_Error with Errors.Set (Msg);
+   end Raise_Checked_Error;
+
    ----------------------------
    -- Outcome_From_Exception --
    ----------------------------
@@ -95,15 +105,5 @@ package body Alire is
                          Message => +Full_Msg);
       end if;
    end Outcome_From_Exception;
-
-   -----------------------
-   -- Uncontained_Error --
-   -----------------------
-
-   procedure Uncontained_Error (Msg : String) is
-   begin
-      Trace.Error (Msg);
-      raise Internal_Error with Msg;
-   end Uncontained_Error;
 
 end Alire;

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -15,14 +15,6 @@ package Alire with Preelaborate is
    --  Outcomes for results returned to clients. That is, a Checked_Error ought
    --  not to propagate into Alr.* code.
 
-   Internal_Error : exception;
-   --  While we transition to error codes, there are places that would require
-   --  extensive refactoring. Also, legitimate irrecoverable situations may
-   --  arise in places were an outcome cannot be easily returned. Instead of
-   --  aborting and exiting from Alire, a last resort handler in Alr can catch
-   --  this exception and exit gracefully. Should be used sparingly and of
-   --  course not when user input is involved.
-
    Query_Unsuccessful : exception;
    --  Raised by subprograms that return releases/dependencies when not
    --  found/impossible.
@@ -167,14 +159,10 @@ package Alire with Preelaborate is
    --  Does nothing for successful outcomes. Raises Checked_Error with the
    --  corresponding message set in Alire.Errors otherwise.
 
-   -----------------------
-   -- Uncontained_Error --
-   -----------------------
-
-   procedure Uncontained_Error (Msg : String) with No_Return;
-   --  For errors where we can't or won't (for now) proceed normally, nor
-   --  return an Outcome_Failure, we trace an error message (Msg) and raise
-   --  Internal_Error.
+   procedure Raise_Checked_Error (Msg : String) with No_Return;
+   --  For errors where we do not return an Outcome_Failure, we log an error
+   --  message (Msg) and raise Checked_Error. There is no limitation on the
+   --  length of Msg.
 
    ---------------
    --  LOGGING  --


### PR DESCRIPTION
This patch removes inconsistent use of `Internal_Error`/`Unconstrained_Error` in favor of `Checked_Error`.

We were using those in just a couple of places when explicitly checking for errors, and that's what `Checked_Error` is for.

`Internal_Error` is directly replaced by `Checked_Error`. `Unconstrained_Error` is renamed as `Raise_Checked_Error`, which logs to stderr (when enabled) the error message, and raises a `Checked_Error` with the message stored with `Alire.Errors` as the information for the user.