### PR TITLE
Fix bug where only the first added dependency is recorded

### DIFF
--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -47,8 +47,8 @@ package body Alr.Commands.Withing is
             Trace.Info
               ("Not adding " & (+Requested.Crate)
                & " because " & Dep.Image & " is already a dependency");
+            return Deps;
          end if;
-         return Deps;
       end loop;
 
       --  Merge the dependency and ensure there is a solution

--- a/testsuite/tests/with/add-several/test.py
+++ b/testsuite/tests/with/add-several/test.py
@@ -1,0 +1,26 @@
+"""
+Verify that more than one dependency can be added
+"""
+
+import os
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+
+import re
+
+# Initialize a project, enter it and two dependencies
+
+p = run_alr('init', '--bin', 'xxx')
+os.chdir('xxx')
+p = run_alr('with', 'libhello')
+p = run_alr('with', 'hello')
+p = run_alr('show')
+
+assert_match('.*\n'
+             'Dependencies \(direct\):\n'
+             '   hello\*\n'
+             '   libhello\*\n',
+             p.out, flags=re.S)
+
+print('SUCCESS')

--- a/testsuite/tests/with/add-several/test.yaml
+++ b/testsuite/tests/with/add-several/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
This was recently introduced with #342. I've added a test for this situation.