### PR TITLE
Clean up some unused/unneeded code 

### DIFF
--- a/src/alire/alire-lockfiles.adb
+++ b/src/alire/alire-lockfiles.adb
@@ -70,11 +70,9 @@ package body Alire.Lockfiles is
    -- Write --
    -----------
 
-   procedure Write (Solution    : Solver.Solution;
-                    Environment : Properties.Vector;
-                    Filename    : Any_Path)
+   procedure Write (Solution : Solver.Solution;
+                    Filename : Any_Path)
    is
-      pragma Unreferenced (Environment);
       use Ada.Text_IO;
       File : File_Type;
    begin

--- a/src/alire/alire-lockfiles.ads
+++ b/src/alire/alire-lockfiles.ads
@@ -22,7 +22,6 @@ package Alire.Lockfiles is
    --  Check if given file is a valid lockfile
 
    procedure Write (Solution    : Solver.Solution;
-                    Environment : Properties.Vector;
                     Filename    : Any_Path);
    --  Write a solution to a file
 

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -185,13 +185,6 @@ package Alire.Utils with Preelaborate is
                     Separator : String := ASCII.LF & "");
    --  Dump contents to a given file
 
-   -----------------
-   -- XXX_XXX_XXX --
-   -----------------
-
-   type XXX_XXX (<>) is limited private;
-   function XXX_XXX_XXX return XXX_XXX;
-
 private
 
    Empty_Vector : constant String_Vector :=
@@ -205,8 +198,5 @@ private
 
    function Trim (S : String) return String is
      (Ada.Strings.Fixed.Trim (S, Ada.Strings.Both));
-
-   type XXX_XXX is limited null record;
-   function XXX_XXX_XXX return XXX_XXX is (null record);
 
 end Alire.Utils;

--- a/src/alr/alr-checkout.adb
+++ b/src/alr/alr-checkout.adb
@@ -103,7 +103,6 @@ package body Alr.Checkout is
 
       Alire.Lockfiles.Write
         (Solution,
-         Platform.Properties,
          Alire.Lockfiles.File_Name (Name     => Root,
                                     Root_Dir => Root_Dir));
 
@@ -185,14 +184,13 @@ package body Alr.Checkout is
             Templates.Generate_Prj_Alr (R.Whenever (Platform.Properties),
                                         Root.Crate_File);
 
-            --  Create also an invalid solution lockfile (since dependencies
+            --  Create also an incomplete solution lockfile (since dependencies
             --  are still unretrieved). Once they are checked out, the lockfile
             --  will be replaced with the complete solution.
             Alire.Lockfiles.Write
               (Solution    => (if R.Dependencies (Platform.Properties).Is_Empty
                                then Alire.Solutions.Empty_Valid_Solution
                                else Alire.Solutions.Empty_Invalid_Solution),
-               Environment => Platform.Properties,
                Filename    => Root.Lock_File);
          end;
       end if;

--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -8,7 +8,6 @@ with Alire.Releases;
 with Alire.Roots;
 with Alire.Solutions;
 
-with Alr.Platform;
 with Alr.Root;
 with Alr.Templates;
 with Alr.Utils;
@@ -177,7 +176,6 @@ package body Alr.Commands.Init is
 
          Alire.Lockfiles.Write
            (Alire.Solutions.Empty_Valid_Solution,
-            Platform.Properties,
             Root.Lock_File);
       end;
    end Generate;

--- a/src/alr/alr-commands-pin.adb
+++ b/src/alr/alr-commands-pin.adb
@@ -140,9 +140,8 @@ package body Alr.Commands.Pin is
             if Commands.User_Input.Confirm_Solution_Changes
               (Diff, Changed_Only => not Alire.Detailed)
             then
-               Alire.Lockfiles.Write (Solution    => New_Sol,
-                                      Environment => Platform.Properties,
-                                      Filename    => Root.Current.Lock_File);
+               Alire.Lockfiles.Write (Solution => New_Sol,
+                                      Filename => Root.Current.Lock_File);
 
                --  We force the update because we have just stored the new
                --  solution, so Update won't detect any changes.

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -15,7 +15,6 @@ with Alire.Utils;
 
 with Alr.Commands.Update;
 with Alr.Commands.User_Input;
-with Alr.Exceptions;
 with Alr.OS_Lib;
 with Alr.Platform;
 with Alr.Root;
@@ -378,11 +377,6 @@ package body Alr.Commands.Withing is
       else
          raise Program_Error with "List should have already happened";
       end if;
-   exception
-      when E : Constraint_Error =>
-         Exceptions.Report ("In Withing.Execute:", E);
-         Reportaise_Command_Failed
-           ("Could not locate package containing releases of " & Argument (1));
    end Execute;
 
    ----------------------

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -485,10 +485,7 @@ package body Alr.Commands is
                          Platform.Properties,
                          Alire.Solutions.Empty_Valid_Solution);
       begin
-         Alire.Lockfiles.Write
-           (Solution,
-            Platform.Properties,
-            Checked.Lock_File);
+         Alire.Lockfiles.Write (Solution, Checked.Lock_File);
       end;
    end Requires_Valid_Session;
 


### PR DESCRIPTION
Goes on top of #429. 

- Clean up an unused parameter in `Alire.Lockfiles`
- Remove an old helper type from `Alire.Utils`
- Remove a wrong exception handler in `Alr.Commands.Withing`