### PR TITLE
Don't attempt to detect system packages in unknown distros

### DIFF
--- a/src/alire/alire-externals-from_system.adb
+++ b/src/alire/alire-externals-from_system.adb
@@ -38,6 +38,13 @@ package body Alire.Externals.From_System is
    is
       package System renames Origins.Deployers.System;
    begin
+      --  No need to look for anything if the distro is unknown:
+      if not Platform.Distribution_Is_Known then
+         Trace.Detail ("Cannot look for system packages for crate " & (+Name)
+                       & "in unknown distribution");
+         return Containers.Release_Sets.Empty_Set;
+      end if;
+
       Trace.Detail ("Looking for system packages that provide crate "
                     & (+Name));
       return Releases : Containers.Release_Set do

--- a/src/alire/alire-externals-from_system.ads
+++ b/src/alire/alire-externals-from_system.ads
@@ -48,7 +48,7 @@ private
    end record;
 
    function System_Candidates (This   : External;
-                               Distro : Platforms.Distributions)
+                               Distro : Platforms.Known_Distributions)
                                return Package_Vector
    is
      (if This.Origin.Is_Case


### PR DESCRIPTION
Fixes a bug uncovered by alire-crates-ci nightly CI.
Fixes #337.