### PR TITLE
Refactor variations of fulfil to fulfill

### DIFF
--- a/src/alire/alire-dependencies-states.adb
+++ b/src/alire/alire-dependencies-states.adb
@@ -64,9 +64,9 @@ package body Alire.Dependencies.States is
       -- Load_Fulfilment --
       ---------------------
 
-      function Load_Fulfilment return Fulfilment_Data is
-         Data  : Fulfilment_Data
-           (Fulfilments'Value
+      function Load_Fulfilment return Fulfillment_Data is
+         Data  : Fulfillment_Data
+           (Fulfillments'Value
               (From.Checked_Pop (Keys.Fulfilment, TOML_String).As_String));
          Crate : Crates.With_Releases.Crate :=
                    Crates.With_Releases.New_Crate (From_TOML.Crate);
@@ -153,7 +153,7 @@ package body Alire.Dependencies.States is
       -- To_TOML --
       -------------
 
-      procedure To_TOML (Data : Fulfilment_Data; Table : TOML_Value) is
+      procedure To_TOML (Data : Fulfillment_Data; Table : TOML_Value) is
       begin
          Table.Set (Keys.Fulfilment,
                     +To_Lower_Case (This.Fulfilled.Fulfillment'Img));

--- a/src/alire/alire-dependencies-states.ads
+++ b/src/alire/alire-dependencies-states.ads
@@ -11,10 +11,10 @@ package Alire.Dependencies.States is
    --  extra information goes into the lockfile and allows tracking the status
    --  of special dependencies (pins, links, missing) across solution changes.
 
-   type Fulfilments is (Missed,  -- Version not found, nor external definition
-                        Hinted,  -- Undetected external
-                        Linked,  -- Supplied for any version by a local dir
-                        Solved); -- Solved with a regular release/detected hint
+   type Fulfillments is (Missed,  -- Version not found, nor external definition
+                         Hinted,  -- Undetected external
+                         Linked,  -- Supplied for any version by a local dir
+                         Solved); -- Solved with an index release/detected hint
 
    type Transitivities is (Unknown,   -- Needed by limitations in the solver
                            Direct,    -- A dependency of the root release
@@ -59,7 +59,7 @@ package Alire.Dependencies.States is
                      Using : Releases.Release)
                      return State
      with Pre => Base.Crate = Using.Name;
-   --  Uses release to fulfil this dependency in a copy of Base
+   --  Uses release to fulfill this dependency in a copy of Base
 
    function Unpinning (Base : State) return State;
    --  Removes the pin in a copy of Base
@@ -93,7 +93,7 @@ package Alire.Dependencies.States is
 
    --  Case-specific info
 
-   function Fulfilment (This : State) return Fulfilments;
+   function Fulfilment (This : State) return Fulfillments;
 
    function Link (This : State) return Externals.Softlinks.External
      with Pre => This.Is_Linked;
@@ -162,7 +162,7 @@ private
       Versions : Semantic_Versioning.Extended.Version_Set)
       return State;
 
-   type Fulfilment_Data (Fulfillment : Fulfilments := Missed) is record
+   type Fulfillment_Data (Fulfillment : Fulfillments := Missed) is record
       case Fulfillment is
          when Linked =>
             Target  : Link_Holder;
@@ -185,7 +185,7 @@ private
    -----------
 
    type State (Name_Len : Natural) is new Dependency (Name_Len) with record
-      Fulfilled    : Fulfilment_Data;
+      Fulfilled    : Fulfillment_Data;
       Pinning      : Pinning_Data;
       Transitivity : Transitivities := Unknown;
    end record;
@@ -219,7 +219,7 @@ private
    -- Fulfilment --
    ----------------
 
-   function Fulfilment (This : State) return Fulfilments
+   function Fulfilment (This : State) return Fulfillments
    is (This.Fulfilled.Fulfillment);
 
    -----------------

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -58,10 +58,10 @@ package Alire.Solutions is
    type Solution is new Interfaces.Tomifiable with private;
 
    --  A solution stores all dependencies required by some root crate. More
-   --  precisely, it stores the regular releases that fulfil some dependency
+   --  precisely, it stores the regular releases that fulfill some dependency
    --  and the particular standing of a dependency (solved, hinted, missing...)
    --  A solved dependency will be accompanied by the particular release that
-   --  fulfils it.
+   --  fulfills it.
 
    ------------------
    -- Construction --

--- a/src/alire/alire-solver.adb
+++ b/src/alire/alire-solver.adb
@@ -267,7 +267,7 @@ package body Alire.Solver is
                elsif not R.Satisfies (Dep) then
                   Trace.Debug
                     ("SOLVER: discarding search branch because "
-                     & R.Milestone.Image & " FAILS to fulfil dependency "
+                     & R.Milestone.Image & " FAILS to fulfill dependency "
                      & Dep.TTY_Image
                      & " when the search tree was "
                      & Tree'(Expanded
@@ -287,7 +287,7 @@ package body Alire.Solver is
                              and Target
                              and Remaining).Image_One_Line);
 
-               --  If we reached here, the release fulfils the dependency and
+               --  If we reached here, the release fulfills the dependency and
                --  it's a first time seen, so we add it to the solution.
 
                else


### PR DESCRIPTION
The spellchecker complained about some declarations but missed another bunch. Better have the same spelling everywhere.

Although both are apparently correct, the spellchecker seems to favor the US-prevalent fulfill.