### PR TITLE
Add a -f, --force global switch

### DIFF
--- a/src/alire/alire.adb
+++ b/src/alire/alire.adb
@@ -110,18 +110,6 @@ package body Alire is
       return +Err = "";
    end Is_Valid_Name;
 
-   -------------------
-   -- Raise_Checked_Error --
-   -------------------
-
-   procedure Raise_Checked_Error (Msg : String) is
-   begin
-      if Log_Debug then
-         Err_Log (Msg);
-      end if;
-      raise Checked_Error with Errors.Set (Msg);
-   end Raise_Checked_Error;
-
    ---------------------
    -- Outcome_Failure --
    ---------------------
@@ -171,5 +159,30 @@ package body Alire is
                          Message => +Full_Msg);
       end if;
    end Outcome_From_Exception;
+
+   -------------------------
+   -- Raise_Checked_Error --
+   -------------------------
+
+   procedure Raise_Checked_Error (Msg : String) is
+   begin
+      if Log_Debug then
+         Err_Log (Msg);
+      end if;
+      raise Checked_Error with Errors.Set (Msg);
+   end Raise_Checked_Error;
+
+   -----------------------
+   -- Recoverable_Error --
+   -----------------------
+
+   procedure Recoverable_Error (Msg : String) is
+   begin
+      if Force then
+         Trace.Warning (Msg);
+      else
+         Raise_Checked_Error (Msg);
+      end if;
+   end Recoverable_Error;
 
 end Alire;

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -172,6 +172,13 @@ package Alire with Preelaborate is
    --  The exception stack trace will be dumped at debug level.
    --  If message is empty, message will be Ex exception message.
 
+   ----------------------
+   -- Error generation --
+   ----------------------
+
+   Force : aliased Boolean := False;
+   --  When True, recoverable errors are demoted to warnings and we keep going
+
    procedure Assert (Result : Outcome'Class);
    --  Does nothing for successful outcomes. Raises Checked_Error with the
    --  corresponding message set in Alire.Errors otherwise.
@@ -180,6 +187,10 @@ package Alire with Preelaborate is
    --  For errors where we do not return an Outcome_Failure, we log an error
    --  message (Msg) and raise Checked_Error. There is no limitation on the
    --  length of Msg.
+
+   procedure Recoverable_Error (Msg : String);
+   --  When Force, emit a warning and return normally. When not Force call
+   --  Raise_Checked_Error instead.
 
    ---------------
    --  LOGGING  --

--- a/src/alr/alr-commands-version.adb
+++ b/src/alr/alr-commands-version.adb
@@ -1,5 +1,5 @@
 with Alire.Properties;
-with Alire.Utils;
+with Alire.Utils.User_Input;
 
 with Alr.Files;
 with Alr.OS_Lib;
@@ -24,6 +24,11 @@ package body Alr.Commands.Version is
       Trace.Always ("alr build is " & Bootstrap.Status_Line);
       Trace.Always ("config folder is " & Paths.Alr_Config_Folder);
       Trace.Always ("source folder is " & Paths.Alr_Source_Folder);
+
+      Trace.Always
+        ("interaction flags are:"
+         & " force:" & Alire.Force'Img
+         & " not-interactive:" & Alire.Utils.User_Input.Not_Interactive'Img);
 
       if not Root.Current.Is_Valid then
          Trace.Always ("alr root is empty");

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -180,6 +180,12 @@ package body Alr.Commands is
                      Command_Line_Config_Path'Access,
                      "-c=", "--config=",
                      "Override configuration folder location");
+
+      Define_Switch (Config,
+                     Alire.Force'Access,
+                     "-f", "--force",
+                     "Keep going after a recoverable troublesome situation");
+
       Define_Switch (Config,
                      Help_Switch'Access,
                      "-h", "--help",

--- a/testsuite/tests/misc/force-switch/test.py
+++ b/testsuite/tests/misc/force-switch/test.py
@@ -1,0 +1,18 @@
+"""
+Verify the global --force switch is in effect
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+
+import re
+
+assert_match('.*interaction flags are:.*force:TRUE.*',
+             run_alr('version', '--force').out,
+             flags=re.S)
+
+assert_match('.*interaction flags are:.*force:TRUE.*',
+             run_alr('version', '-f').out,
+             flags=re.S)
+
+print('SUCCESS')

--- a/testsuite/tests/misc/force-switch/test.yaml
+++ b/testsuite/tests/misc/force-switch/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
This global modifier is available as the boolean `Alire.Force`. Other candidate locations, like `Alire.Config, ` Alire.Errors`, `Alire.Utils.User_Input` cannot be used because they bring in non-preelaborable units and it snowballs from there.

The recommended usage is through `Alire.Recoverable_Error`, which will warn or raise appropriately depending on the flag.

I plan to use this one for example to allow the addition of unindexed dependencies in conjunction with pinning of directories. It may also serve to change some defaults from No to Yes, which may be useful when running non-interactive.

Closes #197 