### PR TITLE
Rely on lockfile for `alr show` of local crate

### DIFF
--- a/src/alr/alr-commands-search.adb
+++ b/src/alr/alr-commands-search.adb
@@ -29,7 +29,7 @@ package body Alr.Commands.Search is
       ------------------
 
       procedure List_Release (R : Alire.Releases.Release) is
-         package Solver renames Alire.Solver; use Solver;
+         package Solver renames Alire.Solver;
       begin
          if (Cmd.Prop.all = ""
              or else
@@ -53,8 +53,8 @@ package body Alr.Commands.Search is
                          (R.Dependencies (Platform.Properties),
                           Platform.Properties,
                           Options => (Age       => Query_Policy,
-                                      Detecting => Dont_Detect,
-                                      Hinting   => Hint))
+                                      Detecting => Solver.Dont_Detect,
+                                      Hinting   => Solver.Hint))
                        then " "
                        else "X")));
             Tab.Append (Semantic_Versioning.Image (R.Version));

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -63,18 +63,17 @@ package body Alr.Commands.Show is
 
          if Cmd.Solve then
             declare
-               Needed  : Query.Solution :=
-                           Query.Resolve
-                             (Rel.To_Dependency,
+               Needed : constant Query.Solution :=
+                          (if Current
+                           then Root.Current.Solution
+                           else Query.Resolve
+                             (Rel.Dependencies (Platform.Properties),
                               Platform.Properties,
                               Options => (Age       => Query_Policy,
                                           Detecting => <>,
-                                          Hinting   => <>));
+                                          Hinting   => <>)));
             begin
                if Needed.Valid then
-                  if Needed.Releases.Contains (Rel.Name) then
-                     Needed.Releases.Delete (Rel.Name);
-                  end if;
 
                   --  Show regular dependencies in solution. When requested,
                   --  show also their origin kind.This is useful for crate
@@ -100,17 +99,23 @@ package body Alr.Commands.Show is
                      Put_Line ("Dependencies (external):");
                      for Dep of Needed.Hints loop
                         Put_Line ("   " & Dep.Image);
-                        for Hint of
-                          Alire.Index.Crate (Dep.Crate)
-                          .Externals.Hints
-                            (Name => Dep.Crate,
-                             Env  =>
-                               (if Cmd.System
-                                then Platform.Properties
-                                else Alire.Properties.No_Properties))
-                        loop
-                           Trace.Info ("      Hint: " & Hint);
-                        end loop;
+
+                        --  Look for hints. If we are relying on workspace
+                        --  information the index may not be loaded, or have
+                        --  changed, so we need to ensure the crate is indexed.
+                        if Alire.Index.Exists (Dep.Crate) then
+                           for Hint of
+                             Alire.Index.Crate (Dep.Crate)
+                             .Externals.Hints
+                               (Name => Dep.Crate,
+                                Env  =>
+                                  (if Cmd.System
+                                   then Platform.Properties
+                                   else Alire.Properties.No_Properties))
+                           loop
+                              Trace.Info ("      Hint: " & Hint);
+                           end loop;
+                        end if;
                      end loop;
                   end if;
 


### PR DESCRIPTION
This way we report the actual solution on disk and not the one calculated on the fly from root dependencies.

Only the last commit is new (this was originally part of PR #355, so it has already been reviewed).