### PR TITLE
[RFC] Filesystem deployer: allow the use symlinks for local crates

### DIFF
--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -41,4 +41,12 @@ package Alire.Config is
    --  If interactive, ask the user to press Enter or Ctrl-C to stop.
    --  Output a log trace otherwise and continue.
 
+   --------------
+   -- Symlinks --
+   --------------
+
+   Use_Symlinks : aliased Boolean := False;
+   --  When possible, use symbolic links for local crates instead of copying
+   --  the source directory.
+
 end Alire.Config;

--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -3,6 +3,9 @@ with Ada.Numerics.Discrete_Random;
 with Ada.Unchecked_Deallocation;
 
 with Alire.Paths;
+with Alire.OS_Lib.Subprocess;
+
+with GNATCOLL.OS.Constants;
 
 package body Alire.Directories is
 
@@ -44,6 +47,26 @@ package body Alire.Directories is
       end loop;
       End_Search (Search);
    end Copy;
+
+   --------------------
+   -- Create_Symlink --
+   --------------------
+
+   procedure Create_Symlink (Src, Dst : Absolute_Path) is
+      use Alire.Utils;
+   begin
+      case GNATCOLL.OS.Constants.OS is
+         when GNATCOLL.OS.Unix | GNATCOLL.OS.MacOS =>
+            Alire.OS_Lib.Subprocess.Checked_Spawn
+              ("ln",
+               Utils.Empty_Vector &
+                 "-s" &
+                 Src &
+                 Dst);
+         when others =>
+            Raise_Checked_Error ("Symlinks not available on this platform");
+      end case;
+   end Create_Symlink;
 
    ----------------------
    -- Detect_Root_Path --

--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -63,8 +63,17 @@ package body Alire.Directories is
                  "-s" &
                  Src &
                  Dst);
-         when others =>
-            Raise_Checked_Error ("Symlinks not available on this platform");
+
+         when GNATCOLL.OS.Windows =>
+            declare
+               Extra_Args : constant String_Vector :=
+                 (case Ada.Directories.Kind (Src) is
+                     when Ada.Directories.Directory => Empty_Vector & "/d",
+                     when others                    => Empty_Vector);
+            begin
+               Alire.OS_Lib.Subprocess.Checked_Spawn
+                 ("mklink", Extra_Args & Dst & Src);
+            end;
       end case;
    end Create_Symlink;
 

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -21,6 +21,9 @@ package Alire.Directories is
    --  equivalent to "cp -r src/* dst/". Excluding may be a single name that
    --  will not be copied (if file) or recursed into (if folder).
 
+   procedure Create_Symlink (Src, Dst : Absolute_Path);
+   --  Create a symbolic link Dst pointing to Src
+
    function Current return String renames Ada.Directories.Current_Directory;
 
    function Detect_Root_Path (Starting_At : Absolute_Path := Current)

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -177,6 +177,12 @@ package body Alr.Commands is
                      "Assume default answers for all user prompts");
 
       Define_Switch (Config,
+                     Alire.Config.Use_Symlinks'Access,
+                     "", "--use-symlinks",
+                     "Use symbolic links for local crates instead of copying" &
+                       " directories");
+
+      Define_Switch (Config,
                      Prefer_Oldest'Access,
                      Long_Switch => "--prefer-oldest",
                      Help        => "Prefer oldest versions instead of " &

--- a/testsuite/tests/get/deploy_symlinks/test.py
+++ b/testsuite/tests/get/deploy_symlinks/test.py
@@ -1,0 +1,20 @@
+"""
+Test init command produced artifacts and options
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq
+from drivers.helpers import compare, contents
+
+import os
+
+# Get local crate using symlinks
+run_alr('--use-symlinks', 'get', 'hello')
+
+assert os.path.islink('hello_1.0.1_filesystem')
+assert os.path.islink('hello_1.0.1_filesystem/alire/cache/projects/libhello_1.0.0_filesystem')
+
+assert os.path.exists('hello_1.0.1_filesystem/hello.gpr')
+assert os.path.exists('hello_1.0.1_filesystem/alire/cache/projects/libhello_1.0.0_filesystem/libhello.gpr')
+
+print('SUCCESS')

--- a/testsuite/tests/get/deploy_symlinks/test.yaml
+++ b/testsuite/tests/get/deploy_symlinks/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
This makes it easier to work on multiple crates at the same time by using symlink to local repositories.