### PR TITLE
Show changes to dependencies/solutions in relevant commands

### DIFF
--- a/src/alire/alire-dependencies.ads
+++ b/src/alire/alire-dependencies.ads
@@ -1,4 +1,5 @@
 with Alire.Interfaces;
+with Alire.Milestones;
 with Alire.TOML_Adapters;
 with Alire.Utils;
 
@@ -37,6 +38,9 @@ package Alire.Dependencies with Preelaborate is
 
    overriding
    function Key (Dep : Dependency) return String;
+
+   function From_Milestones (Allowed : Milestones.Allowed_Milestones)
+                             return Dependency;
 
    function From_TOML (Key    : String;
                        Value  : TOML.TOML_Value) return Dependency with
@@ -87,6 +91,10 @@ private
    function Versions (Dep : Dependency)
                       return Semantic_Versioning.Extended.Version_Set
    is (Dep.Versions);
+
+   function From_Milestones (Allowed : Milestones.Allowed_Milestones)
+                             return Dependency is
+     (New_Dependency (Allowed.Crate, Allowed.Versions));
 
    function Image (Dep : Dependency) return String is
       (if Dep = Unavailable

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -204,6 +204,9 @@ package Alire with Preelaborate is
    --  * Debug:   not shown by default, enabled with '-vv' switch, messages
    --             intended for developers or curious users, not user friendly.
 
+   function Detailed return Boolean;
+   --  True when Log_Level is Detail or Debug
+
    Log_Debug : aliased Boolean := False;
    --  This one enables special debug output, irrespectively of the log level.
 
@@ -227,5 +230,8 @@ private
       Message => +"");
 
    function Success (Result : Outcome) return Boolean is (Result.Success);
+
+   function Detailed return Boolean is
+     (Log_Level >= Detail);
 
 end Alire;

--- a/src/alr/alr-checkout.adb
+++ b/src/alr/alr-checkout.adb
@@ -6,6 +6,7 @@ with Alire.Containers;
 with Alire.Externals.Lists;
 with Alire.Lockfiles;
 with Alire.Origins.Deployers;
+with Alire.Solutions;
 with Alire.Roots;
 
 with Alr.Actions;
@@ -176,6 +177,14 @@ package body Alr.Checkout is
             --  current platform (this was also unimplemented in the old index)
             Templates.Generate_Prj_Alr (R.Whenever (Platform.Properties),
                                         Root.Crate_File);
+
+            --  Create also an invalid solution lockfile (since dependencies
+            --  are still unretrieved). Once they are checked out, the lockfile
+            --  will be replaced with the complete solution.
+            Alire.Lockfiles.Write
+              (Solution    => Alire.Solutions.Solution'(Valid => False),
+               Environment => Platform.Properties,
+               Filename    => Root.Lock_File);
          end;
       end if;
    end Working_Copy;

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -15,7 +15,7 @@ package body Alr.Commands.Build is
    -- Do_Compile --
    ----------------
 
-   procedure Do_Compile is
+   function Do_Compile return Boolean is
    begin
       Requires_Full_Index;
 
@@ -37,9 +37,7 @@ package body Alr.Commands.Build is
 
       exception
          when others =>
-            Trace.Warning ("alr detected a compilation failure, " &
-                             "re-run with -vv -d for details");
-            raise;
+            return False;
       end;
 
       --  POST-COMPILE ACTIONS
@@ -50,11 +48,13 @@ package body Alr.Commands.Build is
          when others =>
             Trace.Warning ("A post-compile action failed, " &
                              "re-run with -vv -d for details");
-            raise;
+            return False;
       end;
 
       Trace.Detail ("Compilation finished successfully");
       Trace.Detail ("Use alr run --list to check available executables");
+
+      return True;
    end Do_Compile;
 
    -------------
@@ -64,18 +64,16 @@ package body Alr.Commands.Build is
    overriding procedure Execute (Cmd : in out Command) is
       pragma Unreferenced (Cmd);
    begin
-      Do_Compile;
+      if not Do_Compile then
+         Reportaise_Command_Failed ("Compilation failed.");
+      end if;
    end Execute;
 
    -------------
    -- Execute --
    -------------
 
-   procedure Execute is
-      Cmd : Command;
-   begin
-      Execute (Cmd);
-   end Execute;
+   function Execute return Boolean is (Do_Compile);
 
    ----------------------
    -- Long_Description --

--- a/src/alr/alr-commands-build.ads
+++ b/src/alr/alr-commands-build.ads
@@ -5,7 +5,8 @@ package Alr.Commands.Build is
    overriding
    procedure Execute (Cmd : in out Command);
 
-   procedure Execute;
+   function Execute return Boolean;
+   --  Returns True if compilation succeeded
 
    overriding
    function Long_Description (Cmd : Command)

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -132,26 +132,22 @@ package body Alr.Commands.Get is
       --  Final report
 
       Trace.Info ("");
+
       Trace.Log (Rel.Milestone.Image & " successfully retrieved"
                  & (if Cmd.Build
-                   then
-                     (if Build_OK
-                      then " and built."
-                      else " but its build failed.")
-                   else ".")
-                 & (if Diff.Contains_Changes
-                   then " Dependencies were solved as follows:"
-                   else " There are no dependencies."),
+                   then (if Build_OK
+                         then " and built."
+                         else " but its build failed.")
+                   else "."),
                  Level => (if not Cmd.Build or else Build_OK
                            then Info
                            else Warning));
 
       if Diff.Contains_Changes then
-         Trace.Log ("", -- Empty line for consistency with `with`, `update`
-                    Level => (if not Cmd.Build or else Build_OK
-                              then Info
-                              else Warning));
+         Trace.Info ("Dependencies were solved as follows:");
          Diff.Print (Changed_Only => False);
+      else
+         Trace.Info ("There are no dependencies.");
       end if;
 
    exception

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -6,6 +6,7 @@ with Alire.Milestones;
 with Alire.Origins.Deployers;
 with Alire.Platform;
 with Alire.Platforms;
+with Alire.Solutions.Diffs;
 with Alire.Solver;
 
 with Alr.Actions;
@@ -36,23 +37,14 @@ package body Alr.Commands.Get is
       --  resolve the release as part of the dependencies at this point so if
       --  the latest release is not solvable we get another one that is. We
       --  should warn in that case that newer releases exist.
-      Rel : constant Alire.Index.Release :=
-        Query.Find (Name, Versions, Query_Policy);
-   begin
-      if not Query.Is_Resolvable
-        (Rel.Dependencies.Evaluate (Platform.Properties),
-         Platform.Properties)
-        and then not Cmd.Only
-      then
-         Trace.Error ("Could not resolve dependencies for: " &
-                        Query.Dependency_Image (Name, Versions));
-         Trace.Error ("This may happen when requesting a release that" &
-                        " requires system libraries, while using a GPL gnat");
-         Trace.Error ("In that case, try again with the system" &
-                        " FSF gnat compiler");
-         raise Command_Failed;
-      end if;
+      Rel      : constant Alire.Index.Release :=
+                   Query.Find (Name, Versions, Query_Policy);
 
+      Diff     : Alire.Solutions.Diffs.Diff;
+      --  Used to present dependencies to the user
+
+      Build_OK : Boolean;
+   begin
       declare
          R : constant Alire.Index.Release :=
                Query.Find (Name, Versions, Query_Policy);
@@ -80,9 +72,33 @@ package body Alr.Commands.Get is
       end;
 
       --  Check if we are already in the fresh copy
+
       if Session_State > Outside then
          Reportaise_Command_Failed
            ("Cannot get a release inside another alr release, stopping.");
+      end if;
+
+      --  Check that the dependencies can be solved before retrieving anything
+
+      if not Cmd.Only then
+         declare
+            Solution : constant Alire.Solutions.Solution :=
+                         Query.Resolve
+                           (Rel.Dependencies (Platform.Properties),
+                            Platform.Properties);
+         begin
+            if Solution.Valid then
+               Diff := Alire.Solutions.Solution'
+                 (Valid  => True,
+                  others => <>).Changes (Solution);
+            else
+               Trace.Error ("Could not resolve dependencies for: " &
+                              Query.Dependency_Image (Name, Versions));
+               Trace.Error ("You can still retrieve the crate without "
+                            & "dependencies with --only.");
+               raise Command_Failed;
+            end if;
+         end;
       end if;
 
       --  Check out requested crate release under current directory,
@@ -102,16 +118,42 @@ package body Alr.Commands.Get is
          Guard : Folder_Guard (Enter_Folder (Rel.Unique_Folder))
            with Unreferenced;
       begin
-         Commands.Update.Execute;
+         Commands.Update.Execute (Interactive => False);
 
          --  Execute the checked out release post_fetch actions, now that
          --    dependencies are in place
          Actions.Execute_Actions (Rel, Alire.Actions.Post_Fetch);
 
          if Cmd.Build then
-            Commands.Build.Execute;
+            Build_OK := Commands.Build.Execute;
          end if;
       end;
+
+      --  Final report
+
+      Trace.Info ("");
+      Trace.Log (Rel.Milestone.Image & " successfully retrieved"
+                 & (if Cmd.Build
+                   then
+                     (if Build_OK
+                      then " and built."
+                      else " but its build failed.")
+                   else ".")
+                 & (if Diff.Contains_Changes
+                   then " Dependencies were solved as follows:"
+                   else " There are no dependencies."),
+                 Level => (if not Cmd.Build or else Build_OK
+                           then Info
+                           else Warning));
+
+      if Diff.Contains_Changes then
+         Trace.Log ("", -- Empty line for consistency with `with`, `update`
+                    Level => (if not Cmd.Build or else Build_OK
+                              then Info
+                              else Warning));
+         Diff.Print (Changed_Only => False);
+      end if;
+
    exception
       when Alire.Query_Unsuccessful =>
          Trace.Info ("Release [" & Query.Dependency_Image (Name, Versions) &

--- a/src/alr/alr-commands-pin.adb
+++ b/src/alr/alr-commands-pin.adb
@@ -1,5 +1,6 @@
 with Alire.Releases;
 with Alire.Solver;
+with Alire.Solutions.Diffs;
 
 with Alr.Commands.Update;
 with Alr.Platform;
@@ -22,6 +23,7 @@ package body Alr.Commands.Pin is
       Requires_Valid_Session;
 
       declare
+         Old : constant Solver.Solution := Root.Current.Solution;
          Sol : constant Solver.Solution :=
                  Solver.Resolve
                    (Root.Current.Release.Dependencies (Platform.Properties),
@@ -29,16 +31,28 @@ package body Alr.Commands.Pin is
                     Options => (Age       => Query_Policy,
                                 Detecting => <>,
                                 Hinting   => <>));
+         Diff : constant Alire.Solutions.Diffs.Diff := Old.Changes (Sol);
       begin
          if Sol.Valid then
+
+            --  Pinning not necessarily results in changes in the solution. No
+            --  need to bother the user with empty questions in that case.
+
+            if Diff.Contains_Changes then
+               if not Diff.Print_And_Confirm (Changed_Only =>
+                                                 not Alire.Detailed)
+               then
+                  Trace.Detail ("Abandoning pinning.");
+               end if;
+            end if;
+
             Templates.Generate_Prj_Alr
               (Root.Current.Release.Replacing
                  (Dependencies => Sol.Releases.To_Dependencies));
 
-            Update.Execute;
+            Update.Execute (Interactive => False);
          else
-            Trace.Error ("Could not resolve dependencies");
-            raise Command_Failed;
+            Reportaise_Command_Failed ("Could not resolve dependencies");
          end if;
       end;
    end Execute;

--- a/src/alr/alr-commands-pin.adb
+++ b/src/alr/alr-commands-pin.adb
@@ -3,6 +3,7 @@ with Alire.Solver;
 with Alire.Solutions.Diffs;
 
 with Alr.Commands.Update;
+with Alr.Commands.User_Input;
 with Alr.Platform;
 with Alr.Root;
 with Alr.Templates;
@@ -39,8 +40,9 @@ package body Alr.Commands.Pin is
             --  need to bother the user with empty questions in that case.
 
             if Diff.Contains_Changes then
-               if not Diff.Print_And_Confirm (Changed_Only =>
-                                                 not Alire.Detailed)
+               if not User_Input.Confirm_Solution_Changes
+                 (Diff,
+                  Changed_Only => not Alire.Detailed)
                then
                   Trace.Detail ("Abandoning pinning.");
                end if;

--- a/src/alr/alr-commands-run.adb
+++ b/src/alr/alr-commands-run.adb
@@ -129,7 +129,9 @@ package body Alr.Commands.Run is
 
          --  COMPILATION  --
          if not Cmd.No_Compile then
-            Commands.Build.Execute;
+            if not Commands.Build.Execute then
+               Reportaise_Command_Failed ("Build failed");
+            end if;
          end if;
 
          --  EXECUTION  --

--- a/src/alr/alr-commands-update.adb
+++ b/src/alr/alr-commands-update.adb
@@ -3,6 +3,7 @@ with Alire.Solutions.Diffs;
 with Alire.Solver;
 
 with Alr.Checkout;
+with Alr.Commands.User_Input;
 with Alr.Platform;
 with Alr.Root;
 
@@ -58,7 +59,9 @@ package body Alr.Commands.Update is
          --  Show changes and ask user to apply them
 
          if Interactive then
-            if not Diff.Print_And_Confirm (Changed_Only => not Alire.Detailed)
+            if not User_Input.Confirm_Solution_Changes
+              (Diff,
+               Changed_Only => not Alire.Detailed)
             then
                Trace.Detail ("Update abandoned.");
                return;

--- a/src/alr/alr-commands-update.ads
+++ b/src/alr/alr-commands-update.ads
@@ -23,7 +23,10 @@ package Alr.Commands.Update is
    function Usage_Custom_Parameters (Cmd : Command) return String
    is ("");
 
-   procedure Execute;
+   procedure Execute (Interactive : Boolean);
+   --  Interactive serves to flag that the update is requested from somewhere
+   --  else within Alire, and is already confirmed by the user. So, when False,
+   --  not output of differences or confirmation will be presented.
 
 private
 

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -7,11 +7,12 @@ with Alire.Conditional;
 with Alire.Dependencies.Diffs;
 with Alire.Milestones;
 with Alire.Roots;
-with Alire.Solutions.Diffs;
+with Alire.Solutions;
 with Alire.Solver;
 with Alire.Utils;
 
 with Alr.Commands.Update;
+with Alr.Commands.User_Input;
 with Alr.Exceptions;
 with Alr.OS_Lib;
 with Alr.Platform;
@@ -143,12 +144,12 @@ package body Alr.Commands.Withing is
          Trace.Info ("Requested changes:");
          Trace.Info ("");
          Alire.Dependencies.Diffs.Between (Old_Deps, New_Deps).Print;
-         Trace.Info ("");
 
          --  Show the effects on the solution
 
-         if not Root.Current.Solution.Changes (New_Solution)
-           .Print_And_Confirm (Changed_Only => not Alire.Detailed)
+         if not User_Input.Confirm_Solution_Changes
+           (Root.Current.Solution.Changes (New_Solution),
+            Changed_Only => not Alire.Detailed)
          then
             Trace.Info ("No changes applied.");
             return;


### PR DESCRIPTION
Depends on #396.

Use the lockfile to better identify diffs in the workspace after `alr update`, `alr with`. If the operations result in a change of solution the user is prompted for confirmation (see example in #396).

For the `get` command, no confirmation is asked but a summary of installed dependencies is shown after completion:
```
$ alr get ada_voxel_space_demo
...
make: Leaving directory '/tmp/a/ada_voxel_space_demo_1.0.1_69740326/alire/cache/dependencies/sdlada_2.3.1_786a047f/build/gnat'

ada_voxel_space_demo=1.0.1 successfully retrieved. Dependencies were solved as follows:

   ✓ libsdl2       2.0.8  (new)
   ✓ libsdl2_image 2.0.3  (new)
   ✓ libsdl2_ttf   2.0.14 (new)
   ✓ sdlada        2.3.1  (new)
```