### PR TITLE
Improve dependency graphs to display unresolved externals

### DIFF
--- a/src/alire/alire-containers.ads
+++ b/src/alire/alire-containers.ads
@@ -26,6 +26,8 @@ package Alire.Containers with Preelaborate is
 
    type Dependency_Map is new Dependency_Maps.Map with null record;
 
+   Empty_Dependency_Map : constant Dependency_Map;
+
    procedure Merge (This : in out Dependency_Map;
                     Dep  :        Dependencies.Dependency);
    --  If the dependency is already in map, create a combined dependency that
@@ -94,6 +96,9 @@ package Alire.Containers with Preelaborate is
    renames Release_Holders.To_Holder;
 
 private
+
+   Empty_Dependency_Map : constant Dependency_Map :=
+                            (Dependency_Maps.Empty_Map with null record);
 
    Empty_Release_Map : constant Release_Map :=
                          (Crate_Release_Maps.Empty_Map with null record);

--- a/src/alire/alire-dependencies-graphs.ads
+++ b/src/alire/alire-dependencies-graphs.ads
@@ -20,10 +20,10 @@ package Alire.Dependencies.Graphs is
                        Env  : Properties.Vector) return Graph;
    --  Add a release and ALL its potential direct dependencies (even OR'ed)
 
-   function Filtering_Unused (This     : Graph;
-                              Instance : Alire.Containers.Release_Map)
+   function Filtering_Unused (This : Graph;
+                              Used : Alire.Containers.Crate_Name_Sets.Set)
                               return Graph;
-   --  Remove dependencies that don't appear in the solution
+   --  Remove dependencies that don't appear in the set of used releases
 
    function Has_Dependencies (This  : Graph;
                               Crate : Alire.Crate_Name)
@@ -36,11 +36,11 @@ package Alire.Dependencies.Graphs is
    --  Remove all dependencies with Crate as the dependee crate
 
    procedure Plot (This     : Graph;
-                   Instance : Alire.Containers.Release_Map);
+                   Solution : Solutions.Solution);
    --  Requires graph-easy in PATH
 
    procedure Print (This     : Graph;
-                    Instance : Alire.Containers.Release_Map;
+                    Solution : Solutions.Solution;
                     Prefix   : String := "");
    --  Print to terminal with the milestone info in Instance
 

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -38,6 +38,24 @@ package body Alire.Solutions is
       end return;
    end Changing_Pin;
 
+   ---------------
+   -- Including --
+   ---------------
+
+   function Including (This    : Solution;
+                       Release : Alire.Releases.Release)
+                       return Solution
+   is
+   begin
+      if This.Valid then
+         return Result : Solution := This do
+            Result.Releases.Include (Release.Name, Release);
+         end return;
+      else
+         return This;
+      end if;
+   end Including;
+
    ----------------------------------
    -- Libgraph_Easy_Perl_Installed --
    ----------------------------------
@@ -157,10 +175,10 @@ package body Alire.Solutions is
                       Dependencies.Graphs.From_Solution (This, Env)
                                          .Including (Root, Env);
          begin
-            Graph.Print (This.Releases.Including (Root), Prefix => "   ");
+            Graph.Print (This.Including (Root), Prefix => "   ");
 
             if Libgraph_Easy_Perl_Installed then
-               Graph.Plot (This.Releases.Including (Root));
+               Graph.Plot (This.Including (Root));
             else
                Trace.Log ("Cannot display graphical graph: " &
                             Paths.Scripts_Graph_Easy & " not in path" &

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -25,9 +25,10 @@ package Alire.Solutions is
    Invalid_Solution     : constant Solution;
    Empty_Valid_Solution : constant Solution;
 
-   function New_Solution (Releases : Release_Map;
-                          Hints    : Dependency_Map)
-                          return Solution;
+   function New_Solution
+     (Releases : Release_Map    := Containers.Empty_Release_Map;
+      Hints    : Dependency_Map := Containers.Empty_Dependency_Map)
+      return Solution;
    --  A new valid solution
 
    function Releases (This : Solution) return Release_Map with
@@ -55,6 +56,12 @@ package Alire.Solutions is
        This.Valid or else
        raise Checked_Error with "Cannot change pins in invalid solution";
    --  Return a copy of the solution with the new pinning status of Name
+
+   function Including (This    : Solution;
+                       Release : Alire.Releases.Release)
+                       return Solution;
+   --  Add a release to the solution, without doing anything with its
+   --  dependencies. If not This.Valid, result will also be invalid.
 
    function Pins (This : Solution) return Conditional.Dependencies;
    --  Return all pinned releases as exact version dependencies. Will return an
@@ -131,9 +138,10 @@ private
    Invalid_Solution     : constant Solution := (Valid => False);
    Empty_Valid_Solution : constant Solution := (Valid => True, others => <>);
 
-   function New_Solution (Releases : Release_Map;
-                          Hints    : Dependency_Map)
-                          return Solution
+   function New_Solution
+     (Releases : Release_Map    := Containers.Empty_Release_Map;
+      Hints    : Dependency_Map := Containers.Empty_Dependency_Map)
+      return Solution
    is (Solution'(Valid    => True,
                  Releases => Releases,
                  Hints    => Hints));

--- a/src/alr/alr-checkout.adb
+++ b/src/alr/alr-checkout.adb
@@ -139,7 +139,7 @@ package body Alr.Checkout is
                Trace.Error ("Remaining releases:"
                             & Pending.Length'Img &
                               "; Dependency graph:");
-               Graph.Print (Pending);
+               Graph.Print (Alire.Solutions.New_Solution (Pending));
                raise Program_Error
                  with "No release checked-out in round" & Round'Img;
             else

--- a/testsuite/tests/with/external/test.py
+++ b/testsuite/tests/with/external/test.py
@@ -24,7 +24,9 @@ assert_match('Dependencies \(direct\):\n'
              '   make\*\n'
              'Dependencies \(external\):\n'
              '   make\*\n'
-             '.*',  # Skip graph
+             'Dependencies \(graph\):\n'
+             '   xxx=0.0.0 --> make\*\n'
+             '.*',  # skip plot or warning
              p.out, flags=re.S)
 
 


### PR DESCRIPTION
Requires #421 

Improve the `Alire.Dependencies.Graphs` class to consider hints in the dependency graph. Before this PR, dependency hints were omitted in these graphs.