### PR TITLE
Let output of Checked_Spawn go to console

### DIFF
--- a/src/alire/alire-origins-deployers-source_archive.adb
+++ b/src/alire/alire-origins-deployers-source_archive.adb
@@ -69,6 +69,9 @@ package body Alire.Origins.Deployers.Source_Archive is
          Empty_Vector &
            This.Base.Archive_URL &
            "-q" &
+         (if Log_Level < Trace.Info
+            then Empty_Vector
+            else Empty_Vector & "--show-progress" & "--progress=bar") &
            "-O" &
            Archive_File);
 

--- a/src/alr/alr-spawn.adb
+++ b/src/alr/alr-spawn.adb
@@ -1,6 +1,7 @@
+with Alire.OS_Lib.Subprocess;
 with Alire.Paths;
 
-with Alire.OS_Lib.Subprocess;
+with Alr.Commands;
 
 package body Alr.Spawn is
 
@@ -12,8 +13,16 @@ package body Alr.Spawn is
                       Args                : Alire.Utils.String_Vector;
                       Understands_Verbose : Boolean := False)
    is
+      Unused_Output : Alire.Utils.String_Vector;
    begin
-      Alire.OS_Lib.Subprocess.Checked_Spawn (Cmd, Args, Understands_Verbose);
+      if Commands.Is_Quiet then
+         Unused_Output :=
+           Alire.OS_Lib.Subprocess.Checked_Spawn_And_Capture
+             (Cmd, Args, Understands_Verbose, Err_To_Out => True);
+      else
+         Alire.OS_Lib.Subprocess.Checked_Spawn
+           (Cmd, Args, Understands_Verbose);
+      end if;
    end Command;
 
    --------------


### PR DESCRIPTION
Unlike for `Checked_Spawn_And_Capture`

`-q` should continue working.

Now things are much more verbose (the user by default sees fetches, clones and builds), but since we no longer have the line-catcher spinner this might serve for the time being.

