### PR TITLE
Clarify logic and messages when `alr get`ting a system crate

### DIFF
--- a/testsuite/tests/get/system-unsupported/test.py
+++ b/testsuite/tests/get/system-unsupported/test.py
@@ -16,10 +16,11 @@ p = run_alr('get', '--non-interactive', '--only', 'make',
             complain_on_error=False, quiet=False)
 
 if distro_is_known():
-    assert_match(".*No system package for the requested crate was detected.*",
+    assert_match(".*No source release or system package available for the "
+                 "requested crate*",
                  p.out, flags=re.S)
 else:
-    assert_match(".*Unknown distribution: cannot use system package for.*",
+    assert_match(".*cannot use system packages in unknown distribution.*",
                  p.out, flags=re.S)
 
 

--- a/testsuite/tests/index/external-hint/test.py
+++ b/testsuite/tests/index/external-hint/test.py
@@ -17,10 +17,10 @@ import platform
 p = run_alr('get', 'crate', quiet=False, complain_on_error=False)
 
 if distro_is_known():
-    assert_match("Hint: This is a custom hint.*", p.out, flags=re.S)
+    assert_match(".*Hint: This is a custom hint.*", p.out, flags=re.S)
 else:
-    assert_eq('ERROR: Unknown distribution: cannot use system package '
-              'for  the requested crate\n'
+    assert_eq('ERROR: No source release indexed for the requested crate, and '
+              'cannot use system packages in unknown distribution\n'
               'ERROR: alr get unsuccessful\n',
               p.out)
 


### PR DESCRIPTION
No functional changes; a somewhat convoluted mess of nested ifs has been straightened in a sequence of tests removing most nesting. The textual info given to the user has been rephrased a bit.