### PR TITLE
Show origin kind of dependencies in alr show

### DIFF
--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -73,12 +73,21 @@ package body Alr.Commands.Show is
                      Needed.Releases.Delete (Rel.Name);
                   end if;
 
-                  --  Show regular dependencies in solution
+                  --  Show regular dependencies in solution. When requested,
+                  --  show also their origin kind.This is useful for crate
+                  --  testing to let us know that we need to update system
+                  --  repositories. It also raises awareness about the
+                  --  provenance of sources.
 
                   if not Needed.Releases.Is_Empty then
                      Put_Line ("Dependencies (solution):");
                      for Rel of Needed.Releases loop
-                        Put_Line ("   " & Rel.Milestone.Image);
+                        Put_Line ("   " & Rel.Milestone.Image
+                                  & (if Cmd.Detail
+                                    then " (origin: "
+                                         & Utils.To_Lower_Case
+                                             (Rel.Origin.Kind'Img) & ")"
+                                    else ""));
                      end loop;
                   end if;
 
@@ -318,6 +327,11 @@ package body Alr.Commands.Show is
    is
       use GNAT.Command_Line;
    begin
+      Define_Switch (Config,
+                     Cmd.Detail'Access,
+                     "", "--detail",
+                     "Show additional details about dependencies");
+
       Define_Switch (Config,
                      Cmd.Detect'Access,
                      "", "--external-detect",

--- a/src/alr/alr-commands-show.ads
+++ b/src/alr/alr-commands-show.ads
@@ -21,6 +21,7 @@ package Alr.Commands.Show is
 private
 
    type Command is new Commands.Command with record
+      Detail   : aliased Boolean := False;
       Detect   : aliased Boolean := False;
       External : aliased Boolean := False;
       Solve    : aliased Boolean := False;


### PR DESCRIPTION
This is optionally available through the new --detail switch. With this, when doing e.g. `alr show <crate> --solve --detail` you can know the kind of every dependency in the solution. Will come in handy for crate testing (to signal that system repositories may require an update) and may be useful in general to know if a build is purely from sources or not.