### PR TITLE
Better diagnostic when a TOML Boolean was expected

### DIFF
--- a/src/alire/alire-requisites-booleans.adb
+++ b/src/alire/alire-requisites-booleans.adb
@@ -7,7 +7,12 @@ package body Alire.Requisites.Booleans is
       Unused_Key : constant String := From.Pop (Value);
    begin
       --  Should never fail if the caller has properly constructed the adapter:
-      return New_Requisite (Value.As_Boolean);
+      if Value.Kind in TOML.TOML_Boolean then
+         return New_Requisite (Value.As_Boolean);
+      else
+         From.Checked_Error ("expected a Boolean value, but got a "
+                             & Value.Kind'Img);
+      end if;
    end From_TOML;
 
 end Alire.Requisites.Booleans;


### PR DESCRIPTION
Otherwise we got a generic assertion failure.