### PR TITLE
Generate lockfile on the fly when missing

### DIFF
--- a/src/alire/alire-lockfiles.adb
+++ b/src/alire/alire-lockfiles.adb
@@ -1,3 +1,4 @@
+with Ada.Directories;
 with Ada.Text_IO;
 
 with Alire.Directories;
@@ -59,6 +60,12 @@ package body Alire.Lockfiles is
       when others =>
          if Is_Open (File) then
             Close (File);
+         end if;
+
+         --  Clean up
+
+         if Ada.Directories.Exists (Filename) then
+            Ada.Directories.Delete_File (Filename);
          end if;
 
          raise;

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -57,7 +57,8 @@ package Alire.Solutions is
 
    overriding
    function To_TOML (This : Solution) return TOML.TOML_Value with
-     Pre => (for all Release of This.Releases =>
+     Pre => not This.Valid or else
+           (for all Release of This.Releases =>
                Release.Dependencies.Is_Unconditional and then
                Release.Properties.Is_Unconditional);
    --  As previous one, but requires releases not to have dynamic expressions

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -250,10 +250,8 @@ package body Alr.Commands.Show is
             when Outside =>
                Reportaise_Wrong_Arguments
                  ("Cannot proceed without a crate name");
-            when Broken =>
+            when others =>
                Requires_Valid_Session;
-            when Bootstrap.Valid_Session_States =>
-               null;
          end case;
       end if;
 


### PR DESCRIPTION
This PR is intended to reduce manual intervention for users with workspaces initialized pre PR #355. With PR #355 lockfiles are created but never read. However, the queued PRs that build on top of it will cause errors when looking for a lockfile that should be there but isn't.

With this PR the lockfile will be generated transparently when first needed.