### PR TITLE
Default to no ANSI, ASCII-only output

### DIFF
--- a/src/alire/alire-dependencies-diffs.adb
+++ b/src/alire/alire-dependencies-diffs.adb
@@ -68,8 +68,10 @@ package body Alire.Dependencies.Diffs is
 
    begin
       if This.Contains_Changes then
-         Summarize (This.Added,   "(added)",   TTY.OK ("✓"));
-         Summarize (This.Removed, "(removed)", TTY.Emph ("✗"));
+         Summarize (This.Added,   "(added)",
+                    (if TTY.Color_Enabled then TTY.OK ("✓") else "+"));
+         Summarize (This.Removed, "(removed)",
+                    (if TTY.Color_Enabled then TTY.Emph ("✗") else "-"));
          Table.Print (Info);
       else
          Trace.Info ("   No changes.");

--- a/src/alire/alire-solutions-diffs.adb
+++ b/src/alire/alire-solutions-diffs.adb
@@ -198,18 +198,33 @@ package body Alire.Solutions.Diffs is
 
                --  Show icon of change
 
-               Table.Append
-                 (Prefix
-                  & (case This.Change (Key (I)) is
-                       when Added      => TTY.OK ("✓"),
-                       when Removed    => TTY.Emph ("✗"),
-                       when External   => TTY.Warn ("↪"),
-                       when Upgraded   => TTY.OK ("⭧"),
-                       when Downgraded => TTY.Warn ("⭨"),
-                       when Pinned     => TTY.OK ("⊙"),
-                       when Unpinned   => TTY.Emph ("𐩒"),
-                       when Unchanged  => TTY.OK ("="),
-                       when Unsolved   => TTY.Error ("⚠")));
+               if TTY.Color_Enabled then
+                  Table.Append
+                    (Prefix
+                     & (case This.Change (Key (I)) is
+                          when Added      => TTY.OK    ("✓"),
+                          when Removed    => TTY.Emph  ("✗"),
+                          when External   => TTY.Warn  ("↪"),
+                          when Upgraded   => TTY.OK    ("⭧"),
+                          when Downgraded => TTY.Warn  ("⭨"),
+                          when Pinned     => TTY.OK    ("⊙"),
+                          when Unpinned   => TTY.Emph  ("𐩒"),
+                          when Unchanged  => TTY.OK    ("="),
+                          when Unsolved   => TTY.Error ("⚠")));
+               else
+                  Table.Append
+                    (Prefix
+                     & (case This.Change (Key (I)) is
+                          when Added      => "+",
+                          when Removed    => "-",
+                          when External   => "~",
+                          when Upgraded   => "^",
+                          when Downgraded => "v",
+                          when Pinned     => ".",
+                          when Unpinned   => "o",
+                          when Unchanged  => "=",
+                          when Unsolved   => "!"));
+               end if;
 
                --  Always show crate name
 

--- a/src/alire/alire-utils-tty.adb
+++ b/src/alire/alire-utils-tty.adb
@@ -14,6 +14,12 @@ package body Alire.Utils.TTY is
                                Message : String) return String;
 
    -------------------
+   -- Color_Enabled --
+   -------------------
+
+   function Color_Enabled return Boolean is (Use_Color);
+
+   -------------------
    -- Disable_Color --
    -------------------
 

--- a/src/alire/alire-utils-tty.adb
+++ b/src/alire/alire-utils-tty.adb
@@ -5,9 +5,7 @@ package body Alire.Utils.TTY is
    use all type ANSI.Colors;
    use all type ANSI.Styles;
 
-   type States is (Disabled, Enabled, Default);
-
-   Status : States := Default;
+   Use_Color : Boolean := False; -- Err on the safe side
 
    function Regular_Decorator (Level   : Simple_Logging.Levels;
                                Message : String) return String;
@@ -15,23 +13,13 @@ package body Alire.Utils.TTY is
    function Verbose_Decorator (Level   : Simple_Logging.Levels;
                                Message : String) return String;
 
-   ---------------
-   -- Use_Color --
-   ---------------
-
-   function Use_Color return Boolean is
-     (case Status is
-         when Enabled  => True,
-         when Disabled => False,
-         when Default  => Simple_Logging.Is_TTY);
-
    -------------------
    -- Disable_Color --
    -------------------
 
    procedure Disable_Color is
    begin
-      Status := Disabled;
+      Use_Color := False;
    end Disable_Color;
 
    ------------------
@@ -43,8 +31,13 @@ package body Alire.Utils.TTY is
 
       --  Enable when appropriate
 
-      if Force or else Simple_Logging.Is_TTY then
-         Status := Enabled;
+      if Force or else Is_TTY then
+         Use_Color := True;
+         Trace.Debug ("Color output enabled");
+      else
+         Trace.Debug ("Color output was requested but not enabled:"
+                      & " force=" & Force'Img
+                      & "; Is_TTY=" & Is_TTY'Img);
       end if;
 
       --  Set debug colors. When Detail/Debug are also enabled, we add the

--- a/src/alire/alire-utils-tty.ads
+++ b/src/alire/alire-utils-tty.ads
@@ -9,6 +9,12 @@ package Alire.Utils.TTY with Preelaborate is
    --  Re-expose for clients
    package ANSI renames Standard.ANSI;
 
+   --------------------
+   -- Color enabling --
+   --------------------
+
+   function Color_Enabled return Boolean;
+
    procedure Disable_Color;
    --  Disables color/formatting output even when TTY is capable
 

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -197,6 +197,11 @@ package Alire with Preelaborate is
 
    package Trace renames Simple_Logging;
 
+   Is_TTY : Boolean renames Simple_Logging.Is_TTY;
+   --  Flag to enable ASCII control sequences for progress indicators. When
+   --  redirecting the output these do not work and are too noisy. Defaults
+   --  to False.
+
    Log_Level : Simple_Logging.Levels renames Simple_Logging.Level;
    --  This one selects the verbosity level of the logging library. The usage
    --  of log levels in Alire is as follows. By default, no output is produced

--- a/src/alire/alire_early_elaboration.adb
+++ b/src/alire/alire_early_elaboration.adb
@@ -5,7 +5,7 @@ with Alire;
 with GNAT.Command_Line;
 with GNAT.OS_Lib;
 
-with GNATCOLL.Terminal;
+with Interfaces.C_Streams;
 
 with Simple_Logging.Filtering;
 
@@ -141,18 +141,9 @@ package body Alire_Early_Elaboration is
    -------------------
 
    procedure TTY_Detection is
-      use GNATCOLL.Terminal;
-      Info : Terminal_Info;
+      use Interfaces.C_Streams;
    begin
-      Init_For_Stdout (Info);
-
-      --  Internally, GNATCOLL uses _istty to ascertain color availability, so
-      --  this serves us too to check if output is being redirected, in which
-      --  case we don't want certain log output to be emitted.
-
-      if not Has_Colors (Info) then
-         Simple_Logging.Is_TTY := False;
-      end if;
+      Simple_Logging.Is_TTY := isatty (fileno (stdout)) /= 0;
    end TTY_Detection;
 
 begin

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -626,15 +626,13 @@ package body Alr.Commands is
       --  Raw_Arguments.
 
       if No_TTY then
-         Simple_Logging.Is_TTY := False;
+         Alire.Is_TTY := False;
       end if;
 
-      if Platform.Operating_System in Alire.Platforms.Windows or else
-        No_Color or else
-        No_TTY
+      if Platform.Operating_System not in Alire.Platforms.Windows and then
+        not No_Color and then
+        not No_TTY
       then
-         Alire.Utils.TTY.Disable_Color;
-      else
          Alire.Utils.TTY.Enable_Color (Force => False);
          --  This may still not enable color if TTY is detected to be incapable
       end if;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -635,6 +635,9 @@ package body Alr.Commands is
       then
          Alire.Utils.TTY.Enable_Color (Force => False);
          --  This may still not enable color if TTY is detected to be incapable
+
+         Simple_Logging.ASCII_Only := False;
+         --  Also use a fancier busy spinner
       end if;
 
       if Raw_Arguments.Is_Empty then


### PR DESCRIPTION
Color/UTF-8 output is enabled when no redirection and no Windows is detected