### PR TITLE
Fix withing of external dependencies

### DIFF
--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -5,6 +5,7 @@ with Ada.Text_IO;
 
 with Alire.Conditional;
 with Alire.Dependencies.Diffs;
+with Alire.Index;
 with Alire.Milestones;
 with Alire.Releases;
 with Alire.Roots;
@@ -41,7 +42,7 @@ package body Alr.Commands.Withing is
 
       --  Check that the requested dependency exists
 
-      if not Query.Exists (Requested.Crate) then
+      if not Alire.Index.Exists (Requested.Crate) then
          Reportaise_Command_Failed
            ("The requested crate was not found in the catalog: " &
             (+Requested.Crate));

--- a/testsuite/tests/with/external/test.py
+++ b/testsuite/tests/with/external/test.py
@@ -1,0 +1,31 @@
+"""
+Verify that withing a dependency on a crate with only unavailable externals
+works
+"""
+
+from glob import glob
+import os
+import re
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq, assert_match
+
+
+# Initialize a new project
+run_alr('init', '--bin', 'xxx')
+os.chdir('xxx')
+
+# Add a dependency on 'make', defined in the index as only a hint
+run_alr('with', 'make')
+
+# Verify that it appears in the solution as unavailable external
+p = run_alr('with', '--solve')
+assert_match('Dependencies \(direct\):\n'
+             '   make\*\n'
+             'Dependencies \(external\):\n'
+             '   make\*\n'
+             '.*',  # Skip graph
+             p.out, flags=re.S)
+
+
+print('SUCCESS')

--- a/testsuite/tests/with/external/test.yaml
+++ b/testsuite/tests/with/external/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
The check was looking for concrete releases, while it's enough to check for the crate existence.