### PR TITLE
New --docker switch for `alr test` to containerize release builds

### DIFF
--- a/src/alire/alire-defaults.ads
+++ b/src/alire/alire-defaults.ads
@@ -3,6 +3,9 @@ package Alire.Defaults with Preelaborate is
    Description : constant String := "Shiny new project";
    --  TODO: replace this constant with a function that returns random fortunes
 
+   Docker_Test_Image : constant String := "alire/gnat:debian-stable";
+   --  Docker image to be used with `alr test --docker` unless overriden
+
    Maintainer  : constant String := "your@email.here";
 
    Maintainer_Login : constant String := "github-username";

--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -1,3 +1,5 @@
+with Ada.Command_Line;
+
 with Ada.Streams.Stream_IO;
 with Ada.Strings.Maps;
 
@@ -48,6 +50,23 @@ package body Alire.Utils is
          end return;
       end if;
    end Append_To_Last_Line;
+
+   ---------------------------
+   -- Command_Line_Contains --
+   ---------------------------
+
+   function Command_Line_Contains (Prefix : String) return Boolean is
+   begin
+      for I in 1 .. Ada.Command_Line.Argument_Count loop
+         if Starts_With (Full_String => Ada.Command_Line.Argument (I),
+                         Substring   => Prefix)
+         then
+            return True;
+         end if;
+      end loop;
+
+      return False;
+   end Command_Line_Contains;
 
    --------------
    -- Contains --

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -7,6 +7,13 @@ private with Ada.Strings.Fixed;
 
 package Alire.Utils with Preelaborate is
 
+   function Command_Line_Contains (Prefix : String) return Boolean;
+   --  Say if any of the command-line arguments begins with Prefix. This is
+   --  needed for string arguments, that even when not supplied are initialized
+   --  to an empty string by GNAT.Command_Line. Thus, it is impossible to
+   --  distinguish by the switch value alone if the switch has been given
+   --  without an optional argument, or not given at all.
+
    function Could_Be_An_Email (Str       : String;
                                With_Name : Boolean) return Boolean;
    --  Minimally check that a string could be an email. Since well-formed

--- a/src/alr/alr-commands-test.ads
+++ b/src/alr/alr-commands-test.ads
@@ -1,3 +1,5 @@
+with GNAT.Strings;
+
 package Alr.Commands.Test is
 
    type Command is new Commands.Command with private;
@@ -26,6 +28,7 @@ private
 
    type Command is new Commands.Command with record
       Cont   : aliased Boolean := False;
+      Docker : aliased GNAT.Strings.String_Access;
       Full   : aliased Boolean := False;
       Last   : aliased Boolean := False;
       Redo   : aliased Boolean := False;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -32,7 +32,6 @@ with Alr.Commands.Update;
 with Alr.Commands.Version;
 with Alr.Commands.Withing;
 with Alr.Commands.Setenv;
-with Alr.Platform;
 with Alr.Root;
 
 with GNAT.Command_Line.Extra;
@@ -207,8 +206,7 @@ package body Alr.Commands is
    procedure Create_Alire_Folders is
       use GNATCOLL.VFS;
    begin
-      Make_Dir (Create (+Platform.Config_Folder));
-      Make_Dir (Create (+Platform.Cache_Folder));
+      Make_Dir (Create (+Alire.Config.Path));
    end Create_Alire_Folders;
 
    -------------------


### PR DESCRIPTION
With this switch, the actual build of the tested releases can be optionally done inside a docker container. May come in handy in the future for the publishing workflow.

Implements #43.

Does *not* implement #161, since the index look-up of candidates is still done in the host context.