### PR TITLE
Bugfix: don't clear exception error before re-raise

### DIFF
--- a/src/alire/alire-origins-deployers-source_archive.adb
+++ b/src/alire/alire-origins-deployers-source_archive.adb
@@ -80,7 +80,7 @@ package body Alire.Origins.Deployers.Source_Archive is
 
    exception
       when E : Checked_Error =>
-         Trace.Debug ("tar failed: " & Errors.Get (E));
+         Trace.Warning ("tar failed: " & Errors.Get (E, Clear => False));
 
          --  Reraise current occurence
          raise;


### PR DESCRIPTION
When an exception is still live, its stored error should be preserved for the next catcher. Otherwise, retrieving the error later will itself raise, and mask the original error.

Also emit the `tar` error, since things are going downhill from there.

Actually, since `alr` is not intended for long-term operation and once errors occur the end is near, we could dispense entirely with the error clearing machinery, and get rid of this kind of bugs forever. I think that would be a better solution. Thoughts?