### PR TITLE
Debug dump stack trace on Outcome_Failure

### DIFF
--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -43,8 +43,6 @@ package body Alire.Features.Index is
 
          Priority : Index_On_Disk.Priorities := Index_On_Disk.Default_Priority;
       begin
-         Result := Outcome_Failure ("Internal error: result status not set");
-
          --  Trivial case if not Before
          if Before = "" then
             Result := Outcome_Success;
@@ -109,22 +107,13 @@ package body Alire.Features.Index is
          end if;
       end loop;
 
-      --  Check, with fake priority, that the index does not exist already
-      declare
-         Result : Outcome;
-         Index  : constant Index_On_Disk.Index'Class :=
-                    Index_On_Disk.New_Handler
-                      (Origin, Name, Under, Result,
-                       Index_On_Disk.Default_Priority);
-      begin
-         --  Don't re-add if it is already valid:
-         if Result.Success and then Index.Verify.Success then
-            Trace.Warning ("Index with given name exists, skipping action.");
-            return Outcome_Success;
-         elsif not Result.Success then
-            return Result;
+      --  Check that no other index has the same name (& hence dir location)
+      for Index of Indexes loop
+         if Index.Name = Name then
+            return Outcome_Failure
+              ("Given name already in use by existing index");
          end if;
-      end;
+      end loop;
 
       --  Create handler with proper priority and proceed
       declare

--- a/src/alire/alire.adb
+++ b/src/alire/alire.adb
@@ -1,3 +1,5 @@
+with AAA.Debug;
+
 with Alire.Errors;
 with Alire.Utils;
 
@@ -114,9 +116,32 @@ package body Alire is
 
    procedure Raise_Checked_Error (Msg : String) is
    begin
-      Err_Log (Msg);
+      if Log_Debug then
+         Err_Log (Msg);
+      end if;
       raise Checked_Error with Errors.Set (Msg);
    end Raise_Checked_Error;
+
+   ---------------------
+   -- Outcome_Failure --
+   ---------------------
+
+   function Outcome_Failure (Message : String) return Outcome is
+      Stack : constant String := AAA.Debug.Stack_Trace;
+   begin
+      if Log_Debug then
+         Err_Log ("Generating Outcome_Failure with message: " & Message);
+         Err_Log ("Generating Outcome_Failure with call stack:");
+         Err_Log (Stack);
+      end if;
+
+      Trace.Debug ("Generating Outcome_Failure with message: " & Message);
+      Trace.Debug ("Generating Outcome_Failure with call stack:");
+      Trace.Debug (Stack);
+
+      return (Success => False,
+              Message => +Message);
+   end Outcome_Failure;
 
    ----------------------------
    -- Outcome_From_Exception --

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -159,6 +159,8 @@ package Alire with Preelaborate is
    function Outcome_Failure (Message : String) return Outcome with
      Pre  => Message'Length > 0,
      Post => not Outcome_Failure'Result.Success;
+   --  Calling this function generates a debug stack trace log, so it should
+   --  not be called until a failure is actually happening.
 
    function Outcome_Success return Outcome with
      Post => Outcome_Success'Result.Success;
@@ -219,10 +221,6 @@ private
    --  small overhead of always having the Message member is the price to pay.
 
    function Message (Result : Outcome) return String is (+Result.Message);
-
-   function Outcome_Failure (Message : String) return Outcome is
-     (Success => False,
-      Message => +Message);
 
    function Outcome_Success return Outcome is
      (Success => True,

--- a/testsuite/tests/debug/outcome-stack-trace/test.py
+++ b/testsuite/tests/debug/outcome-stack-trace/test.py
@@ -1,0 +1,20 @@
+"""
+Verify that creating a Outcome_Failure also dumps the stack trace to log output
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+
+import re
+
+p = run_alr('index', '--name', 'xx', '--add', '.',
+            complain_on_error=False, debug=True, quiet=True)
+# Failed call because name is too short. That causes a Outcome_Failure to be
+# returned.
+
+# Since stack traces wildly differ across platforms, a minimal check is done:
+assert_match(
+    '.*Generating Outcome_Failure with call stack:.*',
+    p.out, flags=re.S)
+
+print('SUCCESS')

--- a/testsuite/tests/debug/outcome-stack-trace/test.yaml
+++ b/testsuite/tests/debug/outcome-stack-trace/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script

--- a/testsuite/tests/index/bad-name/test.py
+++ b/testsuite/tests/index/bad-name/test.py
@@ -7,7 +7,7 @@ from drivers.asserts import assert_match
 
 
 p = run_alr('index', '--add', 'xx', '--name', 'xx',
-            complain_on_error=False)
+            complain_on_error=False, debug=False)
 assert_match('.*Identifier too short.*', p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/local-index-not-found/test.py
+++ b/testsuite/tests/index/local-index-not-found/test.py
@@ -16,7 +16,7 @@ for d in ('no-such-directory',
     rm('alr-config', recursive=True)
     prepare_indexes('alr-config', '.',
                     {'bad_index': {'dir': d, 'in_fixtures': False}})
-    p = run_alr('list', complain_on_error=False)
+    p = run_alr('list', complain_on_error=False, debug=False)
 
     path_excerpt = os.path.join('alr-config', 'indexes', 'bad_index',
                                 'index.toml')

--- a/testsuite/tests/index/origin-filesystem-bad-path/test.py
+++ b/testsuite/tests/index/origin-filesystem-bad-path/test.py
@@ -13,7 +13,7 @@ def run(i, error):
     prepare_env(config_dir, os.environ)
     prepare_indexes(
         config_dir, '.', {'bad_index_{}'.format(i): {'in_fixtures': False}})
-    p = run_alr('list', complain_on_error=False)
+    p = run_alr('list', complain_on_error=False, debug=False)
     assert_match(
         'ERROR: {}'
         '\nERROR: alr list unsuccessful\n$'.format(error),

--- a/testsuite/tests/index/origin-unknown-kind/test.py
+++ b/testsuite/tests/index/origin-unknown-kind/test.py
@@ -6,7 +6,8 @@ from drivers.alr import run_alr
 from drivers.asserts import assert_match
 
 
-p = run_alr('show', 'hello_world', complain_on_error=False, quiet=False)
+p = run_alr('show', 'hello_world',
+            complain_on_error=False, debug=False, quiet=False)
 assert_match(
     'ERROR: .* unknown origin: .*'
     '\nERROR: alr show unsuccessful'


### PR DESCRIPTION
When returning an Outcome_Failure, the call stack is lost which may be inconvenient for further debugging. With this patch, the call stack is dumped at debug level (and optionally to stderr if
-d is in effect). Does not affect users at above debug log levels.