### PR TITLE
Types to identify changes in dependencies/solutions

### DIFF
--- a/src/alire/alire-containers.adb
+++ b/src/alire/alire-containers.adb
@@ -79,6 +79,35 @@ package body Alire.Containers is
       end return;
    end Including;
 
+   -----------
+   -- Merge --
+   -----------
+
+   procedure Merge (This : in out Dependency_Map;
+                    Dep  :        Dependencies.Dependency)
+   is
+      use type Dependencies.Dependency;
+      use type Semantic_Versioning.Extended.Version_Set;
+   begin
+      if This.Contains (Dep.Crate) then
+         declare
+            Old : constant Dependencies.Dependency := This (Dep.Crate);
+         begin
+            if Old /= Dep then
+               --  Include should work to replace the dependency, but I'm
+               --  getting a tampering error using it (?)
+               This.Delete (Dep.Crate);
+               This.Insert (Dep.Crate,
+                            Dependencies.New_Dependency
+                              (Dep.Crate,
+                               Old.Versions and Dep.Versions));
+            end if;
+         end;
+      else
+         This.Insert (Dep.Crate, Dep);
+      end if;
+   end Merge;
+
    ---------------------
    -- To_Dependencies --
    ---------------------

--- a/src/alire/alire-containers.ads
+++ b/src/alire/alire-containers.ads
@@ -11,10 +11,25 @@ with Alire.Releases;
 
 package Alire.Containers with Preelaborate is
 
+   package Crate_Name_Sets is
+      new Ada.Containers.Indefinite_Ordered_Sets (Crate_Name);
+
    package Dependency_Lists
    is new Ada.Containers.Indefinite_Doubly_Linked_Lists
      (Dependencies.Dependency,
       Dependencies."=");
+
+   package Dependency_Maps
+   is new Ada.Containers.Indefinite_Ordered_Maps
+     (Crate_Name, Dependencies.Dependency,
+      "<", Dependencies."=");
+
+   type Dependency_Map is new Dependency_Maps.Map with null record;
+
+   procedure Merge (This : in out Dependency_Map;
+                    Dep  :        Dependencies.Dependency);
+   --  If the dependency is already in map, create a combined dependency that
+   --  ANDs both.
 
    package Milestone_Sets
    is new Ada.Containers.Indefinite_Ordered_Sets (Milestones.Milestone,

--- a/src/alire/alire-dependencies-containers.ads
+++ b/src/alire/alire-dependencies-containers.ads
@@ -5,4 +5,6 @@ package Alire.Dependencies.Containers with Preelaborate is
    package Lists is new
      Ada.Containers.Indefinite_Doubly_Linked_Lists (Dependency);
 
+   subtype List is Lists.List;
+
 end Alire.Dependencies.Containers;

--- a/src/alire/alire-dependencies-diffs.adb
+++ b/src/alire/alire-dependencies-diffs.adb
@@ -1,0 +1,79 @@
+with Alire.Utils.Tables;
+
+package body Alire.Dependencies.Diffs is
+
+   -------------
+   -- Between --
+   -------------
+
+   function Between (Former, Latter : Containers.Lists.List) return Diff is
+   begin
+      return This : Diff do
+
+         --  Identify new:
+
+         for Dep of Latter loop
+            if not (for some Old of Former => Dep = Old) then
+               This.Added.Append (Dep);
+            end if;
+         end loop;
+
+         --  Identify old:
+
+         for Dep of Former loop
+            if not (for some Novel of Latter => Dep = Novel) then
+               This.Removed.Append (Dep);
+            end if;
+         end loop;
+
+      end return;
+   end Between;
+
+   -------------
+   -- Between --
+   -------------
+
+   function Between (Former, Latter : Conditional.Dependencies) return Diff is
+     (Between (Conditional.Enumerate (Former),
+               Conditional.Enumerate (Latter)));
+
+   ----------------------
+   -- Contains_Changes --
+   ----------------------
+
+   function Contains_Changes (This : Diff) return Boolean is
+     (not (This.Added.Is_Empty and then This.Removed.Is_Empty));
+
+   -----------
+   -- Print --
+   -----------
+
+   procedure Print (This : Diff) is
+      Table : Utils.Tables.Table;
+
+      procedure Summarize (List    : Containers.Lists.List;
+                           Comment : String;
+                           Icon    : String)
+      is
+      begin
+         for Dep of List loop
+            Table
+              .Append ("   " & Icon)
+              .Append (+Dep.Crate)
+              .Append (Dep.Versions.Image)
+              .Append (Comment)
+              .New_Row;
+         end loop;
+      end Summarize;
+
+   begin
+      if This.Contains_Changes then
+         Summarize (This.Added,   "(added)",   "✓");
+         Summarize (This.Removed, "(removed)", "✗");
+         Table.Print (Info);
+      else
+         Trace.Info ("   No changes.");
+      end if;
+   end Print;
+
+end Alire.Dependencies.Diffs;

--- a/src/alire/alire-dependencies-diffs.ads
+++ b/src/alire/alire-dependencies-diffs.ads
@@ -1,0 +1,23 @@
+with Alire.Conditional;
+with Alire.Dependencies.Containers;
+
+package Alire.Dependencies.Diffs is
+
+   type Diff is tagged private;
+
+   function Between (Former, Latter : Conditional.Dependencies) return Diff;
+
+   function Between (Former, Latter : Containers.Lists.List) return Diff;
+
+   function Contains_Changes (This : Diff) return Boolean;
+
+   procedure Print (This : Diff);
+
+private
+
+   type Diff is tagged record
+      Added   : Containers.Lists.List;
+      Removed : Containers.Lists.List;
+   end record;
+
+end Alire.Dependencies.Diffs;

--- a/src/alire/alire-solutions-diffs.adb
+++ b/src/alire/alire-solutions-diffs.adb
@@ -1,0 +1,221 @@
+with Alire.Containers;
+with Alire.Utils.Tables;
+with Alire.Utils.User_Input;
+
+package body Alire.Solutions.Diffs is
+
+   use type Semantic_Versioning.Version;
+
+   ------------------
+   -- Best_Version --
+   ------------------
+
+   function Best_Version (Status : Crate_Status) return String is
+     (case Status.Status is
+         when Needed   => Semantic_Versioning.Image (Status.Version),
+         when Hinted   => Status.Versions.Image,
+         when Unneeded => "unneeded",
+         when Unsolved => "unsolved");
+
+   -------------
+   -- Between --
+   -------------
+
+   function Between (Former, Latter : Solution) return Diff is
+
+      use type Containers.Crate_Name_Sets.Set;
+
+      -----------------
+      -- Make_Status --
+      -----------------
+
+      function Make_Status (Crate : Crate_Name;
+                            Sol   : Solution) return Crate_Status is
+      begin
+         if not Sol.Valid then
+            return (Status => Unsolved);
+
+         elsif Sol.Releases.Contains (Crate) then
+            return (Status  => Needed,
+                    Version => Sol.Releases (Crate).Version);
+
+         elsif Sol.Hints.Contains (Crate) then
+            return (Status   => Hinted,
+                    Versions => Sol.Hints (Crate).Versions);
+
+         else
+            return (Status => Unneeded);
+
+         end if;
+      end Make_Status;
+
+      --  Get all involved crates, before and after
+
+      Crates : constant Containers.Crate_Name_Sets.Set :=
+                 Former.Required or Latter.Required;
+   begin
+      return This : Diff do
+
+         --  Solution validities
+
+         This.Former_Valid := Former.Valid;
+         This.Latter_Valid := Latter.Valid;
+
+         --  Store changes for each crate
+
+         for Crate of Crates loop
+            This.Changes.Insert (Crate,
+                                 Crate_Changes'
+                                   (Former => Make_Status (Crate, Former),
+                                    Latter => Make_Status (Crate, Latter)));
+         end loop;
+
+      end return;
+   end Between;
+
+   ------------
+   -- Change --
+   ------------
+
+   function Change (This : Diff; Crate : Crate_Name) return Changes is
+      Former : Crate_Status renames This.Changes (Crate).Former;
+      Latter : Crate_Status renames This.Changes (Crate).Latter;
+   begin
+      if Former.Status = Latter.Status then
+         return Unchanged;
+      end if;
+
+      return
+        (case Latter.Status is
+            when Needed =>
+              (if Former.Status = Needed then
+                 (if Former.Version < Latter.Version then Upgraded
+                  elsif Former.Version = Latter.Version then Unchanged
+                  else Downgraded)
+               else Added),
+            when Hinted   => External,
+            when Unneeded => Removed,
+            when Unsolved => Unsolved);
+   end Change;
+
+   ----------------------
+   -- Contains_Changes --
+   ----------------------
+
+   function Contains_Changes (This : Diff) return Boolean is
+     (This.Former_Valid /= This.Latter_Valid or else
+      (for some Change of This.Changes => Change.Former /= Change.Latter));
+
+   -----------
+   -- Print --
+   -----------
+
+   procedure Print (This         : Diff;
+                    Changed_Only : Boolean)
+   is
+      use Change_Maps;
+
+      package Semver renames Semantic_Versioning;
+
+      Table : Utils.Tables.Table;
+   begin
+      if not This.Latter_Valid then
+         Trace.Info ("   New solution is invalid.");
+      elsif This.Latter_Valid and then not This.Former_Valid then
+         Trace.Info ("   New solution is valid.");
+      end if;
+
+      --  Early exit if no changes
+
+      if not This.Contains_Changes then
+         Trace.Info ("   No changes between former an new solution.");
+         return;
+      end if;
+
+      --  Detailed changes otherwise
+
+      for I in This.Changes.Iterate loop
+         declare
+            Former : Crate_Status renames This.Changes (I).Former;
+            Latter : Crate_Status renames This.Changes (I).Latter;
+         begin
+            if not Changed_Only or else Former /= Latter then
+
+               --  Show icon of change
+
+               Table.Append
+                 ("   "
+                  & (case This.Change (Key (I)) is
+                       when Added      => "✓",
+                       when Removed    => "✗",
+                       when External   => "↪",
+                       when Upgraded   => "⭧",
+                       when Downgraded => "⭨",
+                       when Unchanged  => "=",
+                       when Unsolved   => "⚠"));
+
+               --  Always show crate name
+
+               Table.Append (+Key (I));
+
+               --  Show most precise version available
+
+               if Latter.Status in Hinted | Needed then
+                  Table.Append (Best_Version (Latter));
+               else
+                  Table.Append (Best_Version (Former));
+               end if;
+
+               --  Finally show an explanation of the change depending on
+               --  status changes.
+
+               Table.Append
+                 ("("
+                  & (case This.Change (Key (I)) is
+                       when Added      => "new",
+                       when Removed    => "removed",
+                       when External   => "external",
+                       when Upgraded   => "upgraded from "
+                                          & Semver.Image (Former.Version),
+                       when Downgraded => "downgraded from "
+                                          & Semver.Image (Former.Version),
+                       when Unchanged  => "unchanged",
+                       when Unsolved   => "missing")
+                  & ")");
+
+               Table.New_Row;
+            end if;
+         end;
+      end loop;
+
+      Table.Print (Level => Info);
+   end Print;
+
+   -----------------------
+   -- Print_And_Confirm --
+   -----------------------
+
+   function Print_And_Confirm
+     (This         : Diff;
+      Changed_Only : Boolean)
+      return Boolean
+   is
+      use Utils.User_Input;
+   begin
+      if This.Contains_Changes then
+         Trace.Info ("Changes to dependency solution:");
+         Trace.Info ("");
+         This.Print (Changed_Only => Changed_Only);
+         Trace.Info ("");
+      else
+         Trace.Info
+           ("There are no changes between the former and new solution.");
+      end if;
+
+      return Utils.User_Input.Query
+        (Question => "Do you want to proceed?",
+         Valid    => (Yes | No => True, others => False),
+         Default  => Yes) = Yes;
+   end Print_And_Confirm;
+
+end Alire.Solutions.Diffs;

--- a/src/alire/alire-solutions-diffs.adb
+++ b/src/alire/alire-solutions-diffs.adb
@@ -1,6 +1,5 @@
 with Alire.Containers;
 with Alire.Utils.Tables;
-with Alire.Utils.User_Input;
 
 package body Alire.Solutions.Diffs is
 
@@ -111,7 +110,9 @@ package body Alire.Solutions.Diffs is
    -----------
 
    procedure Print (This         : Diff;
-                    Changed_Only : Boolean)
+                    Changed_Only : Boolean;
+                    Prefix       : String       := "   ";
+                    Level        : Trace.Levels := Trace.Info)
    is
       use Change_Maps;
 
@@ -119,16 +120,22 @@ package body Alire.Solutions.Diffs is
 
       Table : Utils.Tables.Table;
    begin
+
+      --  Start with an empty line to separate from previous output
+
+      Trace.Log ("", Level);
+
       if not This.Latter_Valid then
-         Trace.Info ("   New solution is invalid.");
+         Trace.Log (Prefix & "New solution is invalid.", Level);
       elsif This.Latter_Valid and then not This.Former_Valid then
-         Trace.Info ("   New solution is valid.");
+         Trace.Log (Prefix & "New solution is valid.", Level);
       end if;
 
       --  Early exit if no changes
 
       if not This.Contains_Changes then
-         Trace.Info ("   No changes between former an new solution.");
+         Trace.Log (Prefix & "No changes between former an new solution.",
+                    Level);
          return;
       end if;
 
@@ -144,7 +151,7 @@ package body Alire.Solutions.Diffs is
                --  Show icon of change
 
                Table.Append
-                 ("   "
+                 (Prefix
                   & (case This.Change (Key (I)) is
                        when Added      => "✓",
                        when Removed    => "✗",
@@ -188,34 +195,7 @@ package body Alire.Solutions.Diffs is
          end;
       end loop;
 
-      Table.Print (Level => Info);
+      Table.Print (Level);
    end Print;
-
-   -----------------------
-   -- Print_And_Confirm --
-   -----------------------
-
-   function Print_And_Confirm
-     (This         : Diff;
-      Changed_Only : Boolean)
-      return Boolean
-   is
-      use Utils.User_Input;
-   begin
-      if This.Contains_Changes then
-         Trace.Info ("Changes to dependency solution:");
-         Trace.Info ("");
-         This.Print (Changed_Only => Changed_Only);
-         Trace.Info ("");
-      else
-         Trace.Info
-           ("There are no changes between the former and new solution.");
-      end if;
-
-      return Utils.User_Input.Query
-        (Question => "Do you want to proceed?",
-         Valid    => (Yes | No => True, others => False),
-         Default  => Yes) = Yes;
-   end Print_And_Confirm;
 
 end Alire.Solutions.Diffs;

--- a/src/alire/alire-solutions-diffs.ads
+++ b/src/alire/alire-solutions-diffs.ads
@@ -27,15 +27,11 @@ package Alire.Solutions.Diffs is
    --  Says if there are, in fact, changes between both solutions
 
    procedure Print (This         : Diff;
-                    Changed_Only : Boolean);
-   --  Print a summary of changes between two solutions
-
-   function Print_And_Confirm
-     (This           : Diff;
-      Changed_Only   : Boolean)
-      return Boolean;
-   --  Present a summary of changes and ask the user for confirmation. Returns
-   --  True when the user answers positively.
+                    Changed_Only : Boolean;
+                    Prefix       : String       := "   ";
+                    Level        : Trace.Levels := Trace.Info);
+   --  Print a summary of changes between two solutions. Prefix is prepended to
+   --  every line.
 
 private
 

--- a/src/alire/alire-solutions-diffs.ads
+++ b/src/alire/alire-solutions-diffs.ads
@@ -1,0 +1,76 @@
+with Semantic_Versioning.Extended;
+
+private with Ada.Containers.Indefinite_Ordered_Maps;
+
+package Alire.Solutions.Diffs is
+
+   type Changes is
+     (Added,      -- A new release
+      Removed,    -- A removed dependency of any kind
+      External,   -- A new external dependency
+      Upgraded,   -- An upgraded release
+      Downgraded, -- A downgraded release
+      Unchanged,  -- An unchanged dependency/release
+      Unsolved    -- A missing dependency
+     );
+
+   type Diff is tagged private;
+   --  Encapsulates the differences between two solutions
+
+   function Between (Former, Latter : Solution) return Diff;
+   --  Create a Diff from two solutions
+
+   function Change (This : Diff; Crate : Crate_Name) return Changes;
+   --  Summary of what happened with a crate
+
+   function Contains_Changes (This : Diff) return Boolean;
+   --  Says if there are, in fact, changes between both solutions
+
+   procedure Print (This         : Diff;
+                    Changed_Only : Boolean);
+   --  Print a summary of changes between two solutions
+
+   function Print_And_Confirm
+     (This           : Diff;
+      Changed_Only   : Boolean)
+      return Boolean;
+   --  Present a summary of changes and ask the user for confirmation. Returns
+   --  True when the user answers positively.
+
+private
+
+   type Install_Status is (Unsolved, Unneeded, Hinted, Needed);
+   --  Unsolved will apply to all crates when a solution is invalid. TODO: when
+   --  reasons for solving failure are tracked, improve the diff output.
+
+   type Crate_Status (Status : Install_Status := Unneeded) is record
+      case Status is
+         when Needed =>
+            Version  : Semantic_Versioning.Version;
+         when Hinted =>
+            Versions : Semantic_Versioning.Extended.Version_Set;
+         when Unneeded | Unsolved =>
+            null;
+      end case;
+   end record;
+
+   function Best_Version (Status : Crate_Status) return String;
+   --  Used to provide the most precise version available depending on the
+   --  crate status.
+
+   type Crate_Changes is record
+      Former, Latter : Crate_Status := (Status => Unneeded);
+   end record;
+
+   package Change_Maps is new Ada.Containers.Indefinite_Ordered_Maps
+     (Crate_Name, Crate_Changes);
+
+   type Diff is tagged record
+      Former_Valid,
+      Latter_Valid   : Boolean := False;
+      --  Empty solutions but with different validity still count as changes.
+
+      Changes        : Change_Maps.Map;
+   end record;
+
+end Alire.Solutions.Diffs;

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -1,8 +1,39 @@
 with Alire.Crates.With_Releases;
 with Alire.Dependencies;
 with Alire.Releases;
+with Alire.Solutions.Diffs;
 
 package body Alire.Solutions is
+
+   -------------
+   -- Changes --
+   -------------
+
+   function Changes (Former, Latter : Solution) return Diffs.Diff is
+     (Diffs.Between (Former, Latter));
+
+   --------------
+   -- Required --
+   --------------
+
+   function Required (This : Solution) return Containers.Crate_Name_Sets.Set is
+   begin
+      if not This.Valid then
+         return Containers.Crate_Name_Sets.Empty_Set;
+      end if;
+
+      --  Merge release and hint crates
+
+      return Set : Containers.Crate_Name_Sets.Set do
+         for Dep of This.Hints loop
+            Set.Include (Dep.Crate);
+         end loop;
+
+         for Rel of This.Releases loop
+            Set.Include (Rel.Name);
+         end loop;
+      end return;
+   end Required;
 
    ----------
    -- Keys --
@@ -117,7 +148,7 @@ package body Alire.Solutions is
       begin
          if Has_Externals then -- It's a table containing dependencies
             for I in 1 .. Externals.Keys'Length loop
-               This.Hints.Append
+               This.Hints.Merge
                  (Dependencies.From_TOML
                     (Key   => +Externals.Keys (I),
                      Value => Externals.Get (Externals.Keys (I))));

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -3,6 +3,8 @@ with Alire.Interfaces;
 with Alire.Properties;
 with Alire.TOML_Adapters;
 
+limited with Alire.Solutions.Diffs;
+
 with TOML;
 
 package Alire.Solutions is
@@ -10,7 +12,7 @@ package Alire.Solutions is
    --  A solutions is a set of releases + externals that fulfills the
    --  transitive dependencies of the root crate.
 
-   subtype Dependency_List is Alire.Containers.Dependency_Lists.List;
+   subtype Dependency_Map is Alire.Containers.Dependency_Map;
 
    subtype Release_Map is Alire.Containers.Release_Map;
 
@@ -22,7 +24,7 @@ package Alire.Solutions is
             Releases : Release_Map;
             --  Resolved dependencies to be deployed
 
-            Hints    : Dependency_List;
+            Hints    : Dependency_Map;
             --  Unresolved external dependencies
 
          when False =>
@@ -32,6 +34,14 @@ package Alire.Solutions is
 
    Invalid_Solution     : constant Solution;
    Empty_Valid_Solution : constant Solution;
+
+   function Changes (Former, Latter : Solution) return Diffs.Diff;
+
+   function Required (This : Solution) return Containers.Crate_Name_Sets.Set;
+   --  Retrieve all required crates in the solution, no matter if they have
+   --  known releases or only hints. Will return an empty set for invalid
+   --  solutions. TODO: when we track reasons for solving failure, return
+   --  the required crates with their reason for non-solvability.
 
    function From_TOML (From : TOML_Adapters.Key_Queue)
                        return Solution;

--- a/src/alire/alire-solver.adb
+++ b/src/alire/alire-solver.adb
@@ -17,28 +17,26 @@ package body Alire.Solver is
 
    use all type Semver.Extended.Version_Set;
 
-   subtype Dependency_List is Solutions.Dependency_List;
+   subtype Dependency_Map is Solutions.Dependency_Map;
 
    subtype Release_Map is Alire.Containers.Release_Map;
    --  Releases with a concrete version (source and detected external releases)
 
-   Empty_Deps : constant Dependency_List :=
-                  Alire.Containers.Dependency_Lists.Empty_List;
+   Empty_Deps : constant Dependency_Map :=
+                  (Alire.Containers.Dependency_Maps.Empty_Map with
+                   null record);
 
    Empty_Map : constant Release_Map :=
-     (Alire.Containers.Crate_Release_Maps.Empty_Map with null record);
+                 (Alire.Containers.Crate_Release_Maps.Empty_Map with
+                  null record);
 
-   ---------
-   -- "&" --
-   ---------
-
-   function "&" (L : Dependency_List;
+   function "&" (L : Dependency_Map;
                  R : Dependencies.Dependency)
-                 return Dependency_List
+                 return Dependency_Map
    is
    begin
-      return Result : Dependency_List := L do
-         Result.Append (R);
+      return This : Dependency_Map := L do
+         This.Merge (R);
       end return;
    end "&";
 
@@ -367,7 +365,7 @@ package body Alire.Solver is
                         Forbidden : Types.Forbidden_Dependencies;
                         --  Releases that conflict with current solution
 
-                        Hints     : Dependency_List)
+                        Hints     : Dependency_Map)
                         --  Externals that supply a dependency
       is
 

--- a/src/alire/alire-utils-tables.adb
+++ b/src/alire/alire-utils-tables.adb
@@ -1,0 +1,24 @@
+package body Alire.Utils.Tables is
+
+   -----------
+   -- Print --
+   -----------
+
+   procedure Print (T         : Table;
+                    Level     : Trace.Levels            := Info;
+                    Separator : String                  := " ";
+                    Align     : AAA.Table_IO.Alignments := (1 .. 0 => <>))
+   is
+
+      procedure Print (Line : String) is
+      begin
+         Trace.Log (Line, Level);
+      end Print;
+
+   begin
+      T.Print (Separator => Separator,
+               Align     => Align,
+               Put_Line  => Print'Access);
+   end Print;
+
+end Alire.Utils.Tables;

--- a/src/alire/alire-utils-tables.ads
+++ b/src/alire/alire-utils-tables.ads
@@ -1,0 +1,13 @@
+with AAA.Table_IO;
+
+package Alire.Utils.Tables with Preelaborate is
+
+   type Table is new AAA.Table_IO.Table with null record;
+
+   procedure Print (T         : Table;
+                    Level     : Trace.Levels            := Info;
+                    Separator : String                  := " ";
+                    Align     : AAA.Table_IO.Alignments := (1 .. 0 => <>));
+   --  Hook so tables use the default output facilities of Alire
+
+end Alire.Utils.Tables;

--- a/src/alr/alr-commands-user_input.adb
+++ b/src/alr/alr-commands-user_input.adb
@@ -1,0 +1,38 @@
+with Alire.Utils.User_Input;
+
+package body Alr.Commands.User_Input is
+
+   ------------------------------
+   -- Confirm_Solution_Changes --
+   ------------------------------
+
+   function Confirm_Solution_Changes
+     (Changes        : Alire.Solutions.Diffs.Diff;
+      Changed_Only   : Boolean;
+      Level          : Alire.Trace.Levels := Info)
+      return Boolean
+   is
+      package UI renames Alire.Utils.User_Input;
+      use all type UI.Answer_Kind;
+   begin
+      Trace.Log ("", Level);
+
+      if Changes.Contains_Changes then
+         Trace.Log ("Changes to dependency solution:", Level);
+         Changes.Print (Changed_Only => Changed_Only);
+      else
+         Trace.Log
+           ("There are no changes between the former and new solution.",
+            Level);
+      end if;
+
+      Trace.Log ("", Level);
+
+      return UI.Query
+        (Question => "Do you want to proceed?",
+         Valid    => (Yes | No => True,
+                      others   => False),
+         Default  => Yes) = Yes;
+   end Confirm_Solution_Changes;
+
+end Alr.Commands.User_Input;

--- a/src/alr/alr-commands-user_input.ads
+++ b/src/alr/alr-commands-user_input.ads
@@ -1,0 +1,15 @@
+with Alire.Solutions.Diffs;
+
+package Alr.Commands.User_Input is
+
+   --  Reusable user interactions
+
+   function Confirm_Solution_Changes
+     (Changes        : Alire.Solutions.Diffs.Diff;
+      Changed_Only   : Boolean;
+      Level          : Alire.Trace.Levels := Info)
+      return Boolean;
+   --  Present a summary of changes and ask the user for confirmation. Returns
+   --  True when the user answers positively.
+
+end Alr.Commands.User_Input;

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -59,6 +59,7 @@ def run_alr(*args, **kwargs):
         raise ValueError('Invalid argument: {}'.format(first_unknown_kwarg))
 
     argv = ['alr']
+    argv.append('-n') # always non-interactive
     if debug:
         argv.append('-d')
     if quiet:


### PR DESCRIPTION
Depends on #355.

This PR is a preparatory one for an upcoming PR that improves the information shown when performing commands that change the crates needed in a workspace. For example:
```
$ alr init --bin xxx && cd xxx
$ alr with ada_voxel_space_demo 
Requested changes:                               

   ✓ ada_voxel_space_demo * (added)

Changes to dependency solution:

   ✓ ada_voxel_space_demo 1.0.1  (new)
   ✓ libsdl2              2.0.8  (new)
   ✓ libsdl2_image        2.0.3  (new)
   ✓ libsdl2_ttf          2.0.14 (new)
   ✓ sdlada               2.3.1  (new)

Do you want to proceed?
[Y] Yes  [N] No  (default is Yes)
```

This PR implements packages `Alire.Dependencies.Diffs` and `Alire.Solutions.Diffs` which are used to simplify and reuse the identification of changes between the current status and the one post `update/with`.