### PR TITLE
Check for GNAT in path before invoking it

### DIFF
--- a/src/alr/alr-bootstrap.adb
+++ b/src/alr/alr-bootstrap.adb
@@ -17,14 +17,6 @@ package body Alr.Bootstrap is
    ---------------------
 
    procedure Check_Ada_Tools is
-      procedure Check_Tool (Exec : String) is
-      begin
-         if not OS_Lib.Exists_In_Path (Exec) then
-            Trace.Error ("Required tool not detected: " & Exec);
-            Trace.Error ("alr cannot proceed");
-            OS_Lib.Bailout (1);
-         end if;
-      end Check_Tool;
    begin
       Check_Tool ("gprbuild");
 
@@ -33,6 +25,19 @@ package body Alr.Bootstrap is
            ("git is not detected, alr will fail on most operations");
       end if;
    end Check_Ada_Tools;
+
+   ----------------
+   -- Check_Tool --
+   ----------------
+
+   procedure Check_Tool (Exec : String) is
+   begin
+      if not OS_Lib.Exists_In_Path (Exec) then
+         Trace.Error ("Required tool not detected: " & Exec);
+         Trace.Error ("alr cannot proceed");
+         OS_Lib.Bailout (1);
+      end if;
+   end Check_Tool;
 
    -----------------
    -- Interrupted --

--- a/src/alr/alr-bootstrap.ads
+++ b/src/alr/alr-bootstrap.ads
@@ -27,6 +27,10 @@ package Alr.Bootstrap is
    procedure Check_Ada_Tools;
    --  Check gprbuild/gnatmake are within reach
 
+   procedure Check_Tool (Exec : String);
+   --  Check that some executable is in the path, or print error and die with
+   --  exit code 1.
+
    function Status_Line return String;
    --  One-liner reporting most interesting information
 

--- a/src/alr/alr-platform.adb
+++ b/src/alr/alr-platform.adb
@@ -1,6 +1,5 @@
-with Alire.Properties.Platform;
-
 with Alire.OS_Lib.Subprocess;
+with Alire.Properties.Platform;
 with Alire.Utils;
 
 with Alr.Utils;


### PR DESCRIPTION
Fixes #236

Stop-gag measure until we fully address the cross-compiling situation. I see that cross-compiling-gnats have unpredictable names like `riscv32-elf-gnat`, so perhaps it will be the responsibility of the user to supply the actual gnat name?