### PR TITLE
Colorize output

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 [submodule "testsuite/fixtures/crates/libhello_git"]
 	path = testsuite/fixtures/crates/libhello_git
 	url = https://github.com/alire-project/libhello.git
+[submodule "deps/ansi"]
+	path = deps/ansi
+	url = https://github.com/mosteo/ansi-ada

--- a/alire.gpr
+++ b/alire.gpr
@@ -2,6 +2,7 @@ with "aaa";
 with "ada_toml";
 with "alire_common";
 with "ajunitgen";
+with "ansi";
 with "gnatcoll";
 with "semantic_versioning";
 with "simple_logging";

--- a/alr_env.gpr
+++ b/alr_env.gpr
@@ -6,6 +6,7 @@ aggregate project Alr_Env is
                          "deps/aaa",
                          "deps/ada-toml",
                          "deps/ajunitgen",
+                         "deps/ansi",
                          "deps/gnatcoll-slim",
                          "deps/semantic_versioning",
                          "deps/simple_logging",

--- a/src/alire/alire-conditional.ads
+++ b/src/alire/alire-conditional.ads
@@ -12,7 +12,7 @@ package Alire.Conditional with Preelaborate is
    ------------------
 
    package For_Dependencies is new Conditional_Trees (Dependencies.Dependency,
-                                                      Dependencies.Image);
+                                                      Dependencies.TTY_Image);
    subtype Dependencies is For_Dependencies.Tree;
 
    subtype Platform_Dependencies is Conditional.Dependencies

--- a/src/alire/alire-crates-with_releases.adb
+++ b/src/alire/alire-crates-with_releases.adb
@@ -4,6 +4,7 @@ with Alire.Origins;
 with Alire.Properties.Labeled;
 with Alire.Requisites;
 with Alire.TOML_Keys;
+with Alire.Utils.TTY;
 
 with TOML;
 
@@ -214,11 +215,25 @@ package body Alire.Crates.With_Releases is
       end if;
    end Description;
 
+   ---------------------
+   -- TTY_Description --
+   ---------------------
+
+   function TTY_Description (This : Crate) return String
+   is (Utils.TTY.Description (This.Description));
+
    ----------
    -- Name --
    ----------
 
    function Name (This : Crate) return Crate_Name is (+(+This.Name));
+
+   --------------
+   -- TTY_Name --
+   --------------
+
+   function TTY_Name (This : Crate) return String
+   is (Utils.TTY.Name (+This.Name));
 
    ---------------
    -- New_Crate --

--- a/src/alire/alire-crates-with_releases.ads
+++ b/src/alire/alire-crates-with_releases.ads
@@ -16,6 +16,8 @@ package Alire.Crates.With_Releases is
 
    function Name (This : Crate) return Crate_Name;
 
+   function TTY_Name (This : Crate) return String;
+
    procedure Add (This    : in out Crate;
                   Release : Releases.Release) with Pre =>
      not This.Contains (Release.Version) or else
@@ -32,6 +34,8 @@ package Alire.Crates.With_Releases is
                       Version : Semantic_Versioning.Version) return Boolean;
 
    function Description (This : Crate) return Description_String;
+
+   function TTY_Description (This : Crate) return String;
 
    function Externals (This : Crate) return Alire.Externals.Lists.List;
 

--- a/src/alire/alire-dependencies-diffs.adb
+++ b/src/alire/alire-dependencies-diffs.adb
@@ -59,8 +59,8 @@ package body Alire.Dependencies.Diffs is
          for Dep of List loop
             Table
               .Append ("   " & Icon)
-              .Append (+Dep.Crate)
-              .Append (Dep.Versions.Image)
+              .Append (TTY.Name (+Dep.Crate))
+              .Append (TTY.Version (Dep.Versions.Image))
               .Append (Comment)
               .New_Row;
          end loop;
@@ -68,8 +68,8 @@ package body Alire.Dependencies.Diffs is
 
    begin
       if This.Contains_Changes then
-         Summarize (This.Added,   "(added)",   "✓");
-         Summarize (This.Removed, "(removed)", "✗");
+         Summarize (This.Added,   "(added)",   TTY.OK ("✓"));
+         Summarize (This.Removed, "(removed)", TTY.Emph ("✗"));
          Table.Print (Info);
       else
          Trace.Info ("   No changes.");

--- a/src/alire/alire-dependencies-graphs.adb
+++ b/src/alire/alire-dependencies-graphs.adb
@@ -139,9 +139,9 @@ package body Alire.Dependencies.Graphs is
       Filtered : constant Graph := This.Filtering_Unused (Instance);
    begin
       for Dep of Filtered loop
-         Table.Append (Prefix & Instance (+Dep.Dependent).Milestone.Image);
+         Table.Append (Prefix & Instance (+Dep.Dependent).Milestone.TTY_Image);
          Table.Append ("-->");
-         Table.Append (Instance (+Dep.Dependee).Milestone.Image);
+         Table.Append (Instance (+Dep.Dependee).Milestone.TTY_Image);
          Table.New_Row;
       end loop;
 

--- a/src/alire/alire-dependencies.ads
+++ b/src/alire/alire-dependencies.ads
@@ -8,12 +8,15 @@ with Semantic_Versioning.Extended;
 
 with TOML; use all type TOML.Any_Value_Kind;
 
+private with Alire.Utils.TTY;
+
 package Alire.Dependencies with Preelaborate is
 
    --  A single dependency is a crate name plus a version set
 
    type Dependency (<>) is
      new Interfaces.Classificable -- since the crate name is the key
+     and Interfaces.Colorable
      and Interfaces.Tomifiable
      and Interfaces.Yamlable
    with private;
@@ -35,6 +38,9 @@ package Alire.Dependencies with Preelaborate is
 
    function Image (Dep : Dependency) return String;
    --  Standard-style version image, e.g. "make^3.1"
+
+   overriding
+   function TTY_Image (Dep : Dependency) return String;
 
    overriding
    function Key (Dep : Dependency) return String;
@@ -62,8 +68,11 @@ package Alire.Dependencies with Preelaborate is
 
 private
 
+   package TTY renames Utils.TTY;
+
    type Dependency (Name_Len : Natural) is
      new Interfaces.Classificable
+     and Interfaces.Colorable
      and Interfaces.Tomifiable
      and Interfaces.Yamlable
    with record
@@ -97,11 +106,17 @@ private
      (New_Dependency (Allowed.Crate, Allowed.Versions));
 
    function Image (Dep : Dependency) return String is
-      (if Dep = Unavailable
+     (if Dep = Unavailable
       then "Unavailable"
+      else (+Dep.Crate) & Dep.Versions.Image);
+
+   overriding
+   function TTY_Image (Dep : Dependency) return String is
+     (if Dep = Unavailable
+      then
+         TTY.Version ("Unavailable")
       else
-         (Utils.To_Lower_Case (+Dep.Crate)
-          & Dep.Versions.Image));
+        (TTY.Name (+Dep.Crate) & TTY.Version (Dep.Versions.Image)));
 
    overriding
    function To_YAML (Dep : Dependency) return String is

--- a/src/alire/alire-interfaces.ads
+++ b/src/alire/alire-interfaces.ads
@@ -21,6 +21,15 @@ package Alire.Interfaces with Preelaborate is
 
    function Image (This : Imaginable) return String is abstract;
 
+   ---------------
+   -- Colorable --
+   ---------------
+
+   type Colorable is limited interface;
+   --  Types that can be displayed with ANSI colors/formatting
+
+   function TTY_Image (This : Colorable) return String is abstract;
+
    ----------------
    -- Tomifiable --
    ----------------

--- a/src/alire/alire-milestones.ads
+++ b/src/alire/alire-milestones.ads
@@ -1,8 +1,12 @@
+with Alire.Interfaces;
+
 with Semantic_Versioning.Extended;
+
+private with Alire.Utils.TTY;
 
 package Alire.Milestones with Preelaborate is
 
-   type Milestone (<>) is tagged private;
+   type Milestone (<>) is new Interfaces.Colorable with private;
 
    function "<" (L, R : Milestone) return Boolean;
 
@@ -15,6 +19,9 @@ package Alire.Milestones with Preelaborate is
    function Version (M : Milestone) return Semantic_Versioning.Version;
 
    function Image (M : Milestone) return String;
+
+   overriding
+   function TTY_Image (M : Milestone) return String;
 
    -----------------------
    -- Milestone parsing --
@@ -32,7 +39,9 @@ package Alire.Milestones with Preelaborate is
 
 private
 
-   type Milestone (Name_Len : Natural) is tagged record
+   package TTY renames Utils.TTY;
+
+   type Milestone (Name_Len : Natural) is new Interfaces.Colorable with record
       Name    : Crate_Name (1 .. Name_Len);
       Version : Semantic_Versioning.Version;
    end record;
@@ -55,6 +64,14 @@ private
    is (M.Version);
 
    function Image (M : Milestone) return String is
-      (+M.Crate & "=" & Image (M.Version));
+     ((+M.Crate)
+      & "="
+      & Image (M.Version));
+
+   overriding
+   function TTY_Image (M : Milestone) return String is
+     (TTY.Name (+M.Crate)
+      & "="
+      & TTY.Version (Image (M.Version)));
 
 end Alire.Milestones;

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -443,7 +443,7 @@ package body Alire.Releases is
       use GNAT.IO;
    begin
       --  MILESTONE
-      Put_Line (R.Milestone.Image & ": " & R.Description);
+      Put_Line (R.Milestone.TTY_Image & ": " & R.TTY_Description);
 
       if R.Provides /= R.Name then
          Put_Line ("Provides: " & (+R.Provides));

--- a/src/alire/alire-releases.ads
+++ b/src/alire/alire-releases.ads
@@ -21,6 +21,7 @@ with Semantic_Versioning;
 with TOML;
 
 private with Alire.OS_Lib;
+private with Alire.Utils.TTY;
 
 package Alire.Releases with Preelaborate is
 
@@ -122,9 +123,14 @@ package Alire.Releases with Preelaborate is
 
    function Name_Str (R : Release) return String is (+R.Name);
 
+   function TTY_Name (R : Release) return String;
+
    function Description (R : Release) return Description_String;
    --  Returns the description for the crate, which is also stored as a
    --  property of the release.
+
+   function TTY_Description (R : Release) return String;
+   --  Colorized description
 
    function Long_Description (R : Release) return String;
    --  Returns the long description for the crate, which is also stored as a
@@ -325,6 +331,9 @@ private
    function Name (R : Release) return Crate_Name
    is (R.Name);
 
+   function TTY_Name (R : Release) return String
+   is (Utils.TTY.Name (+R.Name));
+
    function Provides (R : Release) return Crate_Name
    is (if UStrings.Length (R.Alias) = 0
        then R.Name
@@ -364,6 +373,9 @@ private
    is (Utils.Tail
        (Conditional.Enumerate (R.Properties).Filter
         (Alire.TOML_Keys.Description).First_Element.Image, ' '));
+
+   function TTY_Description (R : Release) return String
+   is (Utils.TTY.Description (R.Description));
 
    function Is_Pinned (R : Release) return Boolean
    is (R.Pinned);

--- a/src/alire/alire-solutions-diffs.adb
+++ b/src/alire/alire-solutions-diffs.adb
@@ -1,7 +1,10 @@
 with Alire.Containers;
 with Alire.Utils.Tables;
+with Alire.Utils.TTY;
 
 package body Alire.Solutions.Diffs is
+
+   package TTY renames Utils.TTY;
 
    use type Semantic_Versioning.Version;
 
@@ -130,14 +133,14 @@ package body Alire.Solutions.Diffs is
 
       if Former.Status = Needed and then Latter.Status = Needed then
          if Former.Version < Latter.Version then
-            return ", upgraded from " & Former.Version.Image;
+            return ", upgraded from " & TTY.Version (Former.Version.Image);
          elsif Former.Version = Latter.Version then
             return ", version unchanged";
          else
-            return ", downgraded from " & Former.Version.Image;
+            return ", downgraded from " & TTY.Version (Former.Version.Image);
          end if;
       elsif Former.Status = Needed and then Latter.Status /= Needed then
-         return " from " & Former.Version.Image;
+         return " from " & TTY.Version (Former.Version.Image);
       else
          --  Pinned, nothing else to say
          return "";
@@ -192,26 +195,26 @@ package body Alire.Solutions.Diffs is
                Table.Append
                  (Prefix
                   & (case This.Change (Key (I)) is
-                       when Added      => "✓",
-                       when Removed    => "✗",
-                       when External   => "↪",
-                       when Upgraded   => "⭧",
-                       when Downgraded => "⭨",
-                       when Pinned     => "⊙", -- ⍟⟟⫯🞊⊙⊛
-                       when Unpinned   => "𐩒", -- 📍🖈○⚪⭘
-                       when Unchanged  => "=",
-                       when Unsolved   => "⚠"));
+                       when Added      => TTY.OK ("✓"),
+                       when Removed    => TTY.Emph ("✗"),
+                       when External   => TTY.Warn ("↪"),
+                       when Upgraded   => TTY.OK ("⭧"),
+                       when Downgraded => TTY.Warn ("⭨"),
+                       when Pinned     => TTY.OK ("⊙"),
+                       when Unpinned   => TTY.Emph ("𐩒"),
+                       when Unchanged  => TTY.OK ("="),
+                       when Unsolved   => TTY.Error ("⚠")));
 
                --  Always show crate name
 
-               Table.Append (+Key (I));
+               Table.Append (TTY.Name (+Key (I)));
 
                --  Show most precise version available
 
                if Latter.Status in Hinted | Needed then
-                  Table.Append (Best_Version (Latter));
+                  Table.Append (TTY.Version (Best_Version (Latter)));
                else
-                  Table.Append (Best_Version (Former));
+                  Table.Append (TTY.Version (Best_Version (Former)));
                end if;
 
                --  Finally show an explanation of the change depending on
@@ -224,9 +227,9 @@ package body Alire.Solutions.Diffs is
                        when Removed    => "removed",
                        when External   => "external",
                        when Upgraded   => "upgraded from "
-                                         & Semver.Image (Former.Version),
+                                 & TTY.Version (Semver.Image (Former.Version)),
                        when Downgraded => "downgraded from "
-                                         & Semver.Image (Former.Version),
+                                 & TTY.Version (Semver.Image (Former.Version)),
                        when Pinned     => "pinned"
                                          & Pin_Change_Summary (Former, Latter),
                        when Unpinned   => "unpinned"

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -5,10 +5,13 @@ with Alire.OS_Lib.Subprocess;
 with Alire.Paths;
 with Alire.Solutions.Diffs;
 with Alire.Utils.Tables;
+with Alire.Utils.TTY;
 
 with Semantic_Versioning;
 
 package body Alire.Solutions is
+
+   package TTY renames Utils.TTY;
 
    -------------
    -- Changes --
@@ -79,9 +82,9 @@ package body Alire.Solutions is
       if not This.Releases.Is_Empty then
          Trace.Log ("Dependencies (solution):", Level);
          for Rel of This.Releases loop
-            Trace.Log ("   " & Rel.Milestone.Image
+            Trace.Log ("   " & Rel.Milestone.TTY_Image
                        & (if Rel.Is_Pinned
-                         then " (pinned)"
+                         then TTY.Emph (" (pinned)")
                          else "")
                        & (if Detailed then
                             " (origin: " &
@@ -97,7 +100,7 @@ package body Alire.Solutions is
       if not This.Hints.Is_Empty then
          Trace.Log ("Dependencies (external):", Level);
          for Dep of This.Hints loop
-            Trace.Log ("   " & Dep.Image, Level);
+            Trace.Log ("   " & Dep.TTY_Image, Level);
 
             --  Look for hints. If we are relying on workspace
             --  information the index may not be loaded, or have
@@ -110,7 +113,7 @@ package body Alire.Solutions is
                    (Name => Dep.Crate,
                     Env  => Alire.Properties.No_Properties)
                loop
-                  Trace.Log ("      Hint: " & Hint, Level);
+                  Trace.Log (TTY.Emph ("      Hint: ") & Hint, Level);
                end loop;
             end if;
          end loop;
@@ -151,8 +154,8 @@ package body Alire.Solutions is
          for Release of This.Releases loop
             if Release.Is_Pinned then
                Table
-                 .Append (+Release.Name)
-                 .Append (Release.Version.Image)
+                 .Append (Release.TTY_Name)
+                 .Append (TTY.Version (Release.Version.Image))
                  .New_Row;
             end if;
          end loop;

--- a/src/alire/alire-utils-tty.adb
+++ b/src/alire/alire-utils-tty.adb
@@ -1,0 +1,108 @@
+with ANSI;
+
+with Simple_Logging.Decorators;
+
+package body Alire.Utils.TTY is
+
+   use all type ANSI.Colors;
+   use all type ANSI.Styles;
+
+   type States is (Disabled, Enabled, Default);
+
+   Status : States := Default;
+
+   function Regular_Decorator (Level   : Simple_Logging.Levels;
+                               Message : String) return String;
+
+   function Verbose_Decorator (Level   : Simple_Logging.Levels;
+                               Message : String) return String;
+
+   ---------------
+   -- Use_Color --
+   ---------------
+
+   function Use_Color return Boolean is
+     (case Status is
+         when Enabled  => True,
+         when Disabled => False,
+         when Default  => Simple_Logging.Is_TTY);
+
+   -------------------
+   -- Disable_Color --
+   -------------------
+
+   procedure Disable_Color is
+   begin
+      Status := Disabled;
+   end Disable_Color;
+
+   ------------------
+   -- Enable_Color --
+   ------------------
+
+   procedure Enable_Color (Force : Boolean := False) is
+   begin
+
+      --  Enable when appropriate
+
+      if Force or else Simple_Logging.Is_TTY then
+         Status := Enabled;
+      end if;
+
+      --  Set debug colors. When Detail/Debug are also enabled, we add the
+      --  "info:" prefix to otherwise normal output, so it's seen more easily.
+
+      if Use_Color then
+         case Log_Level is
+            when Always .. Info =>
+               Simple_Logging.Decorators.Level_Decorator :=
+                 Regular_Decorator'Access;
+            when others =>
+               Simple_Logging.Decorators.Level_Decorator :=
+                 Verbose_Decorator'Access;
+         end case;
+      end if;
+   end Enable_Color;
+
+   -----------------------
+   -- Regular_Decorator --
+   -----------------------
+
+   function Regular_Decorator (Level   : Simple_Logging.Levels;
+                               Message : String) return String is
+     (case Level is
+         when Info   => Message,
+         when others => Verbose_Decorator (Level, Message));
+
+   -----------------------
+   -- Verbose_Decorator --
+   -----------------------
+
+   function Verbose_Decorator (Level : Simple_Logging.Levels;
+                               Message : String) return String is
+     (case Level is
+         when Always  => Message,
+         when Error   =>
+            ANSI.Wrap (Text       => "error:",
+                       Style      => Bright,
+                       Foreground => ANSI.Foreground (Red)) & " " & Message,
+         when Warning =>
+            ANSI.Wrap (Text       => "warn:",
+                       Style      => Bright,
+                       Foreground => ANSI.Foreground (Yellow)) & " " & Message,
+         when Info    =>
+            ANSI.Wrap (Text       => "info:",
+                       Style      => Bright,
+                       Foreground => ANSI.Foreground (Green)) & " " & Message,
+         when Detail  =>
+            ANSI.Wrap (Text       => "detail:",
+                       Style      => Bright,
+                       Foreground => ANSI.Foreground (Cyan)) & " " & Message,
+         when Debug   =>
+            ANSI.Wrap (Text       => "debug:",
+                       Style      => Default,
+                       Foreground => ANSI.Foreground (Grey)) & " "
+            & ANSI.Wrap (Text       => Message,
+                         Style      => Dim));
+
+end Alire.Utils.TTY;

--- a/src/alire/alire-utils-tty.adb
+++ b/src/alire/alire-utils-tty.adb
@@ -1,5 +1,3 @@
-with ANSI;
-
 with Simple_Logging.Decorators;
 
 package body Alire.Utils.TTY is
@@ -64,6 +62,32 @@ package body Alire.Utils.TTY is
       end if;
    end Enable_Color;
 
+   ------------
+   -- Format --
+   ------------
+
+   function Format (Text  : String;
+                    Fore  : ANSI.Colors := ANSI.Default;
+                    Back  : ANSI.Colors := ANSI.Default;
+                    Style : ANSI.Styles := ANSI.Default)
+                    return String
+   is
+      use ANSI;
+   begin
+      if not Use_Color then
+         return Text;
+      end if;
+
+      return
+        ((if Fore  /= Default then Foreground (Fore) else "")
+         & (if Back /= Default then Background (Fore) else "")
+         & (if Style /= Default then ANSI.Style (Style, On) else "")
+         & Text
+         & (if Fore  /= Default then Foreground (Default) else "")
+         & (if Back /= Default then Background (Default) else "")
+         & (if Style /= Default then ANSI.Style (Style, Off) else ""));
+   end Format;
+
    -----------------------
    -- Regular_Decorator --
    -----------------------
@@ -79,7 +103,11 @@ package body Alire.Utils.TTY is
    -----------------------
 
    function Verbose_Decorator (Level : Simple_Logging.Levels;
-                               Message : String) return String is
+                               Message : String) return String
+   is
+      use ANSI;
+   begin
+      return
      (case Level is
          when Always  => Message,
          when Error   =>
@@ -104,5 +132,6 @@ package body Alire.Utils.TTY is
                        Foreground => ANSI.Foreground (Grey)) & " "
             & ANSI.Wrap (Text       => Message,
                          Style      => Dim));
+   end Verbose_Decorator;
 
 end Alire.Utils.TTY;

--- a/src/alire/alire-utils-tty.ads
+++ b/src/alire/alire-utils-tty.ads
@@ -1,0 +1,14 @@
+package Alire.Utils.TTY with Preelaborate is
+
+   --  Color/Formatting related subprograms. These won't have any
+   --  effect if a redirection of output is detected, or if global
+   --  flag Simple_Logging.Is_TTY is false.
+
+   procedure Disable_Color;
+   --  Disables color/formatting output even when TTY is capable
+
+   procedure Enable_Color (Force : Boolean := False);
+   --  Prepares colors for the logging messages. Unless Force, will do nothing
+   --  if a console redirection is detected.
+
+end Alire.Utils.TTY;

--- a/src/alire/alire-utils-tty.ads
+++ b/src/alire/alire-utils-tty.ads
@@ -1,8 +1,13 @@
+with ANSI;
+
 package Alire.Utils.TTY with Preelaborate is
 
    --  Color/Formatting related subprograms. These won't have any
    --  effect if a redirection of output is detected, or if global
    --  flag Simple_Logging.Is_TTY is false.
+
+   --  Re-expose for clients
+   package ANSI renames Standard.ANSI;
 
    procedure Disable_Color;
    --  Disables color/formatting output even when TTY is capable
@@ -10,5 +15,80 @@ package Alire.Utils.TTY with Preelaborate is
    procedure Enable_Color (Force : Boolean := False);
    --  Prepares colors for the logging messages. Unless Force, will do nothing
    --  if a console redirection is detected.
+
+   function Format (Text  : String;
+                    Fore  : ANSI.Colors := ANSI.Default;
+                    Back  : ANSI.Colors := ANSI.Default;
+                    Style : ANSI.Styles := ANSI.Default)
+                    return String;
+   --  Wrap text with the appropriate ANSI sequences. Following text will be
+   --  unaffected. Default colors are interpreted as no change of color (will
+   --  result in no color sequences), not as setting the default color (which
+   --  is always set after a color change).
+
+   ------------------------
+   -- Predefined formats --
+   ------------------------
+
+   function OK (Text : String) return String;
+   --  Bold Light_Green
+
+   function Emph (Text : String) return String;
+   --  Something to highligth not negatively, bold cyan
+
+   function Error (Text : String) return String;
+   --  Bold Red
+
+   function Warn (Text : String) return String;
+   --  Bold Yellow
+
+   function Bold (Text : String) return String;
+
+   function Name (Text : String) return String;
+   --  Bold Default for crate names
+
+   function Description (Text : String) return String;
+   --  Not bold cyan for crate descriptions
+
+   function Version (Text : String) return String;
+   --  For versions/version sets, bold magenta
+
+private
+
+   function OK (Text : String) return String is
+     (Format (Text,
+              Fore  => ANSI.Light_Green,
+              Style => ANSI.Bright));
+
+   function Emph (Text : String) return String is
+     (Format (Text,
+              Fore  => ANSI.Cyan,
+              Style => ANSI.Bright));
+
+   function Error (Text : String) return String is
+     (Format (Text,
+              Fore  => ANSI.Red,
+              Style => ANSI.Bright));
+
+   function Warn (Text : String) return String is
+     (Format (Text,
+              Fore  => ANSI.Yellow,
+              Style => ANSI.Bright));
+
+   function Bold (Text : String) return String is
+     (Format (Text,
+              Style => ANSI.Bright));
+
+   function Name (Text : String) return String is
+     (Bold (Text));
+
+   function Description (Text : String) return String is
+     (Format (Text,
+              Fore  => ANSI.Light_Cyan));
+
+   function Version (Text : String) return String is
+     (Format (Text,
+              Fore  => ANSI.Magenta,
+              Style => ANSI.Bright));
 
 end Alire.Utils.TTY;

--- a/src/alire/alire-utils-user_input.adb
+++ b/src/alire/alire-utils-user_input.adb
@@ -4,6 +4,7 @@ with Ada.Characters.Handling;
 with Interfaces.C_Streams;
 
 with Alire.Config;
+with Alire.Utils.TTY;
 
 package body Alire.Utils.User_Input is
 
@@ -49,10 +50,14 @@ package body Alire.Utils.User_Input is
    begin
       for Kind in Answer_Kind loop
          if Valid (Kind) then
-            TIO.Put ("[" & Answer_Char (Kind) & "] " & Img (Kind) & "  ");
+            TIO.Put ("["
+                     & (if Kind = Default
+                       then TTY.Bold ("" & Answer_Char (Kind))
+                       else           "" & Answer_Char (Kind))
+                     & "] " & Img (Kind) & "  ");
          end if;
       end loop;
-      TIO.Put ("(default is " & Img (Default) & ") ");
+      TIO.Put ("(default is " & TTY.Bold (Img (Default)) & ") ");
    end Print_Valid_Answers;
 
    -----------

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -132,7 +132,7 @@ package body Alr.Commands.Get is
 
       Trace.Info ("");
 
-      Trace.Log (Rel.Milestone.Image & " successfully retrieved"
+      Trace.Log (Rel.Milestone.TTY_Image & " successfully retrieved"
                  & (if Cmd.Build
                    then (if Build_OK
                          then " and built."

--- a/src/alr/alr-commands-list.adb
+++ b/src/alr/alr-commands-list.adb
@@ -39,8 +39,8 @@ package body Alr.Commands.List is
             then
                Found := Found + 1;
                Table.New_Row;
-               Table.Append (+Crate.Name);
-               Table.Append (Crate.Description);
+               Table.Append (Crate.TTY_Name);
+               Table.Append (Crate.TTY_Description);
             end if;
             Busy.Step;
          end loop;


### PR DESCRIPTION
I'm aware of GNATCOLL.Terminal and NCursesAda, but I decided to go for ANSI codes for simplicity. GNATCOLL.Terminal is stateful, which doesn't blend well with our current logging setup, and curses is a heavier dependency with the same problem. Any of these would have required radical changes, whereas this is a minor cumulative change.

This means that colors don't work in Windows (although recent Windows terminal versions can be configured to recognize ANSI).

Colors are palette-based so custom palettes should work properly. Still, I've tried to use colors readable over dark/light backgrounds.

A new global switch `--no-color` allows to force disable colors.

Commands where the effects can be seen, for example: `alr search aw --external-detect`, `alr get ada_voxel_space_demo`