### PR TITLE
The project path can contain several directories and we must take each of them

### DIFF
--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -1,4 +1,5 @@
 with AAA.Table_IO;
+with Ada.Strings.Fixed;
 
 --  with Alire.Platform;
 with Alire.Defaults;
@@ -380,13 +381,15 @@ package body Alire.Releases is
                            return      Utils.String_Set
    is
       use Utils;
+      use Ada.Strings;
       Files : constant String_Vector :=
         Project_Files (R, P, With_Path => True);
    begin
       return Paths : String_Set do
          for File of Files loop
             if Contains (File, "/") then
-               Paths.Include (Head (File, '/'));
+               Paths.Include
+                 (File (File'First .. Fixed.Index (File, "/", Backward)));
             end if;
          end loop;
       end return;


### PR DESCRIPTION
When the project file path contains several directories, we are using Head() to keep the directory part.
The Head() function cannot be used because it seeks forward and stops at the first '/' and hence keeps only the first directory component.

Instead we should seek backward to find the last '/' in the path and return the path from the beginning up to the last part (a Head() function that seeks backward and not forward).
