### PR TITLE
Refactor for expected error exit codes

### DIFF
--- a/src/alire/alire-origins-deployers-system-apt.adb
+++ b/src/alire/alire-origins-deployers-system-apt.adb
@@ -14,18 +14,17 @@ package body Alire.Origins.Deployers.System.Apt is
 
    overriding function Already_Installed (This : Deployer) return Boolean
    is
-      Output : Utils.String_Vector;
-   begin
 
       --  The following call is faster than using apt and the output does not
       --  depend on the system locale, so we can check the Status line safely.
 
-      Subprocess.Checked_Spawn_And_Capture
+      Output : constant Utils.String_Vector :=
+                 Subprocess.Checked_Spawn_And_Capture
                    ("dpkg",
                     Empty_Vector & "-s" & This.Base.Package_Name,
-                    Output,
-                    Err_To_Out => True);
-
+                    Valid_Exit_Codes => (0, 1), -- returned when not found
+                    Err_To_Out       => True);
+   begin
       for Line of Output loop
          if Line = "Status: install ok installed" then
             return True;
@@ -33,10 +32,6 @@ package body Alire.Origins.Deployers.System.Apt is
       end loop;
 
       return False;
-   exception
-      when Checked_Error =>
-         --  This is normal for packages not installed:
-         return False;
    end Already_Installed;
 
    ------------
@@ -53,20 +48,19 @@ package body Alire.Origins.Deployers.System.Apt is
       --  The show command of apt-cache is locale independent, so we can check
       --  the Version: field safely.
 
-      Output : Utils.String_Vector;
+      Output    : constant Utils.String_Vector :=
+                    Subprocess.Checked_Spawn_And_Capture
+                      ("apt-cache",
+                       Empty_Vector &
+                         "-q" &
+                         "show" &
+                         This.Base.Package_Name,
+                       Valid_Exit_Codes => (0, 100), -- Returned when not found
+                       Err_To_Out       => True);
 
       use GNAT.Regpat;
       Matches : Match_Array (1 .. 1);
    begin
-      Subprocess.Checked_Spawn_And_Capture
-                   ("apt-cache",
-                    Empty_Vector &
-                      "-q" &
-                      "show" &
-                      This.Base.Package_Name,
-                    Output,
-                    Err_To_Out => True);
-
       for Line of Output loop
          if Contains (Line, "Version:") then
             Trace.Debug ("Extracting native version from apt output: " & Line);
@@ -89,10 +83,6 @@ package body Alire.Origins.Deployers.System.Apt is
       end loop;
 
       return Version_Outcomes.Outcome_Failure ("could not be detected");
-   exception
-      when Checked_Error =>
-         --  Expected for package names not in the system
-         return Version_Outcomes.Outcome_Failure ("does not exist in system");
    end Detect;
 
    -------------

--- a/src/alire/alire-os_lib-subprocess.ads
+++ b/src/alire/alire-os_lib-subprocess.ads
@@ -13,21 +13,25 @@ package Alire.OS_Lib.Subprocess is
       Understands_Verbose : Boolean := False);
    --  Either suceeds or raises Checked_Error with the code and output as info.
 
+   type Code_Array is array (Positive range <>) of Integer;
+   --  An array of exit codes that won't cause the following calls to raise
+
    function Checked_Spawn_And_Capture
      (Command             : String;
       Arguments           : Utils.String_Vector;
       Understands_Verbose : Boolean := False;
-      Err_To_Out          : Boolean := False) return Utils.String_Vector;
+      Err_To_Out          : Boolean := False;
+      Valid_Exit_Codes    : Code_Array := (1 => 0)) return Utils.String_Vector;
    --  Either suceeds or raises Checked_Error with the code and output as info.
-   --  Output is captured and returned on success.
+   --  Output is captured and returned on success. The exit code is checked
+   --  against the Valid_Exit_Codes.
 
-   procedure Checked_Spawn_And_Capture
+   function Unchecked_Spawn_And_Capture
      (Command             : String;
       Arguments           : Utils.String_Vector;
       Output              : in out Utils.String_Vector;
       Understands_Verbose : Boolean := False;
-      Err_To_Out          : Boolean := False);
-   --  Either suceeds or raises Checked_Error with the code and output as info.
-   --  Output is captured and returned up to completion/failure.
+      Err_To_Out          : Boolean := False) return Integer;
+   --  Returns the output and exit code of the spawned command
 
 end Alire.OS_Lib.Subprocess;

--- a/src/alire/os_windows/alire-platform.adb
+++ b/src/alire/os_windows/alire-platform.adb
@@ -22,9 +22,8 @@ package body Alire.Platform is
       declare
          Unused : Utils.String_Vector;
       begin
-         OS_Lib.Subprocess.Checked_Spawn_And_Capture
+         Unused := OS_Lib.Subprocess.Checked_Spawn_And_Capture
            ("pacman", Utils.Empty_Vector & ("-V"),
-            Unused,
             Err_To_Out => True);
          return True;
       exception when others =>

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -116,9 +116,10 @@ package body Alr.Commands.Test is
                          "-n" &
                          R.Milestone.Image;
 
+            Exit_Code : Integer;
          begin
             if Alire.Utils.Command_Line_Contains (Docker_Switch) then
-               Checked_Spawn_And_Capture
+               Exit_Code := Unchecked_Spawn_And_Capture
                  ("sudo",
                   Empty_Vector
                   & "docker"
@@ -137,11 +138,15 @@ package body Alr.Commands.Test is
                   Output,
                   Err_To_Out => True);
             else
-               Checked_Spawn_And_Capture
+               Exit_Code := Unchecked_Spawn_And_Capture
                  ("alr",
                   Alr_Args,
                   Output,
                   Err_To_Out => True);
+            end if;
+
+            if Exit_Code /= 0 then
+               raise Child_Failed;
             end if;
          end Build_Release;
 
@@ -318,13 +323,14 @@ package body Alr.Commands.Test is
          use Alire.OS_Lib.Subprocess;
          use Alire.Utils;
 
-         Output : String_Vector;
+         Output    : String_Vector;
+         Exit_Code : Integer;
       begin
          if Alire.Utils.Command_Line_Contains (Docker_Switch) then
 
             Trace.Info ("Running builds in docker image: " & Docker_Image);
 
-            Checked_Spawn_And_Capture
+            Exit_Code := Unchecked_Spawn_And_Capture
               ("sudo",
                Empty_Vector
                & "docker"
@@ -332,14 +338,14 @@ package body Alr.Commands.Test is
                & Docker_Image,
                Output,
                Err_To_Out => True);
-         end if;
 
-      exception
-         when Alire.Checked_Error =>
-            Reportaise_Command_Failed
-              ("Failed to pull docker image " & Docker_Image
-               & " with output: "
-               & Output.Flatten (Separator => "" & ASCII.LF));
+            if Exit_Code /= 0 then
+               Reportaise_Command_Failed
+                 ("Failed to pull docker image " & Docker_Image
+                  & " with output: "
+                  & Output.Flatten (Separator => "" & ASCII.LF));
+            end if;
+         end if;
       end Pull_Docker;
 
    begin


### PR DESCRIPTION
There was a check missing in pacman that caused `alr show` to fail when the external is unavailable. I refactored both apt and pacman detection to be more robust since we know the expected exit codes.

Additionally I discovered via ARM 6.4.1(17) that one cannot rely on output parameters passed by value, so I refactored a bit the Alire.Subprocess available calls for when we need both output and code.