### PR TITLE
Ensure the checkout folder is deleted on failure

### DIFF
--- a/src/alr/alr-checkout.adb
+++ b/src/alr/alr-checkout.adb
@@ -61,10 +61,6 @@ package body Alr.Checkout is
    -- To_Folder --
    ---------------
 
-   ---------------
-   -- To_Folder --
-   ---------------
-
    procedure To_Folder (Solution : Query.Solution;
                         Parent   : String := Paths.Dependencies_Folder)
    is


### PR DESCRIPTION
Also: clean up ~a wrong comment (the ability to retrieve not the latest release but one in a version set already exists) and~ a duplicated index lookup (looks like it was mistakenly left there during previous changes).

Deployer machinery already is doing cleanup in case of failure during deployment. This fix covers the case of failures after deployment (during file generation or other unforeseen circumstance).

Fixes #359 