### PR TITLE
Move ASCII graph to `--graph` switch, and add a `--tree` alternative & fallback

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -4,6 +4,25 @@ This document is a development diary summarizing changes in `alr` that notably
 affect the user experience. It is intended as a one-stop point for users to
 stay on top of `alr` new features.
 
+### New `alr with --graph` and `alr with --tree` switches
+
+PR [#465](https://github.com/alire-project/alire/pull/465).
+
+The ASCII art dependency graph generated with `graph-easy`, that was printed at
+the end of `alr with --solve` output, is moved to its own `alr with --graph`
+switch. A fallback tree visualization is generated when `graph-easy` is
+unavailable. This new tree visualization can also be obtained with `alr with
+--tree`:
+```
+my_project=0.0.0
+├── hello=1.0.1 (^1)
+│   └── libhello=1.0.1 (^1.0)
+├── superhello=1.0.0 (*)
+│   └── libhello=1.0.1 (~1.0)
+├── unobtanium* (direct,missed) (*)
+└── wip* (direct,linked,pin=/fake) (*)
+```
+
 ### Automatically 'with' GPR project files from dependencies
 
 PR [#458](https://github.com/alire-project/alire/pull/458).

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -1,6 +1,7 @@
 with Ada.Containers;
 
 with Alire.Crates.With_Releases;
+with Alire.Dependencies.Containers;
 with Alire.Dependencies.Graphs;
 with Alire.Index;
 with Alire.OS_Lib.Subprocess;
@@ -496,6 +497,97 @@ package body Alire.Solutions is
          Table.Print (Always);
       end if;
    end Print_Pins;
+
+   ----------------
+   -- Print_Tree --
+   ----------------
+
+   procedure Print_Tree (This       : Solution;
+                         Root       : Alire.Releases.Release;
+                         Prefix     : String := "";
+                         Print_Root : Boolean := True)
+   is
+
+      Mid_Node  : constant String :=
+                    (if TTY.Color_Enabled then "├── " else "+-- ");
+      Last_Node : constant String :=
+                    (if TTY.Color_Enabled then "└── " else "+-- ");
+      Branch    : constant String :=
+                    (if TTY.Color_Enabled then "│   " else "|   ");
+      No_Branch : constant String := "    ";
+
+      procedure Print (Deps   : Dependencies.Containers.List;
+                       Prefix : String := "";
+                       Omit   : Boolean := False)
+        --  Omit is used to remove the top-level connectors, for when the tree
+        --  is printed without the root release.
+      is
+         Last : UString;
+         --  Used to store the last dependency name in a subtree, to be able to
+         --  use the proper ASCII connector. See just below.
+      begin
+
+         --  Find last printable dependency. This is related to OR trees, that
+         --  might cause the last in the enumeration to not really belong to
+         --  the solution.
+
+         for Dep of Deps loop
+            if This.Depends_On (Dep.Crate) then
+               Last := +(+Dep.Crate);
+            end if;
+         end loop;
+
+         --  Print each dependency for real
+
+         for Dep of Deps loop
+            if This.Depends_On (Dep.Crate) then
+               Trace.Always
+                 (Prefix
+                  --  The prefix is the possible "|" connectors from upper tree
+                  --  levels.
+
+                  --  Print the appropriate final connector for the node
+                  & (if Omit -- top-level, no prefix
+                    then ""
+                    else (if +Dep.Crate = +Last
+                          then Last_Node  -- A └── connector
+                          else Mid_Node)) -- A ├── connector
+
+                  --  For a dependency solved by a release, print exact
+                  --  version. Otherwise print the state of the dependency.
+                  & (if This.State (Dep.Crate).Has_Release
+                    then This.State (Dep.Crate).Release.Milestone.TTY_Image
+                    else This.State (Dep.Crate).TTY_Image)
+
+                  --  And dependency that introduces the crate in the solution
+                  & " (" & TTY.Emph (Dep.Versions.Image) & ")");
+
+               --  Recurse for further releases
+
+               if This.State (Dep.Crate).Has_Release then
+                  Print (Conditional.Enumerate
+                           (This.State (Dep.Crate).Release.Dependencies),
+                         Prefix =>
+                           Prefix
+                           --  Indent adding the proper running connector
+                           & (if Omit
+                              then ""
+                              else (if +Dep.Crate = +Last
+                                    then No_Branch  -- End of this connector
+                                    else Branch))); -- "│" over the subtree
+               end if;
+            end if;
+         end loop;
+      end Print;
+
+   begin
+      if Print_Root then
+         Trace.Always (Prefix & Root.Milestone.TTY_Image);
+      end if;
+      Print (Conditional.Enumerate (Root.Dependencies),
+             Prefix,
+             not Print_Root);
+   end Print_Tree;
 
    --------------
    -- Releases --

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -277,6 +277,13 @@ package Alire.Solutions is
    procedure Print_Pins (This : Solution);
    --  Dump a table with pins in this solution
 
+   procedure Print_Tree (This       : Solution;
+                         Root       : Alire.Releases.Release;
+                         Prefix     : String := "";
+                         Print_Root : Boolean := True);
+   --  Print the solution in tree form. If Print_Root, Root is printed too;
+   --  otherwise the tree is a forest starting at Root direct dependencies.
+
    -----------------
    -- Persistence --
    -----------------

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -270,6 +270,12 @@ package Alire.Solutions is
    --  crate not in solution that introduces the direct dependencies. When
    --  Detailed, extra information about origins is shown.
 
+   procedure Print_Graph (This     : Solution;
+                          Root     : Alire.Releases.Release;
+                          Env      : Properties.Vector);
+   --  Print an ASCII graph of dependencies using libgraph-easy-perl, if
+   --  installed, or default to Print_Tree.
+
    procedure Print_Hints (This : Solution;
                           Env  : Properties.Vector);
    --  Display hints about any undetected externals in the solutions

--- a/src/alire/alire-utils-tools.ads
+++ b/src/alire/alire-utils-tools.ads
@@ -1,9 +1,14 @@
 package Alire.Utils.Tools is
 
-   type Tool_Kind is (Git, Tar, Unzip, Curl, Mercurial, Subversion);
+   type Tool_Kind is
+     (Easy_Graph, Git, Tar, Unzip, Curl, Mercurial, Subversion);
 
-   procedure Check_Tool (Tool : Tool_Kind);
+   function Available (Tool : Tool_Kind) return Boolean;
+   --  Say if tool is already available (attemps detection for the tool, but
+   --  does not install it if missing).
+
+   procedure Check_Tool (Tool : Tool_Kind; Fail : Boolean := True);
    --  Check if a required executable tool is available in PATH.
-   --  If not, try to install it or abort.
+   --  If not, try to install it. If unable and Fail, abort, otherwise return
 
 end Alire.Utils.Tools;

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -57,7 +57,7 @@ package body Alr.Commands.Show is
                Put_Line ("Platform package: " & Rel.Origin.Package_Name);
          end if;
 
-         if Cmd.Solve or else Cmd.Tree then
+         if Cmd.Graph or else Cmd.Solve or else Cmd.Tree then
             declare
                Needed : constant Query.Solution :=
                           (if Current
@@ -74,12 +74,18 @@ package body Alr.Commands.Show is
                                 Platform.Properties,
                                 Cmd.Detail,
                                 Always);
-               else
+               elsif Cmd.Tree then
                   if Needed.Crates.Length not in 0 then
                      Trace.Always ("Dependencies (tree):");
                      Needed.Print_Tree (Rel,
                                         Prefix     => "   ",
                                         Print_Root => False);
+                  end if;
+               elsif Cmd.Graph then
+                  if Needed.Crates.Length not in 0 then
+                     Trace.Always ("Dependencies (graph):");
+                     Needed.Print_Graph (Rel,
+                                         Platform.Properties);
                   end if;
                end if;
 
@@ -211,13 +217,15 @@ package body Alr.Commands.Show is
       end if;
 
       if Cmd.External and then
-        (Cmd.Detect or Cmd.Jekyll or Cmd.Solve or Cmd.Tree)
+        (Cmd.Detect or Cmd.Jekyll or Cmd.Graph or Cmd.Solve or Cmd.Tree)
       then
          Reportaise_Wrong_Arguments
            ("Switch --external can only be combined with --system");
       end if;
 
-      if Num_Arguments = 1 or else Cmd.Solve  or else Cmd.Tree then
+      if Num_Arguments = 1 or else
+        Cmd.Graph or else Cmd.Solve or else Cmd.Tree
+      then
          Requires_Full_Index;
       end if;
 
@@ -299,6 +307,10 @@ package body Alr.Commands.Show is
                      Cmd.External'Access,
                      "", "--external",
                      "Show info about external definitions for a crate");
+
+      Define_Switch (Config,
+                     Cmd.Graph'Access,
+                     "", "--graph", "Print ASCII graph of dependencies");
 
       Define_Switch (Config,
                      Cmd.System'Access,

--- a/src/alr/alr-commands-show.ads
+++ b/src/alr/alr-commands-show.ads
@@ -16,7 +16,8 @@ package Alr.Commands.Show is
      ("See information about a release");
 
    overriding function Usage_Custom_Parameters (Cmd : Command) return String is
-     ("<crate>[allowed versions]");
+     ("[<crate>[allowed versions]] [--system] [--external[-detect]"
+      & " | --graph | --jekyll | --solve | --tree");
 
 private
 
@@ -24,6 +25,7 @@ private
       Detail   : aliased Boolean := False;
       Detect   : aliased Boolean := False;
       External : aliased Boolean := False;
+      Graph    : aliased Boolean := False;
       Solve    : aliased Boolean := False;
       System   : aliased Boolean := False;
       Tree     : aliased Boolean := False;

--- a/src/alr/alr-commands-show.ads
+++ b/src/alr/alr-commands-show.ads
@@ -26,6 +26,7 @@ private
       External : aliased Boolean := False;
       Solve    : aliased Boolean := False;
       System   : aliased Boolean := False;
+      Tree     : aliased Boolean := False;
       Jekyll   : aliased Boolean := False;
    end record;
 

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -441,6 +441,7 @@ package body Alr.Commands.Withing is
 
       Check (Cmd.Del);
       Check (Cmd.From);
+      Check (Cmd.Graph);
       Check (Cmd.Solve);
       Check (Cmd.Tree);
 
@@ -451,6 +452,10 @@ package body Alr.Commands.Withing is
             return;
          elsif Cmd.Tree then
             Root.Current.Solution.Print_Tree (Root.Current.Release);
+            return;
+         elsif Cmd.Graph then
+            Root.Current.Solution.Print_Graph
+              (Root.Current.Release, Platform.Properties);
             return;
          end if;
       end if;
@@ -555,6 +560,11 @@ package body Alr.Commands.Withing is
                      Cmd.From'Access,
                      "", "--from",
                      "Use dependencies declared within GPR project file");
+
+      Define_Switch (Config,
+                     Cmd.Graph'Access,
+                     "", "--graph",
+                     "Show ASCII graph of dependencies");
 
       Define_Switch
         (Config      => Config,

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -442,11 +442,17 @@ package body Alr.Commands.Withing is
       Check (Cmd.Del);
       Check (Cmd.From);
       Check (Cmd.Solve);
+      Check (Cmd.Tree);
 
       --  No parameters: give current platform dependencies and BAIL OUT
-      if Num_Arguments = 0 and then (Flags = 0 or else Cmd.Solve) then
-         List (Cmd);
-         return;
+      if Num_Arguments = 0 then
+         if Flags = 0 or else Cmd.Solve then
+            List (Cmd);
+            return;
+         elsif Cmd.Tree then
+            Root.Current.Solution.Print_Tree (Root.Current.Release);
+            return;
+         end if;
       end if;
 
       if Num_Arguments < 1 then
@@ -561,6 +567,11 @@ package body Alr.Commands.Withing is
                      Cmd.Solve'Access,
                      "", "--solve",
                      "Show complete solution to dependencies");
+
+      Define_Switch (Config,
+                     Cmd.Tree'Access,
+                     "", "--tree",
+                     "Show complete dependency tree");
    end Setup_Switches;
 
 end Alr.Commands.Withing;

--- a/src/alr/alr-commands-withing.ads
+++ b/src/alr/alr-commands-withing.ads
@@ -28,6 +28,7 @@ private
    type Command is new Commands.Command with record
       Del   : aliased Boolean := False;
       From  : aliased Boolean := False;
+      Graph : aliased Boolean := False;
       Solve : aliased Boolean := False;
       Tree  : aliased Boolean := False;
       URL   : aliased GNAT.Strings.String_Access;

--- a/src/alr/alr-commands-withing.ads
+++ b/src/alr/alr-commands-withing.ads
@@ -20,7 +20,8 @@ package Alr.Commands.Withing is
    overriding function Usage_Custom_Parameters (Cmd : Command) return String is
      ("[{ [--del] <crate>[versions]..."
       & " | --from <gpr_file>..."
-      & " | <crate>[versions] --use <path> } ]");
+      & " | <crate>[versions] --use <path> } ]"
+      & " | --tree");
 
 private
 
@@ -28,6 +29,7 @@ private
       Del   : aliased Boolean := False;
       From  : aliased Boolean := False;
       Solve : aliased Boolean := False;
+      Tree  : aliased Boolean := False;
       URL   : aliased GNAT.Strings.String_Access;
    end record;
 

--- a/testsuite/tests/with/tree-switch/test.py
+++ b/testsuite/tests/with/tree-switch/test.py
@@ -1,0 +1,38 @@
+"""
+Check output of the --tree switch
+"""
+
+import os
+import re
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+
+# Initialize project
+run_alr('init', '--bin', 'xxx')
+os.chdir('xxx')
+
+# Add dependency on hello^1. Solution is hello=1.0.1 --> libhello=1.1.0
+run_alr('with', 'hello^1')
+
+# Add dependency on superhello*. Solution is superhello=1.0 --> libhello=1.0.1
+# This implies a downgrade from libhello=1.1.0 to libhello=1.0.1, which is the
+# only possible combination of libhello^1.0 & libhello~1.0
+run_alr('with', 'superhello')
+
+# Add more dependencies, without a proper release
+run_alr('with', 'wip', '--use', '/fake')
+run_alr('with', 'unobtanium', '--force')
+
+# Verify printout (but for test-dependent path)
+p = run_alr('with', '--tree')
+assert_match(re.escape('''xxx=0.0.0
++-- hello=1.0.1 (^1)
+|   +-- libhello=1.0.1 (^1.0)
++-- superhello=1.0.0 (*)
+|   +-- libhello=1.0.1 (~1.0)
++-- unobtanium* (direct,missed) (*)
++-- wip* (direct,linked,pin=''') + '.*' + re.escape(') (*)'),
+             p.out, flags=re.S)
+
+print('SUCCESS')

--- a/testsuite/tests/with/tree-switch/test.yaml
+++ b/testsuite/tests/with/tree-switch/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    solver_index: {}


### PR DESCRIPTION
Currently we attempt to print the ASCII art box graph always at the end of `alr with --solve`. This has two problems: one, that when `easy-graph` isn't installed a warning is always emitted. Two, that when installed, that graph can quickly become too large and may difficult using the rest of the output of `--solve` (which may be the actual part one is interested in).

With this PR, this ASCII graph is removed from `--solve` and emitted stand-alone using the `--graph` switch, for when one is actually interested in that graph.

As a fallback for when `easy-graph` isn't available, a tree representation is provided:
```
xxx=0.0.0
├── hello=1.0.1 (^1)
│   └── libhello=1.0.1 (^1.0)
├── superhello=1.0.0 (*)
│   └── libhello=1.0.1 (~1.0)
├── unobtanium* (direct,missed) (*)
└── wip* (direct,linked,pin=/fake) (*)
```
This tree can also be obtained explicitly with `with --tree`. It shows in essence the same information than `--solve`, but because of the explicit branching, it may be more readable in that regard. `--solve` remains as the "text-only" more detailed output.