### PR TITLE
Explicitly exclude png/pdf from eol detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,7 @@
 *.adc text eol=lf
 *.ads text eol=lf
 *.gpr text eol=lf
+
+# Mark some misidentified files as always binaries
+*.pdf -text
+*.png -text


### PR DESCRIPTION
Some of our files in doc/ are misdetected and mangled on checkout