### PR TITLE
Rework Solutions.Diffs internals to use States

### DIFF
--- a/src/alire/alire-dependencies-diffs.adb
+++ b/src/alire/alire-dependencies-diffs.adb
@@ -68,9 +68,9 @@ package body Alire.Dependencies.Diffs is
 
    begin
       if This.Contains_Changes then
-         Summarize (This.Added,   "(added)",
+         Summarize (This.Added,   "(add)",
                     (if TTY.Color_Enabled then TTY.OK ("✓") else "+"));
-         Summarize (This.Removed, "(removed)",
+         Summarize (This.Removed, "(remove)",
                     (if TTY.Color_Enabled then TTY.Emph ("✗") else "-"));
          Table.Print (Info);
       else

--- a/src/alire/alire-solutions-diffs.ads
+++ b/src/alire/alire-solutions-diffs.ads
@@ -1,20 +1,6 @@
 with Semantic_Versioning.Extended;
 
-private with Ada.Containers.Indefinite_Ordered_Maps;
-
 package Alire.Solutions.Diffs is
-
-   type Changes is
-     (Added,      -- A new release
-      Removed,    -- A removed dependency of any kind
-      External,   -- A new external dependency
-      Upgraded,   -- An upgraded release
-      Downgraded, -- A downgraded release
-      Pinned,     -- A release being pinned
-      Unpinned,   -- A release being unpinned
-      Unchanged,  -- An unchanged dependency/release
-      Unsolved    -- A missing dependency
-     );
 
    type Diff is tagged private;
    --  Encapsulates the differences between two solutions
@@ -22,7 +8,7 @@ package Alire.Solutions.Diffs is
    function Between (Former, Latter : Solution) return Diff;
    --  Create a Diff from two solutions
 
-   function Change (This : Diff; Crate : Crate_Name) return Changes;
+   --  function Change (This : Diff; Crate : Crate_Name) return Changes;
    --  Summary of what happened with a crate
 
    function Contains_Changes (This : Diff) return Boolean;
@@ -40,41 +26,8 @@ package Alire.Solutions.Diffs is
 
 private
 
-   type Install_Status is (Unsolved, Unneeded, Hinted, Linked, Needed);
-   --  Unsolved will apply to all crates when a solution is invalid. TODO: when
-   --  reasons for solving failure are tracked, improve the diff output.
-
-   type Crate_Status (Status : Install_Status := Unneeded) is record
-      case Status is
-         when Needed =>
-            Pinned   : Boolean;
-            Version  : Semantic_Versioning.Version;
-         when Linked =>
-            Path     : UString;
-         when Hinted | Unsolved =>
-            Versions : Semantic_Versioning.Extended.Version_Set;
-         when Unneeded =>
-            null;
-      end case;
-   end record;
-
-   function Best_Version (Status : Crate_Status) return String;
-   --  Used to provide the most precise version available depending on the
-   --  crate status.
-
-   type Crate_Changes is record
-      Former, Latter : Crate_Status := (Status => Unneeded);
-   end record;
-
-   package Change_Maps is new Ada.Containers.Indefinite_Ordered_Maps
-     (Crate_Name, Crate_Changes);
-
    type Diff is tagged record
-      Former_Complete,
-      Latter_Complete : Boolean := False;
-      --  Empty solutions but with different validity still count as changes.
-
-      Changes        : Change_Maps.Map;
+      Former, Latter : Solution;
    end record;
 
 end Alire.Solutions.Diffs;

--- a/src/alire/alire-solutions-diffs.ads
+++ b/src/alire/alire-solutions-diffs.ads
@@ -8,9 +8,6 @@ package Alire.Solutions.Diffs is
    function Between (Former, Latter : Solution) return Diff;
    --  Create a Diff from two solutions
 
-   --  function Change (This : Diff; Crate : Crate_Name) return Changes;
-   --  Summary of what happened with a crate
-
    function Contains_Changes (This : Diff) return Boolean;
    --  Says if there are, in fact, changes between both solutions
 

--- a/src/alire/alire-solver.adb
+++ b/src/alire/alire-solver.adb
@@ -603,8 +603,10 @@ package body Alire.Solver is
 
             --  Mark pins as direct dependencies
 
-            for Dep of Conditional.Dependencies'(Current.Pins) loop
-               Best_Solution.Set (Dep.Value.Crate, Direct);
+            for Dep of Best_Solution.Required loop
+               if Dep.Is_User_Pinned then
+                  Best_Solution.Set (Dep.Crate, Direct);
+               end if;
             end loop;
 
             --  Mark direct dependencies

--- a/testsuite/tests/pin/change-type/test.py
+++ b/testsuite/tests/pin/change-type/test.py
@@ -36,7 +36,7 @@ p = run_alr('show', '--solve')
 s = re.escape(path_separator())  # platform-dependent
 assert_match('.*Dependencies \(external\):.*'
              'libhello\* \(direct,linked'
-             ',target=.*' + s + 'my_index' + s +
+             ',pin=.*' + s + 'my_index' + s +
              'crates' + s + 'libhello_1.0.0\).*',
              p.out, flags=re.S)
 

--- a/testsuite/tests/pin/pin-dir/test.py
+++ b/testsuite/tests/pin/pin-dir/test.py
@@ -32,7 +32,7 @@ p = run_alr('with', '--solve')
 s = re.escape(path_separator())  # platform-dependent
 assert_match('.*Dependencies \(external\):.*'
              'libhello\* \(direct,linked'
-             ',target=.*' + s + 'my_index' + s +
+             ',pin=.*' + s + 'my_index' + s +
              'crates' + s + 'libhello_1.0.0\).*',
              p.out, flags=re.S)
 

--- a/testsuite/tests/with/changes-info/test.py
+++ b/testsuite/tests/with/changes-info/test.py
@@ -1,0 +1,155 @@
+"""
+Check summary of changes shown to the user when modifying dependencies
+"""
+
+import os
+import re
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+from drivers.helpers import path_separator, with_project
+
+# Initialize a workspace for the test
+run_alr('init', '--bin', 'xxx')
+os.chdir('xxx')
+
+###############################################################################
+# Add a regular solvable dependency
+p = run_alr('with', 'libhello', quiet=False)
+assert_match(re.escape("""Requested changes:
+
+   + libhello * (add)
+
+Changes to dependency solution:
+
+   + libhello 2.0.0 (new)""") + ".*",
+             p.out, flags=re.S)
+
+###############################################################################
+# Check adding a missing crate
+p = run_alr('with', 'unobtanium', quiet=False)
+assert_match(".*" +
+             re.escape("""Requested changes:
+
+   + unobtanium * (add)
+
+Changes to dependency solution:
+
+   New solution is incomplete.
+   +! unobtanium * (new,missing)""") + ".*",
+             p.out, flags=re.S)
+
+###############################################################################
+# Check adding a pinned dir
+p = run_alr('with', 'local_crate', '--use=/', quiet=False)
+assert_match(".*" +
+             re.escape("""Requested changes:
+
+   + local_crate * (add)
+
+Changes to dependency solution:
+
+   +· local_crate unknown (new,pin=""") + ".*",  # skip platform-dependent path
+             p.out, flags=re.S)
+
+###############################################################################
+# Pinning a crate to a version
+p = run_alr('pin', 'libhello', quiet=False)
+assert_match(".*" +
+             re.escape("""Changes to dependency solution:
+
+   · libhello 2.0.0 (pin=2.0.0)""") + ".*",
+             p.out, flags=re.S)
+
+###############################################################################
+# Unpinning
+p = run_alr('pin', '--unpin', 'libhello', quiet=False)
+assert_match(".*" +
+             re.escape("""Changes to dependency solution:
+
+   o libhello 2.0.0 (unpinned)""") + ".*",
+             p.out, flags=re.S)
+
+###############################################################################
+# Removal
+p = run_alr('with', '--del', 'libhello', quiet=False)
+assert_match(".*" +
+             re.escape("""Requested changes:
+
+   - libhello * (remove)
+
+Changes to dependency solution:
+
+   - libhello 2.0.0 (removed)""") + ".*",
+             p.out, flags=re.S)
+
+###############################################################################
+# Indirect dependency
+p = run_alr('with', 'hello', quiet=False)
+assert_match(".*" +
+             re.escape("""Requested changes:
+
+   + hello * (add)
+
+Changes to dependency solution:
+
+   + hello    1.0.1 (new)""") + "\s*\n\s*" +
+             re.escape("+ libhello 1.1.0 (new,indirect)") + ".*",
+             p.out, flags=re.S)
+
+###############################################################################
+# Going from indirect to direct. Since the dependency is already in the
+# solution, there is no version change (=).
+p = run_alr('with', 'libhello', quiet=False)
+assert_match(".*" +
+             re.escape("""Requested changes:
+
+   + libhello * (add)
+
+Changes to dependency solution:
+
+   = libhello 1.1.0 (direct)""") + ".*",
+             p.out, flags=re.S)
+
+###############################################################################
+# Going from direct to indirect. Likewise, removing the dependency leaves it in
+# the solution because is still needed indirectly via 'hello'
+p = run_alr('with', '--del', 'libhello', quiet=False)
+assert_match(".*" +
+             re.escape("""Requested changes:
+
+   - libhello * (remove)
+
+Changes to dependency solution:
+
+   = libhello 1.1.0 (indirect)""") + ".*",
+             p.out, flags=re.S)
+
+###############################################################################
+# Display of downgrades. Forcing libhello=1, it results in a downgrade.
+p = run_alr('with', 'libhello=1', quiet=False)
+assert_match(".*" +
+             re.escape("""Requested changes:
+
+   + libhello =1 (add)
+
+Changes to dependency solution:
+
+   v libhello 1.0.0 (direct,downgraded from 1.1.0)""") + ".*",
+             p.out, flags=re.S)
+
+###############################################################################
+# Display of upgrades. By removing libhello=1, it can be upgraded.
+p = run_alr('with', '--del', 'libhello', quiet=False)
+assert_match(".*" +
+             re.escape("""Requested changes:
+
+   - libhello =1 (remove)
+
+Changes to dependency solution:
+
+   ^ libhello 1.1.0 (indirect,upgraded from 1.0.0)""") + ".*",
+             p.out, flags=re.S)
+
+
+print('SUCCESS')

--- a/testsuite/tests/with/changes-info/test.yaml
+++ b/testsuite/tests/with/changes-info/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    solver_index:
+        in_fixtures: true

--- a/testsuite/tests/with/pin-dir/test.py
+++ b/testsuite/tests/with/pin-dir/test.py
@@ -31,7 +31,7 @@ p = run_alr('with', '--solve')
 s = re.escape(path_separator())  # platform-dependent
 assert_match('.*Dependencies \(external\):.*'
              'libhello\* \(direct,linked'
-             ',target=.*' + s + 'my_index' + s +
+             ',pin=.*' + s + 'my_index' + s +
              'crates' + s + 'libhello_1.0.0\).*',
              p.out, flags=re.S)
 


### PR DESCRIPTION
Now that the Solution type stores information for all dependencies via Dependencies.States, making the diffs directly from the solution is both simpler, more maintainable and more accurate.

This PR reworks the implementation of `Alire.Solutions.Diffs` without changing the interface.

New tests for the expected output are included.