### PR TITLE
Move the Alr.Main exception handler to a last chance handler

### DIFF
--- a/src/alr/alr-main.adb
+++ b/src/alr/alr-main.adb
@@ -6,9 +6,7 @@ with Alr.Commands;
 with Alr.Platform.Init;
 with Alr.Platforms.Current;
 
---  Make sure the last chance handler is in the closure
 with Last_Chance_Handler;
-pragma Unreferenced (Last_Chance_Handler);
 
 procedure Alr.Main is
 begin
@@ -17,4 +15,7 @@ begin
    Trace.Detail ("alr build is " & Bootstrap.Status_Line);
 
    Commands.Execute;
+exception
+   when E : others =>
+      Last_Chance_Handler (E);
 end Alr.Main;

--- a/src/alr/alr-main.adb
+++ b/src/alr/alr-main.adb
@@ -1,12 +1,14 @@
 with Alire;
 with Alire_Early_Elaboration; pragma Elaborate_All (Alire_Early_Elaboration);
-with Alire.Errors;
 
 with Alr.Bootstrap;
 with Alr.Commands;
-with Alr.OS_Lib;
 with Alr.Platform.Init;
 with Alr.Platforms.Current;
+
+--  Make sure the last chance handler is in the closure
+with Last_Chance_Handler;
+pragma Unreferenced (Last_Chance_Handler);
 
 procedure Alr.Main is
 begin
@@ -15,12 +17,4 @@ begin
    Trace.Detail ("alr build is " & Bootstrap.Status_Line);
 
    Commands.Execute;
-exception
-   --  Ensure we do not show an exception trace to unsuspecting users
-   when E : others =>
-      Alire.Log_Exception (E);
-      Trace.Error (Alire.Errors.Get (E));
-      Trace.Error ("alr encountered an unexpected error,"
-                   & " re-run with -d for details.");
-      OS_Lib.Bailout (1);
 end Alr.Main;

--- a/src/alr/last_chance_handler.adb
+++ b/src/alr/last_chance_handler.adb
@@ -1,0 +1,14 @@
+with Alire.Errors;
+
+with Alr;
+with Alr.OS_Lib;
+
+procedure Last_Chance_Handler (E : Ada.Exceptions.Exception_Occurrence) is
+begin
+   --  Ensure we do not show an exception trace to unsuspecting users
+   Alire.Log_Exception (E);
+   Alr.Trace.Error (Alire.Errors.Get (E));
+   Alr.Trace.Error ("alr encountered an unexpected error,"
+                    & " re-run with -d for details.");
+   Alr.OS_Lib.Bailout (1);
+end Last_Chance_Handler;

--- a/src/alr/last_chance_handler.ads
+++ b/src/alr/last_chance_handler.ads
@@ -1,0 +1,4 @@
+with Ada.Exceptions;
+
+procedure Last_Chance_Handler (E : Ada.Exceptions.Exception_Occurrence);
+pragma Export (C, Last_Chance_Handler, "__gnat_last_chance_handler");


### PR DESCRIPTION
This way the exceptions raised during elaboration will also be caught.

#441 