### PR TITLE
Workaround for jekyll export of case expressions

### DIFF
--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -235,7 +235,9 @@ package body Alr.Commands.Show is
       begin
          Put_Line ("---");
          Put_Line ("layout: crate");
-         Put_Line (Rel.To_YAML);
+         --  TODO: conditional expressions can't be exported yet, we report in
+         --  the interim the ones that apply to the current system.
+         Put_Line (Rel.Whenever (Platform.Properties).To_YAML);
          Put_Line ("---");
          Put_Line (Rel.Long_Description);
          Put_Line (Rel.Notes);


### PR DESCRIPTION
Short-term fix for the error reported by Henrik Härkönen on gitter:

> something funny happens when browsing this crate: https://alire.ada.dev/crates/openglada
> "layout: crate ERROR: alire-conditional_trees-cases.adb:115...." etc

Root cause is that case expressions export (both to TOML/YAML) is still unimplemented (#358) and that crate has conditional environment variables. This PR uses static properties resolved for the platform running `alr` for the YAML export. The complete information is still visible with a plain `alr show`.