### PR TITLE
Rename config files to `config.toml`

### DIFF
--- a/src/alire/alire-config.adb
+++ b/src/alire/alire-config.adb
@@ -277,7 +277,7 @@ package body Alire.Config is
    begin
       case Lvl is
          when Global =>
-            return Alire.Config.Path / "config";
+            return Alire.Config.Path / "config.toml";
          when Local =>
             declare
                Candidate : constant String :=
@@ -286,7 +286,7 @@ package body Alire.Config is
                if Candidate /= "" then
                   --  This file cannot have a .toml extension or the root
                   --  detection will not work.
-                  return Candidate / "alire" / "config";
+                  return Candidate / "alire" / "config.toml";
                else
                   Raise_Checked_Error
                     ("Can only be used in an Alire directory");


### PR DESCRIPTION
After fixing the local manifest file name to `alire.toml`, there is no possible confusion with other toml files in the same directory, so we can explicitly give `.toml` extension to config files.