### PR TITLE
Detect and use Alire metadata found in pinned directory

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -4,6 +4,19 @@ This document is a development diary summarizing changes in `alr` that notably
 affect the user experience. It is intended as a one-stop point for users to
 stay on top of `alr` new features.
 
+### Use crate metadata when pinning to a directory
+
+PR [#450](https://github.com/alire-project/alire/pull/450).
+
+When pinning a dependency to a directory (`alr pin|with <crate> --url`), detect
+if the target contains Alire metadata (as usual, in an `alire` subdir). In that
+case, use it to determine further dependencies and project file scopes. Also,
+the target dependency name is verified.
+
+For such a target directory, a shortcut `with` command is available since the
+crate name can be determined from the metadata: `alr with --url
+/path/to/target` (note the absence of a crate name).
+
 ### Allow working with incomplete solutions
 
 PR [#447](https://github.com/alire-project/alire/pull/447).

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -1,3 +1,5 @@
+with Ada.Directories;
+
 with Alire.Directories;
 with Alire.Root;
 with Alire.TOML_Index;
@@ -33,7 +35,7 @@ package body Alire.Roots is
                --  Crate loaded properly, we can return a valid root here
                Trace.Debug ("Valid root found at " & Path);
                return New_Root (R    => Release,
-                                Path => Path,
+                                Path => Ada.Directories.Full_Name (Path),
                                 Env  => Alire.Root.Platform_Properties);
             end;
          else

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -1,4 +1,53 @@
+with Alire.Directories;
+with Alire.Root;
+with Alire.TOML_Index;
+
+with GNAT.OS_Lib;
+
 package body Alire.Roots is
+
+   -----------------
+   -- Detect_Root --
+   -----------------
+
+   function Detect_Root (Path : Any_Path) return Root is
+      use GNAT.OS_Lib;
+      Alire_Path : constant Any_Path :=
+                     Path / Alire.Paths.Working_Folder_Inside_Root;
+   begin
+      if not Is_Directory (Alire_Path) then
+         Trace.Debug ("No alire folder while detecting root at " & Path);
+         return New_Invalid_Root.With_Reason ("No alire metadata directory");
+      end if;
+
+      declare
+         Crate_File : constant String := Directories.Find_Single_File
+           (Path      => Alire_Path,
+            Extension => ".toml");
+      begin
+         if Crate_File /= "" then
+            declare
+               Release : constant Releases.Release :=
+                          TOML_Index.Load_Release_From_File (Crate_File);
+            begin
+               --  Crate loaded properly, we can return a valid root here
+               Trace.Debug ("Valid root found at " & Path);
+               return New_Root (R    => Release,
+                                Path => Path,
+                                Env  => Alire.Root.Platform_Properties);
+            end;
+         else
+            Trace.Debug ("No crate file found at " & Alire_Path);
+            return New_Invalid_Root.With_Reason ("no crate file found");
+         end if;
+      exception
+         when E : others =>
+            Trace.Debug ("Crate detection failed while loading toml file:");
+            Log_Exception (E);
+            return New_Invalid_Root.With_Reason
+              ("toml file found but not loadable: " & Crate_File);
+      end;
+   end Detect_Root;
 
    -------------------
    -- Project_Paths --

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -41,6 +41,11 @@ package Alire.Roots is
    -- Valid roots --
    -----------------
 
+   function Detect_Root (Path : Any_Path) return Root;
+   --  Attempt to detect a root at the given path. The root will be valid if
+   --  path/alire exists, path/alire/*.toml is unique and loadable as a crate
+   --  containing a single release.
+
    --  See Alire.Directories.Detect_Root_Path to use with the following
 
    function New_Root (Name : Crate_Name;

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -472,7 +472,7 @@ package body Alire.Solutions is
    begin
       return Result : Release_Map do
          for Dep of This.Dependencies loop
-            if Dep.Is_Solved then
+            if Dep.Has_Release then
                Result.Insert (Dep.Crate, Dep.Release);
             end if;
          end loop;

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -224,7 +224,8 @@ package Alire.Solutions is
    --  return all pinned dependencies as plain dependencies for a exact version
 
    function Releases (This : Solution) return Release_Map;
-   --  Returns the proper releases in the solution (regular and detected)
+   --  Returns the proper releases in the solution (regular and detected
+   --  externals). This also includes releases found at a linked folder.
 
    function Required (This : Solution) return State_Map'Class;
    --  Returns all dependencies required to fulfill this solution,

--- a/src/alire/alire-solver.adb
+++ b/src/alire/alire-solver.adb
@@ -359,7 +359,11 @@ package body Alire.Solver is
                     Tree'(Expanded and Target and Remaining).Image_One_Line);
 
                Expand (Expanded  => Expanded and Dep,
-                       Target    => Remaining,
+                       Target    => Remaining and
+                         (if Current.State (Dep.Crate).Has_Release
+                          then Current.State (Dep.Crate)
+                                      .Release.Dependencies (Props)
+                          else Empty),
                        Remaining => Empty,
                        Solution  =>
                          Solution.Linking (Dep.Crate,

--- a/src/alr/alr-commands-pin.adb
+++ b/src/alr/alr-commands-pin.adb
@@ -191,6 +191,11 @@ package body Alr.Commands.Pin is
                Platform.Properties,
                Old_Sol);
 
+            --  Report crate detection at target destination
+
+            User_Input.Report_Pinned_Crate_Detection (+Argument (1),
+                                                      New_Sol);
+
          else
 
             --  Change a single pin

--- a/src/alr/alr-commands-user_input.adb
+++ b/src/alr/alr-commands-user_input.adb
@@ -37,4 +37,24 @@ package body Alr.Commands.User_Input is
                       else No)) = Yes;
    end Confirm_Solution_Changes;
 
+   -----------------------------------
+   -- Report_Pinned_Crate_Detection --
+   -----------------------------------
+
+   procedure Report_Pinned_Crate_Detection
+     (Crate    : Alire.Crate_Name;
+      Solution : Alire.Solutions.Solution)
+   is
+   begin
+      if Solution.State (Crate).Has_Release then
+         Trace.Info
+           ("Alire crate detected at given destination: "
+            & Solution.State (Crate).Release
+            .Milestone.TTY_Image);
+      else
+         Trace.Warning ("No crate detected at destination;"
+                        & " using it as a raw GNAT project.");
+      end if;
+   end Report_Pinned_Crate_Detection;
+
 end Alr.Commands.User_Input;

--- a/src/alr/alr-commands-user_input.ads
+++ b/src/alr/alr-commands-user_input.ads
@@ -13,4 +13,10 @@ package Alr.Commands.User_Input is
    --  True when the user answers positively. Defaults to Yes when the new
    --  solution is complete, or when Alire.Force.
 
+   procedure Report_Pinned_Crate_Detection
+     (Crate    : Alire.Crate_Name;
+      Solution : Alire.Solutions.Solution);
+   --  When pinning a directory, report if the target already contains an
+   --  initialized crate or not. For reuse from several commands.
+
 end Alr.Commands.User_Input;

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -97,6 +97,20 @@ package body Alr.Commands.Withing is
                                       Path  => Cmd.URL.all);
       begin
 
+         --  Prevent double-add
+
+         if Old_Solution.Depends_On (New_Dep.Crate) then
+            Reportaise_Wrong_Arguments
+              ("Not adding " & New_Dep.Crate.TTY_Image & " because "
+               & Old_Solution.Dependency (New_Dep.Crate).TTY_Image
+               & " is already a dependency");
+         end if;
+
+         --  Report crate detection at target destination
+
+         User_Input.Report_Pinned_Crate_Detection (New_Dep.Crate,
+                                                   New_Solution);
+
          --  If we made here there were no errors adding the dependency
          --  and storing the softlink. We can proceed to confirming the
          --  replacement.
@@ -417,7 +431,12 @@ package body Alr.Commands.Withing is
          --  Must be Add, but it could be regular or softlink
 
          if Cmd.URL.all /= "" then
-            Add_Softlink (Cmd);
+            if Num_Arguments = 1 then
+               Add_Softlink (Cmd);
+            else
+               raise Alire.Unimplemented;
+               --  TODO: detect crate at given path, and use it
+            end if;
          else
             Requires_Full_Index;
             Add;

--- a/testsuite/tests/pin/dir-crate/test.py
+++ b/testsuite/tests/pin/dir-crate/test.py
@@ -1,0 +1,38 @@
+"""
+Detect that a given folder to pin contains a crate and use its info
+"""
+
+import os
+import re
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+from drivers.helpers import path_separator
+from glob import glob
+
+# Retrieve a crate
+run_alr('get', 'hello=1')
+target = glob('hello*')[0]
+
+# Initialize a workspace
+run_alr('init', '--bin', 'xxx')
+os.chdir('xxx')
+
+# Add dependency as regular crate; this has missing dependencies so we have to
+# force. This brings in hello=4.
+run_alr('with', 'hello', '--force')
+
+# Pin the hello crate as local dir dependency. The version in the folder is
+# different to the one we had in the solution, so this should cause a downgrade
+# but with complete solution. Now hello=1 --> libhello=1.1.
+run_alr('pin', 'hello', '--url', '..' + path_separator() + target)
+
+# Verify that hello dependencies are detected and used, and are the ones
+# corresponding to the linked dir versions.
+p = run_alr('with', '--solve')
+assert_match('''.*Dependencies \(solution\):
+   hello=1\.0\.0 .*
+   libhello=1\.1\.0 .*''',  # we skip non-relevant details
+             p.out, flags=re.S)
+
+print('SUCCESS')

--- a/testsuite/tests/pin/dir-crate/test.py
+++ b/testsuite/tests/pin/dir-crate/test.py
@@ -25,7 +25,7 @@ run_alr('with', 'hello', '--force')
 # Pin the hello crate as local dir dependency. The version in the folder is
 # different to the one we had in the solution, so this should cause a downgrade
 # but with complete solution. Now hello=1 --> libhello=1.1.
-run_alr('pin', 'hello', '--url', '..' + path_separator() + target)
+run_alr('pin', 'hello', '--use', '..' + path_separator() + target)
 
 # Verify that hello dependencies are detected and used, and are the ones
 # corresponding to the linked dir versions.

--- a/testsuite/tests/pin/dir-crate/test.yaml
+++ b/testsuite/tests/pin/dir-crate/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    solver_index:
+        in_fixtures: true

--- a/testsuite/tests/pin/dir-mismatch/test.py
+++ b/testsuite/tests/pin/dir-mismatch/test.py
@@ -19,10 +19,10 @@ run_alr('init', '--bin', 'xxx')
 os.chdir('xxx')
 
 # Add a dependency as pinned dir without metadata; this should succeed
-run_alr('with', 'nothello', '--url', '..')
+run_alr('with', 'nothello', '--use', '..')
 
 # Try to repin to a dir with valid crate metadata
-p = run_alr('with', 'nothello', '--url', '..' + path_separator() + target,
+p = run_alr('with', 'nothello', '--use', '..' + path_separator() + target,
             complain_on_error=False)
 
 # Expected error

--- a/testsuite/tests/pin/dir-mismatch/test.py
+++ b/testsuite/tests/pin/dir-mismatch/test.py
@@ -1,0 +1,32 @@
+"""
+Detect that a given folder to pin contains an unexpected crate
+"""
+
+import os
+import re
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+from drivers.helpers import path_separator
+from glob import glob
+
+# Retrieve a crate
+run_alr('get', 'hello=1')
+target = glob('hello*')[0]
+
+# Initialize a workspace
+run_alr('init', '--bin', 'xxx')
+os.chdir('xxx')
+
+# Add a dependency as pinned dir without metadata; this should succeed
+run_alr('with', 'nothello', '--url', '..')
+
+# Try to repin to a dir with valid crate metadata
+p = run_alr('with', 'nothello', '--url', '..' + path_separator() + target,
+            complain_on_error=False)
+
+# Expected error
+assert_match('.*crate mismatch: expected nothello but found hello at.*', p.out)
+# skip test-specific path
+
+print('SUCCESS')

--- a/testsuite/tests/pin/dir-mismatch/test.yaml
+++ b/testsuite/tests/pin/dir-mismatch/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    solver_index:
+        in_fixtures: true

--- a/testsuite/tests/with/pin-dir-crate-autodetect/test.py
+++ b/testsuite/tests/with/pin-dir-crate-autodetect/test.py
@@ -21,7 +21,7 @@ os.chdir('xxx')
 
 # Add the directory as pinned crate, with autodetection (no crate given,
 # inferred from the crate metadata found at target).
-run_alr('with', '--url', '..' + path_separator() + target)
+run_alr('with', '--use', '..' + path_separator() + target)
 
 # Verify that hello^1 is a new dependency and also that hello dependencies are
 # in the solution.

--- a/testsuite/tests/with/pin-dir-crate-autodetect/test.py
+++ b/testsuite/tests/with/pin-dir-crate-autodetect/test.py
@@ -1,0 +1,36 @@
+"""
+Test that `alr with --url` without explicit crate autodetects the target crate
+and correctly adds the pinned dependency
+"""
+
+import os
+import re
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+from drivers.helpers import path_separator
+from glob import glob
+
+# Retrieve a crate
+run_alr('get', 'hello=1')
+target = glob('hello*')[0]
+
+# Initialize a workspace
+run_alr('init', '--bin', 'xxx')
+os.chdir('xxx')
+
+# Add the directory as pinned crate, with autodetection (no crate given,
+# inferred from the crate metadata found at target).
+run_alr('with', '--url', '..' + path_separator() + target)
+
+# Verify that hello^1 is a new dependency and also that hello dependencies are
+# in the solution.
+p = run_alr('with', '--solve')
+assert_match('''Dependencies \(direct\):
+   hello\^1\.0\.0
+.*Dependencies \(solution\):
+   hello=1\.0\.0 .*
+   libhello=1\.1\.0 .*''',  # we skip non-relevant details
+             p.out, flags=re.S)
+
+print('SUCCESS')

--- a/testsuite/tests/with/pin-dir-crate-autodetect/test.yaml
+++ b/testsuite/tests/with/pin-dir-crate-autodetect/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    solver_index:
+        in_fixtures: true

--- a/testsuite/tests/with/pin-dir-crate/test.py
+++ b/testsuite/tests/with/pin-dir-crate/test.py
@@ -1,0 +1,31 @@
+"""
+Detect that a given folder to pin contains a crate and use its info
+"""
+
+import os
+import re
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+from drivers.helpers import path_separator
+from glob import glob
+
+# Retrieve a crate
+run_alr('get', 'hello=1')
+target = glob('hello*')[0]
+
+# Initialize a workspace
+run_alr('init', '--bin', 'xxx')
+os.chdir('xxx')
+
+# Pin the hello crate as local dir dependency
+run_alr('with', 'hello', '--url', '..' + path_separator() + target)
+
+# Verify that hello dependencies are detected and used
+p = run_alr('with', '--solve')
+assert_match('''.*Dependencies \(solution\):
+   hello=1\.0\.0 .*
+   libhello=1\.1\.0 .*''',  # we skip non-relevant details
+             p.out, flags=re.S)
+
+print('SUCCESS')

--- a/testsuite/tests/with/pin-dir-crate/test.py
+++ b/testsuite/tests/with/pin-dir-crate/test.py
@@ -19,7 +19,7 @@ run_alr('init', '--bin', 'xxx')
 os.chdir('xxx')
 
 # Pin the hello crate as local dir dependency
-run_alr('with', 'hello', '--url', '..' + path_separator() + target)
+run_alr('with', 'hello', '--use', '..' + path_separator() + target)
 
 # Verify that hello dependencies are detected and used
 p = run_alr('with', '--solve')

--- a/testsuite/tests/with/pin-dir-crate/test.yaml
+++ b/testsuite/tests/with/pin-dir-crate/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    solver_index:
+        in_fixtures: true

--- a/testsuite/tests/with/pin-dir-mismatch/test.py
+++ b/testsuite/tests/with/pin-dir-mismatch/test.py
@@ -19,7 +19,7 @@ run_alr('init', '--bin', 'xxx')
 os.chdir('xxx')
 
 # Try to pin the hello crate as local dir dependency
-p = run_alr('with', 'nothello', '--url', '..' + path_separator() + target,
+p = run_alr('with', 'nothello', '--use', '..' + path_separator() + target,
             complain_on_error=False)
 
 # Expected error

--- a/testsuite/tests/with/pin-dir-mismatch/test.py
+++ b/testsuite/tests/with/pin-dir-mismatch/test.py
@@ -1,0 +1,29 @@
+"""
+Detect that a given folder to pin contains an unexpected crate
+"""
+
+import os
+import re
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+from drivers.helpers import path_separator
+from glob import glob
+
+# Retrieve a crate
+run_alr('get', 'hello=1')
+target = glob('hello*')[0]
+
+# Initialize a workspace
+run_alr('init', '--bin', 'xxx')
+os.chdir('xxx')
+
+# Try to pin the hello crate as local dir dependency
+p = run_alr('with', 'nothello', '--url', '..' + path_separator() + target,
+            complain_on_error=False)
+
+# Expected error
+assert_match('.*crate mismatch: expected nothello but found hello at.*', p.out)
+# skip test-specific path
+
+print('SUCCESS')

--- a/testsuite/tests/with/pin-dir-mismatch/test.yaml
+++ b/testsuite/tests/with/pin-dir-mismatch/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    solver_index:
+        in_fixtures: true


### PR DESCRIPTION
Goes on top of #449.

PR #447 introduces the ability to pin a folder that needs not be an Alire crate. This allows the use of Ada code entirely out of the Alire ecosystem to fulfill a dependency. The shortcoming is that any dependencies introduced by such code will remain unknown and have to be manually dealt with. Also, if the target folder was, indeed, an Alire crate, its information is ignored.

This is an incremental feature in which, if the target folder contains Alire metadata, it is loaded and used to 

- Verify the crate we are pinning matches its dependency in name
- Add its dependencies during resolution
- Add its project paths during building
- Optionally, autodetect the crate for a shorthand `alr with --url` form.

In short, the pinned Alire crate is used normally as if it had been retrieved as a regular dependency, except for the version, which is ignored (the dependency will always be fulfilled, as if it were a "raw" pinned folder).