### PR TITLE
Show complete solution with `alr with --solve`

### DIFF
--- a/src/alire/alire-dependencies-graphs.ads
+++ b/src/alire/alire-dependencies-graphs.ads
@@ -1,19 +1,23 @@
 with Ada.Containers.Indefinite_Ordered_Sets;
 
 with Alire.Containers;
-with Alire.Solver;
+with Alire.Properties;
+with Alire.Releases;
+with Alire.Solutions;
 
-package Alr.Dependency_Graphs is
+package Alire.Dependencies.Graphs is
 
    type Graph is tagged private;
 
    function Empty_Graph return Graph;
 
-   function From_Solution (Sol : Alire.Solver.Solution)
+   function From_Solution (Sol : Solutions.Solution;
+                           Env : Properties.Vector)
                            return Graph;
 
    function Including (This : Graph;
-                       R    : Types.Release) return Graph;
+                       R    : Releases.Release;
+                       Env  : Properties.Vector) return Graph;
    --  Add a release and ALL its potential direct dependencies (even OR'ed)
 
    function Filtering_Unused (This     : Graph;
@@ -60,4 +64,4 @@ private
 
    type Graph is new Dep_Sets.Set with null record;
 
-end Alr.Dependency_Graphs;
+end Alire.Dependencies.Graphs;

--- a/src/alire/alire-paths.ads
+++ b/src/alire/alire-paths.ads
@@ -11,6 +11,9 @@ package Alire.Paths with Preelaborate is
    function Build_Folder return Relative_Path;
    --  The folder where the out-of-tree global build is performed
 
+   Scripts_Graph_Easy            : constant String := "graph-easy";
+   --  Script for ASCII graphs
+
 private
 
    Crate_File_Extension_With_Dot : constant String := ".toml";

--- a/src/alire/alire-solutions-diffs.adb
+++ b/src/alire/alire-solutions-diffs.adb
@@ -172,7 +172,7 @@ package body Alire.Solutions.Diffs is
 
       --  Early exit if no changes
 
-      if not This.Contains_Changes then
+      if Changed_Only and then not This.Contains_Changes then
          Trace.Log (Prefix & "No changes between former an new solution.",
                     Level);
          return;

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -2,6 +2,7 @@ with Alire.Conditional;
 with Alire.Containers;
 with Alire.Interfaces;
 with Alire.Properties;
+with Alire.Releases;
 with Alire.TOML_Adapters;
 
 limited with Alire.Solutions.Diffs;
@@ -58,6 +59,15 @@ package Alire.Solutions is
 
    function With_Pins (This, Src : Solution) return Solution;
    --  Copy pins from Src to This
+
+   procedure Print (This     : Solution;
+                    Root     : Alire.Releases.Release;
+                    Env      : Properties.Vector;
+                    Detailed : Boolean;
+                    Level    : Trace.Levels);
+   --  Prints releases, and direct and transitive dependencies. Root is the
+   --  crate not in solution that introduces the direct dependencies. When
+   --  Detailed, extra information about origins is shown.
 
    procedure Print_Pins (This : Solution);
    --  Dump a table with pins in this solution

--- a/src/alr/alr-checkout.adb
+++ b/src/alr/alr-checkout.adb
@@ -3,6 +3,7 @@ with Ada.Directories;
 with Alire;
 with Alire.Actions;
 with Alire.Containers;
+with Alire.Dependencies.Graphs;
 with Alire.Externals.Lists;
 with Alire.Lockfiles;
 with Alire.Origins.Deployers;
@@ -10,12 +11,13 @@ with Alire.Solutions;
 with Alire.Roots;
 
 with Alr.Actions;
-with Alr.Dependency_Graphs;
 with Alr.OS_Lib;
 with Alr.Platform;
 with Alr.Templates;
 
 package body Alr.Checkout is
+
+   package Dependency_Graphs renames Alire.Dependencies.Graphs;
 
    --------------
    -- Checkout --
@@ -71,7 +73,8 @@ package body Alr.Checkout is
    is
       Was_There : Boolean;
       Graph     : Dependency_Graphs.Graph  :=
-                    Dependency_Graphs.From_Solution (Solution);
+                    Dependency_Graphs.From_Solution (Solution,
+                                                     Platform.Properties);
       Pending   : Alire.Solutions.Release_Map := Solution.Releases;
       Round     : Natural                     := 0;
    begin

--- a/src/alr/alr-commands-withing.ads
+++ b/src/alr/alr-commands-withing.ads
@@ -21,8 +21,9 @@ package Alr.Commands.Withing is
 private
 
    type Command is new Commands.Command with record
-      Del  : aliased Boolean := False;
-      From : aliased Boolean := False;
+      Del   : aliased Boolean := False;
+      From  : aliased Boolean := False;
+      Solve : aliased Boolean := False;
    end record;
 
 end Alr.Commands.Withing;

--- a/src/alr/alr-paths.ads
+++ b/src/alr/alr-paths.ads
@@ -66,9 +66,6 @@ package Alr.Paths is
    function Dependencies_Folder return Relative_Path;
    --  Location in the working dir where dependencies are deployed
 
-   --  Scripts paths/names
-   Scripts_Graph_Easy : constant String := "graph-easy";
-
 private
 
    function "/" (L, R : String) return String

--- a/testsuite/tests/pin/downgrade/test.py
+++ b/testsuite/tests/pin/downgrade/test.py
@@ -13,12 +13,11 @@ import re
 
 
 # Verify that proper version of libchild is in the printed and disk solution
-def check_child(version, output):
+def check_child(version, output, pinned):
     # Verify output
     assert_match('.*\n'
                  'Dependencies \(solution\):\n'
-                 '   libchild=' + version + '\n'
-                 '.*\n',
+                 '   libchild=' + version + (" \(pinned\)" if pinned else "") + '.*\n',
                  output, flags=re.S)
 
     # Verify lockfile
@@ -37,14 +36,14 @@ os.chdir('xxx')
 # Make it depend on child (there are 0.1 and 0.2, so 0.2 used initially)
 run_alr('with', 'libchild')
 p = run_alr('show', '--solve')
-check_child('0.2.0', p.out)
+check_child('0.2.0', p.out, pinned=False)
 
 # Pin it to a downgrade
 run_alr('pin', 'libchild=0.1')
 
 # Verify new version
 p = run_alr('show', '--solve')
-check_child('0.1.0', p.out)
+check_child('0.1.0', p.out, pinned=True)
 
 
 print('SUCCESS')

--- a/testsuite/tests/pin/post-update/test.py
+++ b/testsuite/tests/pin/post-update/test.py
@@ -12,11 +12,11 @@ import re
 
 
 # Verify that proper version of libchild is in the printed and disk solution
-def check_child(version, output):
+def check_child(version, output, pinned):
     # Verify output
     assert_match('.*\n'
                  'Dependencies \(solution\):\n'
-                 '   libchild=' + version + '\n'
+                 '   libchild=' + version + (' \(pinned\)' if pinned else "") + '\n'
                  '   libparent=1\.0\.0\n'
                  '.*\n',
                  output, flags=re.S)
@@ -46,17 +46,17 @@ run_alr('with', '--del', 'libchild')
 
 # Verify pinned version is still in the solution, pre-update:
 p = run_alr('show', '--solve')
-check_child('0.1.0', p.out)
+check_child('0.1.0', p.out, pinned=True)
 
 # Run an update and verify solution is still the same
 run_alr('update')
 p = run_alr('show', '--solve')
-check_child('0.1.0', p.out)
+check_child('0.1.0', p.out, pinned=True)
 
 # Unpin and check upgraded solution
 run_alr('pin', '--unpin', 'libchild')
 p = run_alr('show', '--solve')
-check_child('0.2.0', p.out)
+check_child('0.2.0', p.out, pinned=False)
 
 
 print('SUCCESS')

--- a/testsuite/tests/pin/unneeded-held/test.py
+++ b/testsuite/tests/pin/unneeded-held/test.py
@@ -33,14 +33,15 @@ assert_eq('libchild 0.2.0\n',
 
 # Check that there are no dependencies
 p = run_alr('with')
-assert_eq('(empty)\n',
+assert_eq('Dependencies (direct):\n'
+          '   (empty)\n',
           p.out)
 
 # But the pinned release is still in the solution
-p = run_alr('show', '--solve')
+p = run_alr('with', '--solve')
 assert_match('.*'
              'Dependencies \(solution\):\n'
-             '   libchild=0\.2\.0\n'
+             '   libchild=0\.2\.0 \(pinned\) \(origin: filesystem\)\n'
              'Dependencies \(graph\):.*',
              p.out, flags=re.S)
 


### PR DESCRIPTION
As pointed out in #371 we didn't have a focused way of seeing the complete solution without other peripheral information (that is, using `alr show --solve`).

This PR refactors that part of `alr show --solve` into `Alire.Solutions.Print` so it can be reused there and with the new `alr with --solve`. As plain `alr with` already shows the direct dependency tree, I think it makes sense to have a way of seeing the transitive dependencies right there without other noise.

Depends on #406
Fixes #371