### PR TITLE
Unify crates/releases/descriptions into Alire.Index

### DIFF
--- a/src/alire/alire-index.adb
+++ b/src/alire/alire-index.adb
@@ -1,56 +1,64 @@
-with Ada.Containers.Indefinite_Ordered_Maps;
-
-with Alire.Projects;
-
 package body Alire.Index is
 
    use all type Semantic_Versioning.Version;
 
-   package Name_Entry_Maps
-   is new Ada.Containers.Indefinite_Ordered_Maps (Alire.Project,
-                                                  Catalog_Entry);
+   Crates : aliased Projects.Containers.Maps.Map;
 
-   Master_Entries : Name_Entry_Maps.Map;
+   ---------
+   -- Add --
+   ---------
 
-   ---------------------------------
-   -- Manually_Catalogued_Project --
-   ---------------------------------
-
-   function Manually_Catalogued_Project
-     (Crate_Name, Description : String) return Catalog_Entry
-   is
-      use Alire.Utils, Name_Entry_Maps;
-      Project  : constant Alire.Project := +To_Lower_Case (Crate_Name);
-      Position : constant Cursor := Master_Entries.Find (Project);
+   procedure Add (Crate  : Projects.With_Releases.Crate;
+                  Policy : Addition_Policies := Merge_Priorizing_Existing) is
+      pragma Unreferenced (Policy);
    begin
-      if Has_Element (Position) then
+      if Exists (Crate.Name) then
+         declare
+            Old : Projects.With_Releases.Crate := Crates (Crate.Name);
+         begin
+            for Release of Crate.Releases loop
+               if Old.Contains (Release.Version) then
+                  Trace.Debug ("Not registering release already indexed: "
+                               & Release.Milestone.Image);
+               else
+                  Old.Add (Release);
+               end if;
+            end loop;
 
-         --  If this package was already registered, just check that arguments
-         --  haven't changed.
-
-         return Result : constant Catalog_Entry := Element (Position) do
-            if Result.Description /= Description then
-               raise Constraint_Error;
-            end if;
-         end return;
-
+            Crates.Include (Crate.Name, Old);
+         end;
       else
-         --  Otherwise, create the entry and register it
-
-         return C : constant Catalog_Entry :=
-           (Name_Len  => Crate_Name'Length,
-            Descr_Len => Description'Length,
-
-            Project      => Project,
-            Description  => Description)
-         do
-            Master_Entries.Insert (C.Project, C);
-            Projects.Descriptions.Include (C.Project, Description);
-            --  This description may be already present from the session
-            --  project file.
-         end return;
+         Crates.Insert (Crate.Name, Crate);
       end if;
-   end Manually_Catalogued_Project;
+   end Add;
+
+   ----------------
+   -- All_Crates --
+   ----------------
+
+   function All_Crates return access constant Projects.Containers.Maps.Map is
+     (Crates'Access);
+
+   -----------
+   -- Crate --
+   -----------
+
+   function Crate (Name : Alire.Project) return Projects.With_Releases.Crate is
+     (Crates (Name));
+
+   -----------------
+   -- Crate_Count --
+   -----------------
+
+   function Crate_Count return Natural is
+     (Natural (Crates.Length));
+
+   ------------
+   -- Exists --
+   ------------
+
+   function Exists (Project : Alire.Project) return Boolean is
+     (Crates.Contains (Project));
 
    ------------
    -- Exists --
@@ -60,11 +68,13 @@ package body Alire.Index is
                     Version : Semantic_Versioning.Version)
                     return Boolean is
    begin
-      for R of Catalog loop
-         if R.Project = Project and then R.Version = Version then
-            return True;
-         end if;
-      end loop;
+      if Exists (Project) then
+         for R of Crates (Project).Releases loop
+            if R.Project = Project and then R.Version = Version then
+               return True;
+            end if;
+         end loop;
+      end if;
 
       return False;
    end Exists;
@@ -76,64 +86,28 @@ package body Alire.Index is
    function Find (Project : Alire.Project;
                   Version : Semantic_Versioning.Version) return Release is
    begin
-      for R of Catalog loop
+      for R of Crates (Project).Releases loop
          if R.Project = Project and then R.Version = Version then
             return R;
          end if;
       end loop;
 
-      raise Constraint_Error
-        with "Not in index: " & (+Project) & "=" &
-        Semantic_Versioning.Image (Version);
+      raise Checked_Error with
+        "Requested milestone not in index: "
+        & (+Project) & "=" & Semantic_Versioning.Image (Version);
    end Find;
 
    -------------------
-   -- Register_Real --
+   -- Release_Count --
    -------------------
 
-   function Register_Real (R : Release) return Release is
+   function Release_Count return Natural is
    begin
-      if Catalog.Contains (R) then
-         Trace.Debug ("Not registering release already indexed: " &
-                        R.Milestone.Image);
-      else
-         Catalog.Insert (R);
-      end if;
-
-      return R;
-   end Register_Real;
-
-   --------------
-   -- Register --
-   --------------
-
-   function Register
-     ( --  Mandatory
-                      This               : Catalog_Entry;
-       Version            : Semantic_Versioning.Version;
-       Origin             : Origins.Origin;
-       -- we force naming beyond this point with this ugly guard:
-       XXXXXXXXXXXXXX     : Utils.XXX_XXX         := Utils.XXX_XXX_XXX;
-       --  Optional
-       Notes              : Description_String    := "";
-       Dependencies       : Release_Dependencies  := No_Dependencies;
-       Properties         : Release_Properties    := No_Properties;
-       Private_Properties : Release_Properties    := No_Properties;
-       Available_When     : Release_Requisites    := No_Requisites)
-      return Release
-   is
-      pragma Unreferenced (XXXXXXXXXXXXXX);
-   begin
-      return Register_Real
-        (Alire.Releases.New_Release
-           (Project            => This.Project,
-            Version            => Version,
-            Origin             => Origin,
-            Notes              => Notes,
-            Dependencies       => Dependencies,
-            Properties         => Properties,
-            Private_Properties => Private_Properties,
-            Available          => Available_When));
-   end Register;
+      return Count : Natural := 0 do
+         for Crate of Crates loop
+            Count := Count + Natural (Crate.Releases.Length);
+         end loop;
+      end return;
+   end Release_Count;
 
 end Alire.Index;

--- a/src/alire/alire-projects-containers.ads
+++ b/src/alire/alire-projects-containers.ads
@@ -1,0 +1,13 @@
+with Ada.Containers.Indefinite_Ordered_Maps;
+
+with Alire.Projects.With_Releases;
+
+package Alire.Projects.Containers with Preelaborate is
+
+   use type With_Releases.Crate;
+
+   package Maps is new Ada.Containers.Indefinite_Ordered_Maps
+     (Alire.Project,
+      With_Releases.Crate);
+
+end Alire.Projects.Containers;

--- a/src/alire/alire-projects-with_releases.adb
+++ b/src/alire/alire-projects-with_releases.adb
@@ -1,12 +1,35 @@
 with Alire.Properties.Labeled;
-with Alire.Releases;
 with Alire.TOML_Keys;
-
-with Semantic_Versioning;
 
 with TOML;
 
 package body Alire.Projects.With_Releases is
+
+   package Keys is new Containers.Release_Sets.Generic_Keys
+     (Semantic_Versioning.Version,
+      Alire.Releases.Version,
+      Semantic_Versioning."<");
+
+   ---------
+   -- Add --
+   ---------
+
+   procedure Add (This    : in out Crate;
+                  Release : Alire.Releases.Release) is
+   begin
+      This.Releases.Insert (Release);
+   end Add;
+
+   --------------
+   -- Contains --
+   --------------
+
+   function Contains (This    : Crate;
+                      Version : Semantic_Versioning.Version) return Boolean
+   is
+   begin
+      return Keys.Contains (This.Releases, Version);
+   end Contains;
 
    ---------------
    -- From_TOML --
@@ -141,6 +164,17 @@ package body Alire.Projects.With_Releases is
    --------------
 
    function Releases (This : Crate) return Containers.Release_Set is
-      (This.Releases);
+     (This.Releases);
+
+   -------------
+   -- Replace --
+   -------------
+
+   procedure Replace (This    : in out Crate;
+                      Release : Alire.Releases.Release)
+   is
+   begin
+      Keys.Replace (This.Releases, Release.Version, Release);
+   end Replace;
 
 end Alire.Projects.With_Releases;

--- a/src/alire/alire-projects-with_releases.ads
+++ b/src/alire/alire-projects-with_releases.ads
@@ -1,6 +1,9 @@
 with Alire.Interfaces;
 with Alire.Containers;
+with Alire.Releases;
 with Alire.TOML_Adapters;
+
+with Semantic_Versioning;
 
 package Alire.Projects.With_Releases with Preelaborate is
 
@@ -12,6 +15,16 @@ package Alire.Projects.With_Releases with Preelaborate is
 
    function Name (This : Crate) return Alire.Project;
 
+   procedure Add (This    : in out Crate;
+                  Release : Releases.Release) with Pre =>
+     not This.Contains (Release.Version) or else
+     raise Checked_Error with
+       "Crate already contains given release: "
+       & Semantic_Versioning.Image (Release.Version);
+
+   function Contains (This    : Crate;
+                      Version : Semantic_Versioning.Version) return Boolean;
+
    function Description (This : Crate) return Description_String;
 
    function Releases (This : Crate) return Containers.Release_Set;
@@ -20,6 +33,13 @@ package Alire.Projects.With_Releases with Preelaborate is
    function From_TOML (This : in out Crate;
                        From :        TOML_Adapters.Key_Queue)
                        return Outcome;
+
+   procedure Replace (This    : in out Crate;
+                      Release : Alire.Releases.Release) with Pre =>
+     This.Contains (Release.Version) or else
+     raise Checked_Error with
+       "Crate does not contain given release: "
+       & Semantic_Versioning.Image (Release.Version);
 
 private
 

--- a/src/alire/alire-projects.ads
+++ b/src/alire/alire-projects.ads
@@ -15,10 +15,6 @@ package Alire.Projects with Preelaborate is
    is new Ada.Containers.Indefinite_Ordered_Maps
      (Alire.Project, Description_String);
 
-   --  TODO: combine Index, Descriptions in a single data structure
-   Descriptions : Project_Description_Maps.Map;
-   --  Master list of known projects & descriptions
-
    function Naming_Convention return Utils.String_Vector;
    --  Return a description of the naming restrictions on crates/indexes.
 

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -498,10 +498,8 @@ package body Alire.TOML_Index is
    -----------------
 
    procedure Index_Crate (Path  : Relative_Path;
-                          Crate : Projects.With_Releases.Crate) is
-      Cat_Ent : constant Index.Catalog_Entry :=
-                  Index.Manually_Catalogued_Project
-                    (+Crate.Name, Crate.Description);
+                          Crate : in out Projects.With_Releases.Crate)
+   is
       use all type Origins.Kinds;
       use GNATCOLL;
       use all type VFS.Filesystem_String;
@@ -511,6 +509,7 @@ package body Alire.TOML_Index is
          --  This is delayed until this moment to keep many other
          --  packages Preelaborable.
          declare
+            use type Origins.Origin;
             Origin : constant Origins.Origin :=
                        Origins.Tweaks.Fixed_Origin (Path, R.Origin);
          begin
@@ -524,18 +523,13 @@ package body Alire.TOML_Index is
                end if;
             end if;
 
-            declare
-               Dummy : constant Index.Release := Cat_Ent.Register
-                 (Version        => R.Version,
-                  Origin         => Origin,
-                  Dependencies   => R.Dependencies,
-                  Properties     => R.Properties,
-                  Available_When => R.Available);
-            begin
-               null;
-            end;
+            if Origin /= R.Origin then
+               Crate.Replace (Release => R.Replacing (Origin));
+            end if;
          end;
       end loop;
+
+      Index.Add (Crate);
    end Index_Crate;
 
 end Alire.TOML_Index;

--- a/src/alire/alire-toml_index.ads
+++ b/src/alire/alire-toml_index.ads
@@ -25,7 +25,7 @@ package Alire.TOML_Index is
 private
 
    procedure Index_Crate (Path  : Relative_Path;
-                          Crate : Projects.With_Releases.Crate);
+                          Crate : in out Projects.With_Releases.Crate);
    --  Add the crate and its releases to the internal index.
    --  Path is where on disk the Crate was loaded from. This is necessary
    --  to fix relative paths in local origins, which at load time are relative

--- a/src/alr/alr-bootstrap.adb
+++ b/src/alr/alr-bootstrap.adb
@@ -77,7 +77,7 @@ package body Alr.Bootstrap is
    begin
       return
         "(" & Session_State'Img & ") (" &
-        Utils.Trim (Alire.Index.Catalog.Length'Img) & " releases indexed)" &
+        Utils.Trim (Alire.Index.Release_Count'Img) & " releases indexed)" &
         (" (loaded in" & Milliseconds'Image (Milliseconds (Elapsed)) & "s)");
    end Status_Line;
 

--- a/src/alr/alr-commands-list.adb
+++ b/src/alr/alr-commands-list.adb
@@ -1,6 +1,6 @@
 with AAA.Table_IO;
 
-with Alire.Projects;
+with Alire.Index;
 
 with Alr.Utils;
 
@@ -28,18 +28,17 @@ package body Alr.Commands.List is
       Requires_Full_Index;
 
       declare
-         use Alire.Projects.Project_Description_Maps;
          Busy : Utils.Busy_Prompt := Utils.Busy_Activity ("Searching...");
       begin
-         for I in Alire.Projects.Descriptions.Iterate loop
+         for Crate of Alire.Index.All_Crates.all loop
             if Num_Arguments = 0 or else
-              Contains (To_Lower_Case (+Key (I)), Search) or else
-              Contains (To_Lower_Case (Element (I)), Search)
+              Contains (+Crate.Name, Search) or else
+              Contains (+Crate.Name, Search)
             then
                Found := Found + 1;
                Table.New_Row;
-               Table.Append (To_Lower_Case (+Key (I)));
-               Table.Append (Element (I));
+               Table.Append (+Crate.Name);
+               Table.Append (Crate.Description);
             end if;
             Busy.Step;
          end loop;

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -10,7 +10,6 @@ with Alr.Platform;
 with Alr.Root;
 
 with Semantic_Versioning.Extended;
-with Alire.Projects;
 
 package body Alr.Commands.Show is
 
@@ -145,7 +144,7 @@ package body Alr.Commands.Show is
          Put_Line ("layout: crate");
          Put_Line (Rel.To_YAML);
          Put_Line ("---");
-         Put_Line (Alire.Projects.Descriptions (Rel.Project));
+         Put_Line (Rel.Description);
          Put_Line (Rel.Notes);
       end;
    exception

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -388,7 +388,7 @@ package body Alr.Commands is
       Result  : Alire.Outcome;
       Indexes : Alire.Features.Index.Index_On_Disk_Set;
    begin
-      if not Alire.Index.Catalog.Is_Empty and then not Force_Reload then
+      if Alire.Index.Crate_Count /= 0 and then not Force_Reload then
          Trace.Detail ("Index already loaded, loading skipped");
          return;
       end if;


### PR DESCRIPTION
Before this patch, the index is exposed in the spec of `Alire.Index` and crate descriptions are exposed in `Alire.Projects`. Other crate properties are accessible only through one of its releases.

This patch improves the situation by unifying crates/releases in `Alire.Index`, moving data structures to the body and allowing their modification only through the subprograms in the spec.

Dead code from the old Ada index, no longer needed to add crates/releases to the index, is also removed in this patch, making things more straightforward.