### PR TITLE
Move manifest and lock files to top-level folder

### DIFF
--- a/src/alire/alire-lockfiles.adb
+++ b/src/alire/alire-lockfiles.adb
@@ -2,7 +2,6 @@ with Ada.Directories;
 with Ada.Text_IO;
 
 with Alire.Directories;
-with Alire.Paths;
 
 with TOML.File_IO;
 
@@ -27,8 +26,8 @@ package body Alire.Lockfiles is
    ---------------
 
    function File_Name (Name     : Crate_Name;
-                       Root_Dir : Any_Path) return Any_Path is
-     (Root_Dir / Paths.Working_Folder_Inside_Root / (+Name) & ".lock");
+                       Root_Dir : Any_Path) return Any_Path
+   is (Root_Dir / "alire.lock");
 
    ---------------
    -- From_TOML --

--- a/src/alire/alire-lockfiles.ads
+++ b/src/alire/alire-lockfiles.ads
@@ -24,8 +24,8 @@ package Alire.Lockfiles is
 
    function File_Name (Name     : Crate_Name;
                        Root_Dir : Any_Path) return Any_Path;
-   --  Return the location /path/to/crate/dir/alire/crate.lock, filename
-   --  included, given the root directory where the crate is deployed.
+   --  Return the location /path/to/crate/dir/alire.lock, filename included,
+   --  given the root directory where the crate is deployed.
 
    function Read (Filename : Any_Path) return Contents;
    --  Read contents from the given lockfile

--- a/src/alire/alire-root.adb
+++ b/src/alire/alire-root.adb
@@ -1,7 +1,4 @@
 with Alire.Directories;
-with Alire.Errors;
-with Alire.Manifest;
-with Alire.Paths;
 with Alire.Releases;
 
 package body Alire.Root is
@@ -22,21 +19,7 @@ package body Alire.Root is
       Path      : constant String := Directories.Detect_Root_Path;
    begin
       if Path /= "" then
-         declare
-            File    : constant String :=
-              Directories.Find_Single_File
-                (Path      => Path / Paths.Working_Folder_Inside_Root,
-                 Extension => Paths.Crate_File_Extension_With_Dot);
-         begin
-            return Roots.New_Root
-              (Releases.From_Manifest (File, Manifest.Local),
-               Path,
-               Platform_Properties);
-         exception
-            when E : others =>
-               Raise_Checked_Error
-                 ("Failed to load " & File & ": " & Errors.Get (E));
-         end;
+         return Roots.Detect_Root (Path);
       else
          Raise_Checked_Error
            ("Could not detect a session folder" &
@@ -44,10 +27,18 @@ package body Alire.Root is
       end if;
    end Current;
 
+   -------------------------
+   -- Platform_Properties --
+   -------------------------
+
    Environment : Properties.Vector;
 
    function Platform_Properties return Properties.Vector
    is (Environment);
+
+   -----------------------------
+   -- Set_Platform_Properties --
+   -----------------------------
 
    procedure Set_Platform_Properties (Env : Properties.Vector) is
    begin

--- a/src/alire/alire-workspace.adb
+++ b/src/alire/alire-workspace.adb
@@ -13,8 +13,6 @@ with Alire.Roots;
 with Alire.Solutions.Diffs;
 with Alire.Workspace;
 
-with GNATCOLL.VFS;
-
 package body Alire.Workspace is
 
    use type Conditional.Dependencies;
@@ -232,6 +230,8 @@ package body Alire.Workspace is
                                Env);
          begin
 
+            Ada.Directories.Create_Path (Root.Working_Folder);
+
             --  Detect a pre-existing manifest (that was distributed with the
             --  sources) and move it out of the way.
 
@@ -264,16 +264,10 @@ package body Alire.Workspace is
    procedure Generate_Manifest (Release : Releases.Release;
                                 Root    : Roots.Root := Alire.Root.Current)
    is
-      use GNATCOLL.VFS;
-      F : constant Virtual_File := Create (+Root.Crate_File,
-                                           Normalize => True);
    begin
       Trace.Debug ("Generating " & Release.Name_Str & ".toml file for "
                    & Release.Milestone.Image & " with"
                    & Release.Dependencies.Leaf_Count'Img & " dependencies");
-
-      --  Ensure working folder exists (might not upon first get)
-      F.Get_Parent.Make_Dir;
 
       Directories.Backup_If_Existing (Root.Crate_File);
 


### PR DESCRIPTION
The manifest and lock files expected location is changed:

- Name is always `alire.toml`, `alire.lock` (crate name is now inside the manifest).
- They're at top-level instead of inside `${crate_root}/alire`.

This way, there's less confusion that these files go under version control and the `alire` folder is to be ignored.