### PR TITLE
Alr.Commands.Init: add library type handling in generated project

### DIFF
--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -422,6 +422,17 @@ package body Alire.Utils is
    end To_Lower_Case;
 
    -------------------
+   -- To_Upper_Case --
+   -------------------
+
+   function To_Upper_Case (S : String) return String is
+   begin
+      return SLC : String := S do
+         GNAT.Case_Util.To_Upper (SLC);
+      end return;
+   end To_Upper_Case;
+
+   -------------------
    -- To_Mixed_Case --
    -------------------
 

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -35,6 +35,7 @@ package Alire.Utils with Preelaborate is
    function Quote (S : String) return String;
 
    function To_Lower_Case (S : String) return String;
+   function To_Upper_Case (S : String) return String;
    function To_Mixed_Case (S : String) return String;
 
    function Contains (Text : String; Sub : String) return Boolean;

--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -34,6 +34,7 @@ package body Alr.Commands.Init is
       For_Library : constant Boolean := not Cmd.Bin;
       Name        : constant String := Argument (1);
       Lower_Name  : constant String := Utils.To_Lower_Case (Name);
+      Upper_Name  : constant String := Utils.To_Upper_Case (Name);
       Mixed_Name  : constant String := Utils.To_Mixed_Case (Name);
 
       Directory     : constant Virtual_File :=
@@ -77,6 +78,14 @@ package body Alr.Commands.Init is
          Put_Line ("   for Object_Dir use ""obj"";");
          if For_Library then
             Put_Line ("   for Library_Dir use ""lib"";");
+            Put_New_Line;
+            Put_Line ("   type Library_Type_Type is " &
+                        "(""relocatable"", ""static"", ""static-pic"");");
+            Put_Line ("   Library_Type : Library_Type_Type :=");
+            Put_Line ("     external (""" & Upper_Name & "_LIBRARY_TYPE"",");
+            Put_Line ("               external (""LIBRARY_TYPE"", " &
+                        """static""));");
+            Put_Line ("   for Library_Kind use Library_Type;");
          else
             Put_Line ("   for Exec_Dir use ""bin"";");
             Put_Line ("   for Main use (""" & Lower_Name & ".adb"");");

--- a/src/alr/alr-utils.ads
+++ b/src/alr/alr-utils.ads
@@ -7,6 +7,9 @@ package Alr.Utils is
    function To_Lower_Case (S : String) return String
    renames Alire.Utils.To_Lower_Case;
 
+   function To_Upper_Case (S : String) return String
+   renames Alire.Utils.To_Upper_Case;
+
    function To_Mixed_Case (S : String) return String
    renames Alire.Utils.To_Mixed_Case;
 


### PR DESCRIPTION
```
   type Library_Type_Type is ("relocatable", "static", "static-pic");
   Library_Type : Library_Type_Type :=
     external ("XXX_LIBRARY_TYPE",
               external ("LIBRARY_TYPE", "static"));
   for Library_Kind use Library_Type;
```