### PR TITLE
Show linked paths and per-release dependencies in `--solve` solutions

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -4,6 +4,20 @@ This document is a development diary summarizing changes in `alr` that notably
 affect the user experience. It is intended as a one-stop point for users to
 stay on top of `alr` new features.
 
+### Show release-specific dependency sets in solutions
+
+PR [#453](https://github.com/alire-project/alire/pull/453).
+
+The dependency solution shown with the `--solve` switch now details for each
+release the particular version set with which a dependency is brought into the
+dependency closure. For example:
+
+```
+Dependencies (graph):
+   hello=1.0.1      --> libhello=1.0.1 (^1.0)
+   superhello=1.0.0 --> libhello=1.0.1 (~1.0)
+```
+
 ### Use crate metadata when pinning to a directory
 
 PR [#450](https://github.com/alire-project/alire/pull/450).

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -184,6 +184,17 @@ package Alire.Solutions is
      with Pre => This.Depends_On (Crate);
    --  Return the specific dependency versions as currently stored
 
+   function Dependency (This      : Solution;
+                        Dependent : Crate_Name;
+                        Dependee  : Crate_Name)
+                        return Dependencies.Dependency
+     with Pre =>
+       (This.State (Dependent).Has_Release and then This.Depends_On (Dependee))
+       or else raise Program_Error with "invalid dependency request";
+   --  The solver groups dependencies on a same crate by several dependents.
+   --  This function allows identifying the concrete dependency that a solved
+   --  release introduced in the solution.
+
    function Depends_On (This : Solution;
                         Name : Crate_Name) return Boolean;
    --  Says if the solution depends on the crate in some way

--- a/testsuite/fixtures/solver_index/su/superhello.toml
+++ b/testsuite/fixtures/solver_index/su/superhello.toml
@@ -1,0 +1,14 @@
+[general]
+description = "A better hello"
+licenses = ["GPL 3.0", "MIT"]
+website = "example.com"
+maintainers = ["bob@example.com"]
+maintainers-logins = ["mylogin"]
+authors = ["Bob", "Alice"]
+
+
+['1.0.0']
+origin = "file://."
+
+    ['1.0.0'.depends-on]
+    libhello = "~1.0"

--- a/testsuite/tests/solver/one-dep-two-constraints/test.py
+++ b/testsuite/tests/solver/one-dep-two-constraints/test.py
@@ -1,0 +1,35 @@
+"""
+Test that a dependency that is introduced by two dependents with different
+constraints is properly solved and shown.
+"""
+
+import os
+import re
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+
+# Initialize project
+run_alr('init', '--bin', 'xxx')
+os.chdir('xxx')
+
+# Add dependency on hello^1. Solution is hello=1.0.1 --> libhello=1.1.0
+run_alr('with', 'hello^1')
+p = run_alr('with', '--solve')
+assert_match('.*'  # skip solution
+             'Dependencies \(graph\):\n'
+             '   hello=1.0.1 --> libhello=1.1.0 \(\^1.0\).*',
+             p.out, flags=re.S)
+
+# Add dependency on superhello*. Solution is superhello=1.0 --> libhello=1.0.1
+# This implies a downgrade from libhello=1.1.0 to libhello=1.0.1, which is the
+# only possible combination of libhello^1.0 & libhello~1.0
+run_alr('with', 'superhello')
+p = run_alr('with', '--solve')
+assert_match('.*'  # skip solution
+             'Dependencies \(graph\):\n'
+             '   hello=1.0.1      --> libhello=1.0.1 \(\^1.0\)\n'
+             '   superhello=1.0.0 --> libhello=1.0.1 \(~1.0\).*',
+             p.out, flags=re.S)
+
+print('SUCCESS')

--- a/testsuite/tests/solver/one-dep-two-constraints/test.yaml
+++ b/testsuite/tests/solver/one-dep-two-constraints/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    solver_index: {}


### PR DESCRIPTION
This PR adds some bits of new info to the output of `alr with --solve`:

In the graph section of the solution printout, the concrete dependency for each release that brings in another release is now shown. This may help in understanding why a release is chosen (or unsolvable), particularly when there are different restrictions on a same crate introduced by different releases.

For the linked folders with Alire metadata introduced in #450, the source folder is shown in the releases section. Otherwise, such source folders are listed in the externals section without a concrete release (as we cannot determine a version for them).

Example output (from the test) with the new dependency set after the solved milestone:
```
Dependencies (graph):
   hello=1.0.1      --> libhello=1.0.1 (^1.0)
   superhello=1.0.0 --> libhello=1.0.1 (~1.0)
```