### PR TITLE
Don't err out in autocompletion script

### DIFF
--- a/scripts/alr-completion.bash
+++ b/scripts/alr-completion.bash
@@ -2,7 +2,7 @@
 
 if ! builtin type -P alr &>/dev/null; then
     echo alr must be in PATH for completion to work
-    exit 1
+    return
 fi
 
 # Commands


### PR DESCRIPTION
This may break other people's scripts and prevent creation of new bash sessions, yikes. Just bail out.