### PR TITLE
More general version sets for dependencies

### DIFF
--- a/doc/catalog-format-spec.rst
+++ b/doc/catalog-format-spec.rst
@@ -57,7 +57,7 @@ dependencies, with version constraints:
 .. code-block:: toml
 
    libfoo = "^1.2"
-   libbar = "^2.0"
+   libbar = "^2.0 & /=2.1.3" # Excluding a known bad version
 
 In some contexts, information can be dynamic: special encodings can be used to
 make data vary depending on the environment (OS, architecture, …). The
@@ -244,7 +244,10 @@ entries:
 
   Available constraint operators are the usual Ada ones (=, /=, >, >=, <, <=)
   plus caret (^, any upwards version within the same major point) and tilde
-  (~, any upwards version within the same minor point).
+  (~, any upwards version within the same minor point). Logical operators for
+  and (&), or (|) are accepted; see the ``Semantic_Versioning`` project 
+  documentation on `extended version sets 
+  <https://github.com/alire-project/semantic_versioning#types>`_.
 
 * ``project-files``: optional list of strings. Each is a path, relative to the
   root of the source directory, to a project file to be made available.

--- a/src/alire/alire-conditional.ads
+++ b/src/alire/alire-conditional.ads
@@ -3,7 +3,7 @@ with Alire.Dependencies;
 with Alire.Properties;
 with Alire.TOML_Adapters;
 
-with Semantic_Versioning;
+with Semantic_Versioning.Extended;
 
 package Alire.Conditional with Preelaborate is
 
@@ -23,9 +23,10 @@ package Alire.Conditional with Preelaborate is
      with Dynamic_Predicate => not Forbidden_Dependencies.Contains_ORs;
    --  A plain tree without conditions or alternatives
 
-   function New_Dependency (Name     : Alire.Project;
-                            Versions : Semantic_Versioning.Version_Set)
-                            return Dependencies;
+   function New_Dependency
+     (Name     : Alire.Project;
+      Versions : Semantic_Versioning.Extended.Version_Set)
+      return Dependencies;
 
    function No_Dependencies return Dependencies is (For_Dependencies.Empty);
 
@@ -64,9 +65,10 @@ package Alire.Conditional with Preelaborate is
 
 private
 
-   function New_Dependency (Name     : Alire.Project;
-                            Versions : Semantic_Versioning.Version_Set)
-                            return Dependencies is
+   function New_Dependency
+     (Name     : Alire.Project;
+      Versions : Semantic_Versioning.Extended.Version_Set)
+      return Dependencies is
      (For_Dependencies.New_Value
         (Alire.Dependencies.New_Dependency (Name, Versions)));
 

--- a/src/alire/alire-containers.adb
+++ b/src/alire/alire-containers.adb
@@ -1,4 +1,5 @@
-with Semantic_Versioning;
+with Semantic_Versioning.Basic;
+with Semantic_Versioning.Extended;
 
 package body Alire.Containers is
 
@@ -76,6 +77,7 @@ package body Alire.Containers is
    function To_Dependencies (Map : Release_Map)
                              return Conditional.Dependencies
    is
+      package Semver renames Semantic_Versioning;
       use Conditional.For_Dependencies;
       use Project_Release_Maps;
    begin
@@ -86,7 +88,8 @@ package body Alire.Containers is
                  Deps and
                  Conditional.New_Dependency
                    (Map (I).Project,
-                    Semantic_Versioning.Exactly (Map (I).Version));
+                    Semver.Extended.To_Extended
+                      (Semver.Basic.Exactly (Map (I).Version)));
             end if;
          end loop;
       end return;

--- a/src/alire/alire-dependencies.adb
+++ b/src/alire/alire-dependencies.adb
@@ -9,9 +9,10 @@ package body Alire.Dependencies is
    is
       package SV renames Semantic_Versioning;
       Version_Str : constant String := Value.As_String;
+      EVS         : constant SV.Extended.Version_Set :=
+                      SV.Extended.Value (Version_Str);
    begin
-      return New_Dependency (+Utils.To_Lower_Case (Key),
-                             SV.To_Set (Version_Str));
+      return New_Dependency (+Utils.To_Lower_Case (Key), EVS);
       --  TODO: if no operator appears the version, this results in strict
       --  match. Rust, for example, assumes caret (^) in this case. Do we want
       --  to do the same?
@@ -25,18 +26,9 @@ package body Alire.Dependencies is
    -------------
 
    overriding function To_TOML (Dep : Dependency) return TOML.TOML_Value is
-      use Semantic_Versioning;
       use TOML_Adapters;
    begin
-      if Dep.Versions = Any then
-         return +"any";
-      elsif Length (Dep.Versions) > 1 then
-         raise Unimplemented; -- TODO (but not yet in index format)
-      else
-         return +Image_Abbreviated (Dep.Versions,
-                                    Unicode        => False,
-                                    Implicit_Equal => True);
-      end if;
+      return +Dep.Versions.Image;
    end To_TOML;
 
 end Alire.Dependencies;

--- a/src/alire/alire-dependencies.ads
+++ b/src/alire/alire-dependencies.ads
@@ -2,7 +2,7 @@ with Alire.Interfaces;
 with Alire.TOML_Adapters;
 with Alire.Utils;
 
-with Semantic_Versioning;
+with Semantic_Versioning.Extended;
 
 with TOML; use all type TOML.Any_Value_Kind;
 
@@ -18,16 +18,15 @@ package Alire.Dependencies with Preelaborate is
      and Interfaces.Yamlable
    with private;
 
-   function New_Dependency (Project  : Alire.Project;
-                            Versions : Semantic_Versioning.Version_Set)
-                            return Dependency;
+   function New_Dependency
+     (Project  : Alire.Project;
+      Versions : Semantic_Versioning.Extended.Version_Set)
+      return Dependency;
 
    function Project (Dep : Dependency) return Names;
 
-   function Versions (Dep : Dependency) return Semantic_Versioning.Version_Set;
-
-   function Image_Ada (Dep : Dependency) return String;
-   --  Adaish string representation of the dependency, e.g. "make is Any"
+   function Versions (Dep : Dependency)
+                      return Semantic_Versioning.Extended.Version_Set;
 
    function Image (Dep : Dependency) return String;
    --  Standard-style version image, e.g. "make^3.1"
@@ -61,32 +60,27 @@ private
      and Interfaces.Yamlable
    with record
       Project    : Alire.Project (1 .. Name_Len);
-      Versions   : Semantic_Versioning.Version_Set;
+      Versions   : Semantic_Versioning.Extended.Version_Set;
    end record;
 
-   function New_Dependency (Project  : Alire.Project;
-                            Versions : Semantic_Versioning.Version_Set)
-                            return Dependency
+   function New_Dependency
+     (Project  : Alire.Project;
+      Versions : Semantic_Versioning.Extended.Version_Set)
+      return Dependency
    is (Project'Length, Project, Versions);
 
    function Project (Dep : Dependency) return Names is (Dep.Project);
 
-   function Versions (Dep : Dependency) return Semantic_Versioning.Version_Set
+   function Versions (Dep : Dependency)
+                      return Semantic_Versioning.Extended.Version_Set
    is (Dep.Versions);
-
-   function Image_Ada (Dep : Dependency) return String is
-     (if Dep = Unavailable
-      then "Unavailable"
-      else
-        (Utils.To_Lower_Case (+Dep.Project) & " is " &
-           Semantic_Versioning.Image_Ada (Dep.Versions)));
 
    function Image (Dep : Dependency) return String is
       (if Dep = Unavailable
       then "Unavailable"
       else
          (Utils.To_Lower_Case (+Dep.Project)
-          & Semantic_Versioning.Image_Abbreviated (Dep.Versions)));
+          & Dep.Versions.Image));
 
    overriding
    function To_YAML (Dep : Dependency) return String is
@@ -94,14 +88,13 @@ private
       then "{}"
       else
         ("{crate: """ & Utils.To_Lower_Case (+Dep.Project) &
-           """, version: """ & Semantic_Versioning.Image_Ada (Dep.Versions) &
+           """, version: """ & Dep.Versions.Image &
            """}"));
 
    overriding function Key (Dep : Dependency) return String is (+Dep.Project);
 
    function Unavailable return Dependency
    is (New_Dependency ("alire",
-                       Semantic_Versioning.Exactly
-                         (Semantic_Versioning.V ("0"))));
+                       Semantic_Versioning.Extended.Value ("0")));
 
 end Alire.Dependencies;

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -9,7 +9,12 @@ with Alire.Utils.YAML;
 
 with GNAT.IO; -- To keep preelaborable
 
+with Semantic_Versioning.Basic;
+with Semantic_Versioning.Extended;
+
 package body Alire.Releases is
+
+   package Semver renames Semantic_Versioning;
 
    use all type Alire.Properties.Labeled.Labels;
 
@@ -538,7 +543,8 @@ package body Alire.Releases is
      (Conditional.For_Dependencies.New_Value
         (Alire.Dependencies.New_Dependency
              (R.Project,
-              Semantic_Versioning.Exactly (R.Version))));
+              Semver.Extended.To_Extended
+                (Semver.Basic.Exactly (R.Version)))));
 
    -------------
    -- To_TOML --

--- a/src/alire/alire-releases.ads
+++ b/src/alire/alire-releases.ads
@@ -393,7 +393,7 @@ private
    function Satisfies (R   : Release;
                        Dep : Alire.Dependencies.Dependency)
                        return Boolean
-   is (R.Project = Dep.Project and then Satisfies (R.Version, Dep.Versions));
+   is (R.Project = Dep.Project and then Dep.Versions.Contains (R.Version));
 
    function Version_Image (R : Release) return String
    is (Semantic_Versioning.Image (R.Version));

--- a/src/alire/alire-types.ads
+++ b/src/alire/alire-types.ads
@@ -3,7 +3,7 @@ with Alire.Dependencies;
 --  with Alire.Dependencies.Vectors;
 with Alire.Releases;
 
-with Semantic_Versioning;
+with Semantic_Versioning.Extended;
 
 package Alire.Types with Preelaborate is
 
@@ -24,9 +24,10 @@ package Alire.Types with Preelaborate is
    function No_Dependencies return Conditional.Dependencies
      renames Conditional.For_Dependencies.Empty;
 
-   function New_Dependency (Name     : Alire.Project;
-                            Versions : Semantic_Versioning.Version_Set)
-                            return Platform_Dependencies
+   function New_Dependency
+     (Name     : Alire.Project;
+      Versions : Semantic_Versioning.Extended.Version_Set)
+      return Platform_Dependencies
      renames Conditional.New_Dependency;
 
    subtype Release is Releases.Release;

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -12,7 +12,7 @@ with Alr.Parsers;
 with Alr.Platform;
 with Alr.Query;
 
-with Semantic_Versioning;
+with Semantic_Versioning.Extended;
 
 package body Alr.Commands.Get is
 
@@ -24,7 +24,7 @@ package body Alr.Commands.Get is
 
    procedure Retrieve (Cmd      : Command;
                        Name     : Alire.Project;
-                       Versions : Semver.Version_Set)
+                       Versions : Semver.Extended.Version_Set)
    is
       Rel : constant Alire.Index.Release :=
         Query.Find (Name, Versions, Query_Policy);

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -9,7 +9,7 @@ with Alr.Parsers;
 with Alr.Platform;
 with Alr.Root;
 
-with Semantic_Versioning;
+with Semantic_Versioning.Extended;
 with Alire.Projects;
 
 package body Alr.Commands.Show is
@@ -39,7 +39,7 @@ package body Alr.Commands.Show is
    ------------
 
    procedure Report (Name     : Alire.Project;
-                     Versions : Semver.Version_Set;
+                     Versions : Semver.Extended.Version_Set;
                      Current  : Boolean;
                      --  session or command-line requested release
                      Cmd      : Command)
@@ -131,7 +131,7 @@ package body Alr.Commands.Show is
    -------------------
 
    procedure Report_Jekyll (Name     : Alire.Project;
-                            Versions : Semver.Version_Set;
+                            Versions : Semver.Extended.Version_Set;
                             Current  : Boolean)
    is
    begin

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -24,11 +24,7 @@ with GNAT.Command_Line;
 
 with GNATCOLL.VFS;
 
-with Semantic_Versioning;
-
 package body Alr.Commands.Test is
-
-   package Semver renames Semantic_Versioning;
 
    -----------------
    -- Check_Files --
@@ -254,8 +250,7 @@ package body Alr.Commands.Test is
                              Parsers.Project_Versions (Argument (J));
                         begin
                            if R.Project = Allowed.Project
-                             and then
-                              Semver.Satisfies (R.Version, Allowed.Versions)
+                             and then Allowed.Versions.Contains (R.Version)
                            then
                               if not Cmd.Last
                                 or else
@@ -264,9 +259,8 @@ package body Alr.Commands.Test is
                                  R.Project /=
                                    Alire.Index.Catalog (Next (I)).Project
                                 or else
-                                 not Semver.Satisfies
-                                      (Alire.Index.Catalog (Next (I)).Version,
-                                       Allowed.Versions)
+                                 not Allowed.Versions.Contains
+                                      (Alire.Index.Catalog (Next (I)).Version)
                               then
                                  Candidates.Include (R);
                               end if;

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -15,7 +15,7 @@ with Alr.Platform;
 with Alr.Root;
 with Alr.Templates;
 
-with Semantic_Versioning;
+with Semantic_Versioning.Extended;
 
 package body Alr.Commands.Withing is
 
@@ -60,11 +60,11 @@ package body Alr.Commands.Withing is
                  return Alire.Conditional.Dependencies
    is
       use all type Alire.Conditional.Dependencies;
-      use all type Semantic_Versioning.Version_Set;
+      use all type Semantic_Versioning.Extended.Version_Set;
       Requested : constant Parsers.Allowed_Milestones :=
         Parsers.Project_Versions (Old_Dep);
    begin
-      if Requested.Versions /= Semantic_Versioning.Any then
+      if Requested.Versions /= Semantic_Versioning.Extended.Any then
          Trace.Warning
            ("Version is not used when removing dependencies: " & Old_Dep);
       end if;

--- a/src/alr/alr-parsers.adb
+++ b/src/alr/alr-parsers.adb
@@ -16,37 +16,26 @@ package body Alr.Parsers is
       use Ada.Strings.Fixed;
       use Ada.Strings.Maps;
 
-      Op_Pos  : constant Natural := Index (Spec, To_Set ("=^~"), Inside);
-
-      --  Ready to separate name from version, and operator if existing
-      Name    : constant String := (if Op_Pos > Spec'First
-                                    then Spec (Spec'First .. Op_Pos - 1)
-                                    else Spec);
-
-      Op      : constant Character := (if Op_Pos > Spec'First
-                                       then Spec (Op_Pos)
-                                       else ASCII.NUL);
-
-      V       : constant Semver.Version :=
-        (if Op_Pos > Spec'First
-         then Semver.Relaxed (Spec (Op_Pos + 1 .. Spec'Last))
-         else Semver.V ("0.0.0"));
-
-      Versions : constant Semver.Version_Set :=
-        (case Op is
-            when ASCII.NUL => Semver.Any,
-            when '='       => Semver.Exactly (V),
-            when '^'       => Semver.Within_Major (V),
-            when '~'       => Semver.Within_Minor (V),
-            when others    => raise Constraint_Error
-              with "Unrecognized version operator: " & Op);
+      Op_Pos  : constant Natural := Index (Spec, To_Set ("=^~<>/("), Inside);
+      Name    : constant String  := (if Op_Pos > Spec'First
+                                     then Spec (Spec'First .. Op_Pos - 1)
+                                     else Spec);
+      Result  : constant Semver.Extended.Result :=
+                  (if Op_Pos > Spec'First
+                   then Semver.Extended.Parse (Spec (Op_Pos .. Spec'Last))
+                   else Semver.Extended.Parse ("*"));
    begin
-      --  Previous return with copy caused double free on finalize of
-      --  Versions???
-      return M : Allowed_Milestones (Name'Length) do
-         M.Project  := +Name;
-         M.Versions := Versions;
-      end return;
+      if Result.Valid then
+         return M : Allowed_Milestones (Name'Length) do
+            M.Project  := +Name;
+            M.Versions := Result.Set;
+         end return;
+      else
+         Trace.Error ("Invalid version set expression: "
+                      & Spec (Op_Pos .. Spec'Last));
+         Trace.Error (Result.Error);
+         raise Command_Failed with "Invalid version set expression";
+      end if;
    exception
       when Alire.Checked_Error =>
          raise;

--- a/src/alr/alr-parsers.ads
+++ b/src/alr/alr-parsers.ads
@@ -1,17 +1,17 @@
 with Alire;
 
-with Semantic_Versioning;
+with Semantic_Versioning.Extended;
 
 package Alr.Parsers with Preelaborate is
 
    type Allowed_Milestones (Len : Positive) is record
       Project  : Alire.Project (1 .. Len);
-      Versions : Semantic_Versioning.Version_Set;
+      Versions : Semantic_Versioning.Extended.Version_Set;
    end record;
 
    function Project_Versions (Spec : String) return Allowed_Milestones;
    --  Either valid set or Constraint_Error
    --  If no version was specified, Any version is returned
-   --  Syntax: name[(=|^|~)version]
+   --  Syntax: name[extended version set expression]
 
 end Alr.Parsers;

--- a/src/alr/alr-query.ads
+++ b/src/alr/alr-query.ads
@@ -3,7 +3,7 @@ with Alire.Index;
 with Alire.Properties;
 with Alire.Types;
 
-with Semantic_Versioning;
+with Semantic_Versioning.Extended;
 
 package Alr.Query is
 
@@ -62,12 +62,14 @@ package Alr.Query is
 
    function Exists
      (Project : Alire.Project;
-      Allowed : Semantic_Versioning.Version_Set := Semantic_Versioning.Any)
+      Allowed : Semantic_Versioning.Extended.Version_Set :=
+        Semantic_Versioning.Extended.Any)
       return Boolean;
 
    function Find
      (Project : Alire.Project;
-      Allowed : Semantic_Versioning.Version_Set := Semantic_Versioning.Any;
+      Allowed : Semantic_Versioning.Extended.Version_Set :=
+        Semantic_Versioning.Extended.Any;
       Policy  : Age_Policies)
       return Release;
 
@@ -111,8 +113,9 @@ package Alr.Query is
 
    procedure Print_Solution (Sol : Solution);
 
-   function Dependency_Image (Project  : Alire.Project;
-                              Versions : Semantic_Versioning.Version_Set;
-                              Policy   : Age_Policies := Newest) return String;
+   function Dependency_Image
+     (Project  : Alire.Project;
+      Versions : Semantic_Versioning.Extended.Version_Set;
+      Policy   : Age_Policies := Newest) return String;
 
 end Alr.Query;

--- a/testsuite/tests/get/native-hint/test.py
+++ b/testsuite/tests/get/native-hint/test.py
@@ -13,7 +13,7 @@ p = run_alr('get', 'libhello=0.9-test_unav_native',
             complain_on_error=True, quiet=False)
 
 assert_match('Warning: The following native dependencies are unavailable within Alire:\n'
-             'Warning:    make=\*\n'
+             'Warning:    make\*\n'
              'Warning: They should be made available in the environment by the user.\n',
              p.out, flags=re.S)
 

--- a/testsuite/tests/show/jekyll/test.py
+++ b/testsuite/tests/show/jekyll/test.py
@@ -17,7 +17,7 @@ assert_eq(
       'websites: ["example.com"]\n'
       'tags: ["tag1", "other-tag"]\n'
       'version: "1.0.1"\n'
-      'dependencies: [{crate: "libhello", version: "Within_Major (1.0.0)"}]\n'
+      'dependencies: [{crate: "libhello", version: "^1.0"}]\n'
       '---\n'
       '"Hello, world!" demonstration project\n'
       '\n', p.out)

--- a/testsuite/tests/workflows/init-with-pin/test.py
+++ b/testsuite/tests/workflows/init-with-pin/test.py
@@ -29,7 +29,7 @@ os.chdir('xxx')
 # Make it depend on libhello
 session_file = os.path.join('alire', 'xxx.toml')
 run_alr('with', 'libhello')
-check_line_in(session_file, 'libhello = "any"')
+check_line_in(session_file, 'libhello = "*"')
 
 # Add the corresponding "with" line in xxx.gpr.
 #
@@ -42,7 +42,7 @@ with open('xxx.gpr', 'w') as f:
 
 # Pin the version of libhello
 run_alr('pin')
-check_line_in(session_file, 'libhello = "1.0.0"')
+check_line_in(session_file, 'libhello = "=1.0.0"')
 
 # Build and run "xxx"
 with open(os.path.join('src', 'xxx.adb'), 'w') as f:


### PR DESCRIPTION
As discussed in #104, current versions sets were limited to one restriction. I've added more general expressions to `Semantic_Versioning` which are readily usable in alire with this patch.

We discussed a possibility of using ',' and arrays for "and"/"or" conditions but after checking similar expressions in `apt` and `opam` I did likewise using '&', '|' respectively, which I found clearer. Example:

`foo = "^3.0 | (^2.0 & /=2.1.3)"`

So current dependencies don't change and more expressive ones can be used when needed.

I intend to take advantage of these more general expressions also to address the unsustainable compiler situation pointed out by @pmderodat in #241 as part of the native package rework. I will discuss this idea in a separate issue.

Fixes #104 