### PR TITLE
Fix spurious warnings on MacOS

### DIFF
--- a/alire.gpr
+++ b/alire.gpr
@@ -15,8 +15,8 @@ library project Alire is
 
    case Alire_Common.Host_Os is
       when "windows" => Src_Dirs := Src_Dirs & ("src/alire/os_windows");
-      when "osx"     => Src_Dirs := Src_Dirs & ("src/alire/os_macos");
-      when others    => Src_Dirs := Src_Dirs & ("src/alire/os_linux");
+      when "macos"   => Src_Dirs := Src_Dirs & ("src/alire/os_macos");
+      when "linux"   => Src_Dirs := Src_Dirs & ("src/alire/os_linux");
    end case;
 
    for Source_Dirs use Src_Dirs;

--- a/alire_common.gpr
+++ b/alire_common.gpr
@@ -2,8 +2,10 @@ abstract project Alire_Common is
 
    for Create_Missing_Dirs use "True";
 
-   Host_OS := external ("ALIRE_OS", "default");
-   --  Defined in alr_env.gpr.
+   type Any_OS is ("linux", "macos", "windows");
+
+   Host_OS : Any_OS := external ("ALIRE_OS");
+   --  Defined in alr_env.gpr. Mandatory.
 
    type Any_Build_Mode is ("debug", "release");
    Build_Mode : Any_Build_Mode := external ("ALIRE_BUILD_MODE", "debug");

--- a/alr.gpr
+++ b/alr.gpr
@@ -13,8 +13,8 @@ project Alr is
 
    case Alire_Common.Host_Os is
       when "windows" => Src_Dirs := Src_Dirs & ("src/alr/os_windows");
-      when "osx"     => Src_Dirs := Src_Dirs & ("src/alr/os_macos");
-      when others    => Src_Dirs := Src_Dirs & ("src/alr/os_linux");
+      when "macos"   => Src_Dirs := Src_Dirs & ("src/alr/os_macos");
+      when "linux"   => Src_Dirs := Src_Dirs & ("src/alr/os_linux");
    end case;
 
    for Source_Dirs use Src_Dirs;

--- a/alr_env.gpr
+++ b/alr_env.gpr
@@ -18,24 +18,19 @@ aggregate project Alr_Env is
    for External ("LIBRARY_TYPE") use "static";
    for External ("BUILD") use "DEBUG";
 
-   Host_OS := external ("OS", "default");
-   --  On Windows an OS environment variable is defined, we can use it to
-   --  determine if we are compiling on Windows.
-   --
-   --  On macOS, the nearest equivalent is OSTYPE; however this is
-   --  e.g. "darwin18", so not useful here. Set "macOS" by hand.
+   type Any_OS is ("linux", "macos", "windows");
+   --  The three supported host OSs
+
+   Host_OS : Any_OS := external ("ALIRE_OS", "linux");
 
    --  ALIRE_OS is used in alire_common.gpr.
    --  GNATCOLL_OS is used in gnatcoll.gpr.
    case Host_OS is
-      when "Windows_NT" =>
-         for External ("ALIRE_OS") use "windows";
+      when "windows" =>
          for External ("GNATCOLL_OS") use "windows";
-      when "macOS"      =>
-         for External ("ALIRE_OS") use "osx";
+      when "macos"   =>
          for External ("GNATCOLL_OS") use "osx";
-      when others       =>
-         for External ("ALIRE_OS") use "unix";
+      when "linux"  =>
          for External ("GNATCOLL_OS") use "unix";
    end case;
 end Alr_Env;

--- a/dev/devbuild.sh
+++ b/dev/devbuild.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
+case $OSTYPE in
+   linux*)  export ALIRE_OS=linux;;
+   msys)    export ALIRE_OS=windows;;
+   darwin*) export ALIRE_OS=macos;;
+   *)       echo Unsupported host OS: OSTYPE=$OSTYPE; exit 1;;
+esac
+
 gprbuild -j0 -r -p -P `dirname $0`/../alr_env.gpr

--- a/scripts/ci-github.sh
+++ b/scripts/ci-github.sh
@@ -8,23 +8,33 @@ set -o nounset
 
 export PATH+=:${PWD}/bin
 
-# For Darwin, have to define OS=macOS for alr_env.gpr
-# Windows defines it anyway
-# Linux (undefined) selects the default
-
-[ `uname -s` == "Darwin" ] && export OS=macOS
-
-# Build alr
-gprbuild -j0 -p -P alr_env
 
 # For the record
 echo ENVIRONMENT:
-env | sort
+set | sort
 echo ............................
 
 echo GNAT VERSION:
 gnatls -v
 echo ............................
+
+echo GCC VERSION/MACHINE
+gcc -v
+gcc -dumpmachine
+echo ............................
+
+# Build alr
+case $OSTYPE in
+   linux-gnu) export ALIRE_OS=linux;;
+   msys)      export ALIRE_OS=windows;;
+   darwin*)   export ALIRE_OS=macos;;
+   *)
+      echo Unsupported host OS: OSTYPE=$OSTYPE
+      exit 1;;
+esac
+
+echo Building with ALIRE_OS=$ALIRE_OS ...
+gprbuild -j0 -p -P alr_env
 
 echo ALR VERSION:
 alr version

--- a/testsuite/tests/run/no-spurious-warning/test.py
+++ b/testsuite/tests/run/no-spurious-warning/test.py
@@ -1,0 +1,25 @@
+"""
+Test that no warning about /etc/os-release is ever emitted
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq
+from drivers.helpers import compare, contents
+
+from glob import glob
+
+from os import chdir
+
+# Create a new working release
+p = run_alr('init', '--bin', 'xxx')
+assert_eq('', p.out)
+
+chdir(glob('xxx*')[0])
+
+# Should not emit the warning about missing '/etc/os-release'
+p = run_alr('run', '--list',
+            quiet=False)
+assert_eq(p.out.find('/etc/os-release'), -1)
+
+
+print('SUCCESS')

--- a/testsuite/tests/run/no-spurious-warning/test.yaml
+++ b/testsuite/tests/run/no-spurious-warning/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    basic_index:
+        in_fixtures: true


### PR DESCRIPTION
For some unclear reason the body of `alr-platforms-linux.adb` seemed to be in use when compiling for MacOS instead of the proper one, causing #329.

We relied on both OS and ALIRE_OS to select the host OS. Each of these used different names for each OS. Furthermore, we needed to explicitly set OS in MacOS but not in other OS. I think the bug was caused by some mix-up with these two variables.

With this patch, one must explicitly set ALIRE_OS only, which defaults to `linux` (as before). The project files now use a typed enumeration instead of a free-form value. The build scripts have been updated to match.

Fixes #329.

- [x] Test pending