### PR TITLE
Fix a compilation error for some GNAT versions

### DIFF
--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -193,14 +193,14 @@ package body Alire.Solutions is
 
    function With_Pins (This, Src : Solution) return Solution is
    begin
-      return This : Solution := With_Pins.This do
+      return Result : Solution := This do
          if not Src.Valid then
             return;
          end if;
 
          for Release of Src.Releases loop
             if Release.Is_Pinned then
-               This.Releases (Release.Name).Pin;
+               Result.Releases.Reference (Release.Name).Pin;
             end if;
          end loop;
       end return;


### PR DESCRIPTION
The version of GNAT (FSF gnat-7 on Ubuntu) used for CI of crates errs out with `alire-solutions.adb:203:20: actual for "This" must be a variable`

Not sure how this could slip through our CI tests.