### PR TITLE
Redirect all table output through regular logging facilities

### DIFF
--- a/src/alr/alr-commands-help.adb
+++ b/src/alr/alr-commands-help.adb
@@ -1,8 +1,8 @@
 with AAA.Enum_Tools;
-with AAA.Table_IO;
 with AAA.Text_IO;
 
 with Alire.Crates;
+with Alire.Utils.Tables;
 
 package body Alr.Commands.Help is
 
@@ -91,7 +91,7 @@ package body Alr.Commands.Help is
 
    procedure Display_Valid_Topics is
       Tab   : constant String (1 .. 6) := (others => ' ');
-      Table : AAA.Table_IO.Table;
+      Table : Alire.Utils.Tables.Table;
    begin
       Put_Line ("Help topics: ");
       New_Line;
@@ -101,7 +101,7 @@ package body Alr.Commands.Help is
          Table.Append (Alire.Utils.To_Lower_Case (Topic'Img));
          Table.Append (One_Liner_Summary (Topic));
       end loop;
-      Table.Print (Separator => "  ");
+      Table.Print (Always, Separator => "  ");
    end Display_Valid_Topics;
 
    -------------

--- a/src/alr/alr-commands-list.adb
+++ b/src/alr/alr-commands-list.adb
@@ -1,6 +1,5 @@
-with AAA.Table_IO;
-
 with Alire.Index;
+with Alire.Utils.Tables;
 
 with Alr.Utils;
 
@@ -16,7 +15,7 @@ package body Alr.Commands.List is
       pragma Unreferenced (Cmd);
       use Alr.Utils;
 
-      Table  : AAA.Table_IO.Table;
+      Table  : Alire.Utils.Tables.Table;
       Search : constant String :=
                  (if Num_Arguments = 1
                   then Utils.To_Lower_Case (Argument (1))
@@ -50,7 +49,7 @@ package body Alr.Commands.List is
       if Found = 0 then
          Put_Line ("No hits");
       else
-         Table.Print (Separator => "  ");
+         Table.Print (Always, Separator => "  ");
       end if;
    end Execute;
 

--- a/src/alr/alr-commands-search.adb
+++ b/src/alr/alr-commands-search.adb
@@ -1,5 +1,3 @@
-with AAA.Table_IO;
-
 with Alire.Containers;
 with Alire.Externals;
 with Alire.Index;
@@ -7,6 +5,7 @@ with Alire.Origins.Deployers;
 with Alire.Crates.With_Releases;
 with Alire.Releases;
 with Alire.Solver;
+with Alire.Utils.Tables;
 
 with Alr.Platform;
 with Alr.Utils;
@@ -22,7 +21,7 @@ package body Alr.Commands.Search is
    overriding procedure Execute (Cmd : in out Command) is
 
       Found : Natural := 0;
-      Tab   : AAA.Table_IO.Table;
+      Tab   : Alire.Utils.Tables.Table;
 
       ------------------
       -- List_Release --
@@ -200,7 +199,7 @@ package body Alr.Commands.Search is
       if Found = 0 then
          Log ("No hits              ");
       else
-         Tab.Print (Separator => "  ");
+         Tab.Print (Always, Separator => "  ");
       end if;
    end Execute;
 

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -1,5 +1,3 @@
-with AAA.Table_IO;
-
 with Alire.Index;
 with Alire.Milestones;
 with Alire.Origins.Deployers;
@@ -10,7 +8,7 @@ with Alire.Properties;
 with Alire.Requisites.Booleans;
 with Alire.Roots;
 with Alire.Solver;
-with Alire.Utils;
+with Alire.Utils.Tables;
 
 with Alr.Bootstrap;
 with Alr.Dependency_Graphs;
@@ -169,7 +167,7 @@ package body Alr.Commands.Show is
 
    procedure Report_Externals (Name : Alire.Crate_Name;
                                Cmd  : Command) is
-      Table : AAA.Table_IO.Table;
+      Table : Alire.Utils.Tables.Table;
    begin
       if Alire.Index.Crate (Name).Externals.Is_Empty then
          Trace.Info ("No externals defined for the requested crate.");
@@ -216,7 +214,7 @@ package body Alr.Commands.Show is
             end;
          end loop;
 
-         Table.Print;
+         Table.Print (Always);
       end if;
    end Report_Externals;
 

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -1,5 +1,4 @@
 with AAA.Enum_Tools;
-with AAA.Table_IO;
 with AAA.Text_IO;
 
 with Ada.Characters.Handling; use Ada.Characters.Handling;
@@ -15,6 +14,7 @@ with Alire.Lockfiles;
 with Alire.Roots;
 with Alire.Roots.Check_Valid;
 with Alire.Solutions;
+with Alire.Utils.Tables;
 
 with Alr.Commands.Build;
 with Alr.Commands.Clean;
@@ -305,7 +305,7 @@ package body Alr.Commands is
 
    procedure Display_Valid_Commands is
       Tab   : constant String (1 .. 6) := (others => ' ');
-      Table : AAA.Table_IO.Table;
+      Table : Alire.Utils.Tables.Table;
    begin
       Put_Line ("Valid commands: ");
       New_Line;
@@ -317,7 +317,7 @@ package body Alr.Commands is
             Table.Append (Dispatch_Table (Cmd).Short_Description);
          end if;
       end loop;
-      Table.Print (Separator => "  ");
+      Table.Print (Always, Separator => "  ");
    end Display_Valid_Commands;
 
    --------------------------

--- a/src/alr/alr-dependency_graphs.adb
+++ b/src/alr/alr-dependency_graphs.adb
@@ -1,6 +1,5 @@
-with AAA.Table_IO;
-
 with Alire.Conditional;
+with Alire.Utils.Tables;
 
 with Alr.OS_Lib;
 with Alr.Paths;
@@ -135,7 +134,7 @@ package body Alr.Dependency_Graphs is
                     Instance : Alire.Containers.Release_Map;
                     Prefix   : String := "")
    is
-      Table : AAA.Table_IO.Table;
+      Table : Alire.Utils.Tables.Table;
 
       Filtered : constant Graph := This.Filtering_Unused (Instance);
    begin
@@ -146,7 +145,7 @@ package body Alr.Dependency_Graphs is
          Table.New_Row;
       end loop;
 
-      Table.Print;
+      Table.Print (Always);
    end Print;
 
    -----------------------


### PR DESCRIPTION
Depends on #397 because the `Alire.Utils.Tables` wrapper is introduced there.

To ensure tables comply with the logging levels, existing tables are updated to use the `Alire.Utils.Tables` wrapper (although the affected tables are shown on demand, so they're logged as `Always`.)