### PR TITLE
Remove unnecessary forced exit from `Alr.Main`

### DIFF
--- a/src/alr/alr-main.adb
+++ b/src/alr/alr-main.adb
@@ -15,11 +15,6 @@ begin
    Trace.Detail ("alr build is " & Bootstrap.Status_Line);
 
    Commands.Execute;
-
-   OS_Lib.Bailout (0);
-   --  There's something writing an empty line on finalization and I can't find
-   --  it. There's almost nothing controlled so it's puzzling. For now, this is
-   --  a temporary workaround.
 exception
    --  Ensure we do not show an exception trace to unsuspecting users
    when E : others =>

--- a/testsuite/tests/misc/clean-end/test.py
+++ b/testsuite/tests/misc/clean-end/test.py
@@ -1,0 +1,34 @@
+"""
+Ensure that no unexpected output appears in the console. This happened in the
+past, where the finalization of something was causing an extra empty line.
+"""
+
+import os
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq, assert_match
+
+# Check a few commands for unexpected output
+
+# Commands that require session
+assert_match(".*Cannot continue with invalid session:"  # skip logging prefix
+             " Could not detect a session folder"
+             " at current or parent locations\n",
+             run_alr('with', quiet=False, complain_on_error=False).out)
+
+# Commands within a trivial session
+assert_eq("",
+          run_alr('init', '--bin', 'xxx').out)
+os.chdir('xxx')
+
+assert_eq("",
+          run_alr('update').out)
+
+assert_eq("Nothing to update.\n",
+          run_alr('update', quiet=False).out)
+
+assert_eq("Dependencies (direct):\n"
+          "   (empty)\n",
+          run_alr('with', quiet=False).out)
+
+print('SUCCESS')

--- a/testsuite/tests/misc/clean-end/test.yaml
+++ b/testsuite/tests/misc/clean-end/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
Historically, something was causing an extra empty line in the output of every
command. At some point this has been fixed inadvertently, so we can remove the
forced exit call, which in turn will allow finalization to complete normally,
if it were ever needed.