### PR TITLE
Fix missing checks for invalid solution

### DIFF
--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -79,6 +79,17 @@ package body Alire.Solutions is
                     Detailed : Boolean;
                     Level    : Trace.Levels) is
    begin
+
+      --  For invalid solutions be terse and gone
+
+      if not This.Valid then
+         Trace.Log ("Dependencies (solution):", Level);
+         Trace.Log ("   No solution", Level);
+         return;
+      end if;
+
+      --  Continue for valid solutions
+
       if not This.Releases.Is_Empty then
          Trace.Log ("Dependencies (solution):", Level);
          for Rel of This.Releases loop
@@ -148,7 +159,9 @@ package body Alire.Solutions is
    procedure Print_Pins (This : Solution) is
       Table : Utils.Tables.Table;
    begin
-      if not (for some Release of This.Releases => Release.Is_Pinned) then
+      if not This.Valid then
+         Trace.Always ("There is no solution, hence there are no pins");
+      elsif not (for some Release of This.Releases => Release.Is_Pinned) then
          Trace.Always ("There are no pins");
       else
          for Release of This.Releases loop

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -50,7 +50,10 @@ package Alire.Solutions is
 
    function Changing_Pin (This   : Solution;
                           Name   : Crate_Name;
-                          Pinned : Boolean) return Solution;
+                          Pinned : Boolean) return Solution
+     with Pre =>
+       This.Valid or else
+       raise Checked_Error with "Cannot change pins in invalid solution";
    --  Return a copy of the solution with the new pinning status of Name
 
    function Pins (This : Solution) return Conditional.Dependencies;

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -148,11 +148,6 @@ package body Alr.Commands.Get is
       else
          Trace.Info ("There are no dependencies.");
       end if;
-
-   exception
-      when Alire.Query_Unsuccessful =>
-         Trace.Info ("Release [" & Query.Dependency_Image (Name, Versions) &
-                       "] does not exist in the catalog.");
    end Retrieve;
 
    -------------

--- a/testsuite/tests/get/only/test.py
+++ b/testsuite/tests/get/only/test.py
@@ -1,0 +1,40 @@
+"""
+Test proper working of alr get --only and other follow-up commands in such an
+invalid solution state
+"""
+
+from glob import glob
+import os
+import re
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq, assert_match
+
+
+# Get the "hello" project and enter its directory, without solving dependencies
+run_alr('get', 'hello', '--only')
+os.chdir(glob('hello*')[0])
+
+# Verify that it has no solution
+p = run_alr('with', '--solve')
+assert_eq('Dependencies (direct):\n'
+          '   libhello^1.0\n'
+          'Dependencies (solution):\n'
+          '   No solution\n',
+          p.out)
+
+# Verify that it has no pins
+p = run_alr('pin')
+assert_eq('There is no solution, hence there are no pins\n', p.out)
+
+# Verify that updating it fixes the solution
+run_alr('update')
+p = run_alr('with', '--solve')
+assert_match('.*\n'   # Skip dependencies
+             'Dependencies \(solution\):\n'
+             '   libhello=1\.0\.0.*\n'
+             '.*',  # Skip graph
+             p.out, flags=re.S)
+
+
+print('SUCCESS')

--- a/testsuite/tests/get/only/test.yaml
+++ b/testsuite/tests/get/only/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
These omissions were causing uncontained errors after an `alr get --only`