### PR TITLE
Remove misleading/redundant error messages

### DIFF
--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -12,14 +12,13 @@ package Alire with Preelaborate is
    --  relation with user inputs (e.g., parsing of TOML files or other inputs).
    --  Used internally in Alire in conjunction with Alire.Errors to use the
    --  normal exception mechanisms, that produce less boilerplate, while using
-   --  Outcomes for results returned to clients. That is, a Checked_Error ought
-   --  not to propagate into Alr.* code.
+   --  Outcomes for results returned to clients.
 
    Query_Unsuccessful : exception;
    --  Raised by subprograms that return releases/dependencies when not
    --  found/impossible.
 
-   Unimplemented      : exception;
+   Unimplemented : exception;
    --  Features that are known to be missing and scheduled for near future
    --  implementation.
 

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -8,6 +8,7 @@ with Ada.Text_IO; use Ada.Text_IO;
 with Alire_Early_Elaboration;
 with Alire;
 with Alire.Config;
+with Alire.Errors;
 with Alire.Features.Index;
 with Alire.Index;
 with Alire.Lockfiles;
@@ -690,8 +691,16 @@ package body Alr.Commands is
          Execute_By_Name (What_Command);
          Log ("alr " & What_Command & " done", Detail);
       exception
+         when E : Alire.Checked_Error =>
+            Trace.Error (Alire.Errors.Get (E, Clear => False));
+            if Alire.Log_Level = Debug then
+               raise;
+            else
+               OS_Lib.Bailout (1);
+            end if;
+
          when Child_Failed | Command_Failed =>
-            Trace.Error ("alr " & What_Command & " unsuccessful");
+            Trace.Detail ("alr " & What_Command & " unsuccessful");
             if Alire.Log_Level = Debug then
                raise;
             else
@@ -713,7 +722,6 @@ package body Alr.Commands is
 
    exception
       when Wrong_Command_Arguments =>
---          Display_Usage (Cmd);
          OS_Lib.Bailout (1);
    end Execute_By_Name;
 

--- a/testsuite/tests/get/get-not-found/test.py
+++ b/testsuite/tests/get/get-not-found/test.py
@@ -10,9 +10,8 @@ from drivers.asserts import assert_eq
 
 p = run_alr('get', 'does_not_exist', complain_on_error=False, quiet=False)
 assert_eq(1, p.status)
-assert_eq('Crate [does_not_exist] does not exist in the catalog.'
-          '\nERROR: alr get unsuccessful',
-          p.out.strip())
+assert_eq('Crate [does_not_exist] does not exist in the catalog.\n',
+          p.out)
 assert_eq([], glob('does_not_exist*'))
 
 print('SUCCESS')

--- a/testsuite/tests/index/bad-action-command/test.py
+++ b/testsuite/tests/index/bad-action-command/test.py
@@ -8,9 +8,8 @@ from drivers.asserts import assert_match
 
 p = run_alr('show', 'hello_world',
             complain_on_error=False, debug=False, quiet=True)
-assert_match(
-    'ERROR: Loading crate .* actions command must be an array of string\(s\)\n'
-    'ERROR: alr show unsuccessful\n',
-    p.out)
+assert_match('ERROR: Loading crate .* actions command must'
+             ' be an array of string\(s\)\n',
+             p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/bad-license/test.py
+++ b/testsuite/tests/index/bad-license/test.py
@@ -8,9 +8,8 @@ from drivers.asserts import assert_match
 
 p = run_alr('show', 'hello_world',
             complain_on_error=False, debug=False, quiet=True)
-assert_match(
-    'ERROR: Loading crate .*hello_world.toml: general: licenses: unknown license: \'Invalid license ID\'\n'
-    'ERROR: alr show unsuccessful\n',
-    p.out)
+assert_match('ERROR: Loading crate .*hello_world.toml: general: '
+             'licenses: unknown license: \'Invalid license ID\'\n',
+             p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/bad-tag/test.py
+++ b/testsuite/tests/index/bad-tag/test.py
@@ -11,8 +11,7 @@ p = run_alr('show', 'hello_world',
 assert_match(
     'ERROR: Loading crate .*hello_world.toml: general: tags: '
     'Tag string is not valid\n'
-    'ERROR: Cannot read valid property from tags\n'
-    'ERROR: alr show unsuccessful\n',
+    'ERROR: Cannot read valid property from tags\n',
     p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/empty-tag/test.py
+++ b/testsuite/tests/index/empty-tag/test.py
@@ -11,8 +11,7 @@ p = run_alr('show', 'hello_world',
 assert_match(
     'ERROR: Loading crate .*hello_world.toml: general: tags: '
     'Tag string is empty\n'
-    'ERROR: Cannot read valid property from tags\n'
-    'ERROR: alr show unsuccessful\n',
+    'ERROR: Cannot read valid property from tags\n',
     p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/external-hint/test.py
+++ b/testsuite/tests/index/external-hint/test.py
@@ -20,8 +20,7 @@ if distro_is_known():
     assert_match(".*Hint: This is a custom hint.*", p.out, flags=re.S)
 else:
     assert_eq('ERROR: No source release indexed for the requested crate, and '
-              'cannot use system packages in unknown distribution\n'
-              'ERROR: alr get unsuccessful\n',
+              'cannot use system packages in unknown distribution\n',
               p.out)
 
 # 2nd test: hint is displayed when the hint belongs to a dependency, on get

--- a/testsuite/tests/index/local-index-not-found/test.py
+++ b/testsuite/tests/index/local-index-not-found/test.py
@@ -22,7 +22,6 @@ for d in ('no-such-directory',
                                 'index.toml')
     assert_match('ERROR: Cannot load metadata from .*{}:'
                  ' Not a readable directory'
-                 '\nERROR: alr list unsuccessful'
                  '\n'
                  .format(re.escape(path_excerpt)),
                  p.out)

--- a/testsuite/tests/index/long-tag/test.py
+++ b/testsuite/tests/index/long-tag/test.py
@@ -9,9 +9,9 @@ from drivers.asserts import assert_match
 p = run_alr('show', 'hello_world',
             complain_on_error=False, debug=False, quiet=True)
 assert_match('ERROR: Loading crate .*hello_world.toml:'
-             ' general: tags: Tag string is too long \(must be no more than [0-9]+\)\n'
-             'ERROR: Cannot read valid property from tags\n'
-             'ERROR: alr show unsuccessful\n',
-    p.out)
+             ' general: tags: Tag string is too long '
+             '\(must be no more than [0-9]+\)\n'
+             'ERROR: Cannot read valid property from tags\n',
+             p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/maint-bad-email/test.py
+++ b/testsuite/tests/index/maint-bad-email/test.py
@@ -11,8 +11,7 @@ p = run_alr('show', 'hello_world',
 assert_match(
     'ERROR: Loading crate .*hello_world.toml: general: maintainers: '
     'Maintainers must have a valid email, but got: Mr. User\n'
-    'ERROR: Cannot read valid property from maintainers\n'
-    'ERROR: alr show unsuccessful\n',
+    'ERROR: Cannot read valid property from maintainers\n',
     p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/maint-bad-login/test.py
+++ b/testsuite/tests/index/maint-bad-login/test.py
@@ -11,8 +11,7 @@ p = run_alr('show', 'hello_world',
 assert_match(
     'ERROR: Loading crate .*hello_world.toml: general: maintainers-logins: '
     'maintainers-logins must be a valid GitHub login, but got: mr.user\n'
-    'ERROR: Cannot read valid property from maintainers-logins\n'
-    'ERROR: alr show unsuccessful\n',
+    'ERROR: Cannot read valid property from maintainers-logins\n',
     p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/origin-filesystem-bad-path/test.py
+++ b/testsuite/tests/index/origin-filesystem-bad-path/test.py
@@ -15,8 +15,7 @@ def run(i, error):
         config_dir, '.', {'bad_index_{}'.format(i): {'in_fixtures': False}})
     p = run_alr('list', complain_on_error=False, debug=False)
     assert_match(
-        'ERROR: {}'
-        '\nERROR: alr list unsuccessful\n$'.format(error),
+        'ERROR: {}\n$'.format(error),
         p.out)
 
 

--- a/testsuite/tests/index/origin-unknown-kind/test.py
+++ b/testsuite/tests/index/origin-unknown-kind/test.py
@@ -10,7 +10,6 @@ p = run_alr('show', 'hello_world',
             complain_on_error=False, debug=False, quiet=False)
 assert_match(
     'ERROR: .* unknown origin: .*'
-    '\nERROR: alr show unsuccessful'
     '\n', p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/too-long-short-description/test.py
+++ b/testsuite/tests/index/too-long-short-description/test.py
@@ -9,9 +9,9 @@ from drivers.asserts import assert_match
 p = run_alr('show', 'hello_world',
             complain_on_error=False, debug=False, quiet=True)
 assert_match('ERROR: Loading crate .*hello_world.toml:'
-             ' general: description: Description string is too long \(must be no more than [0-9]+\)\n'
-             'ERROR: Cannot read valid property from description\n'
-             'ERROR: alr show unsuccessful\n',
-    p.out)
+             ' general: description: Description string is too long'
+             ' \(must be no more than [0-9]+\)\n'
+             'ERROR: Cannot read valid property from description\n',
+             p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/run/no-compile/test.py
+++ b/testsuite/tests/run/no-compile/test.py
@@ -15,8 +15,7 @@ os.chdir('xxx')
 # Run it without compiling it first
 p = run_alr('run', '-s', complain_on_error=False)
 assert p.status != 0
-assert_match('ERROR: Executable "xxx(\.exe)?" not found\n'
-             'ERROR: alr run unsuccessful\n', 
+assert_match('ERROR: Executable "xxx(\.exe)?" not found\n',
              p.out)
 
 print('SUCCESS')


### PR DESCRIPTION
Two changes related to reporting of errors in the command line:

* Downgrade the overkill "alr [command] unsuccessful" message to `Detail` level, since the actual useful error has just been reported at `Error` level.
* Consider `Alire.Checked_Error` exceptions an explicitly handled error with proper error message (as we use it this way consistently), instead of reporting an unexpected internal error (Checked_Errors are not unexpected).