### PR TITLE
Use local repository as reference for publishing

### DIFF
--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -357,6 +357,15 @@ package body Alire.Directories is
       when E : Use_Error =>
          --  For unclear reasons, Windows has trouble removing a folder that
          --  contains a git repository. Warn and continue until we know more.
+
+         --  The actual error, as reported by Python3:
+         --  PermissionError: [WinError 5] Access is denied:
+         --  'alr-fwrt.tmp\\.git\\objects\\1d\\'
+         --  '696bed4ef917b1adbdef18723016987ed62e41'
+
+         --  Since we are running tests as root, this might be that the file is
+         --  still open, but by whom?
+
          Log_Exception (E);
          Trace.Warning ("Could not delete temporary: " & This.Filename);
       when E : others =>

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -417,7 +417,7 @@ package body Alire.Publish is
    ----------------------
 
    procedure Local_Repository (Path     : Any_Path := ".";
-                               Revision : String   := "")
+                               Revision : String   := "HEAD")
    is
       Root : constant Roots.Optional.Root := Roots.Optional.Search_Root (Path);
       use all type VCSs.Git.States;
@@ -466,7 +466,7 @@ package body Alire.Publish is
                                  & TTY.Emph (Revision));
          end if;
 
-         Remote_Origin
+         Publish.Remote_Origin
            (URL => Git.Fetch_URL (Root.Value.Path),
             Commit => Commit);
       end;

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -466,23 +466,23 @@ package body Alire.Publish is
                                  & TTY.Emph (Revision));
          end if;
 
-         Verify_And_Create_Index_Manifest
-           (Origin => Git.Fetch_URL (Root.Value.Path),
+         Remote_Origin
+           (URL => Git.Fetch_URL (Root.Value.Path),
             Commit => Commit);
       end;
    end Local_Repository;
 
-   --------------------------------------
-   -- Verify_And_Create_Index_Manifest --
-   --------------------------------------
+   -------------------
+   -- Remote_Origin --
+   -------------------
 
-   procedure Verify_And_Create_Index_Manifest (Origin : URL;
-                                               Commit : String := "")
+   procedure Remote_Origin (URL    : Alire.URL;
+                            Commit : String := "")
    is
    begin
       --  Preliminary argument checks
 
-      if Utils.Ends_With (Utils.To_Lower_Case (Origin), ".git") and then
+      if Utils.Ends_With (Utils.To_Lower_Case (URL), ".git") and then
         Commit = ""
       then
          Raise_Checked_Error
@@ -495,12 +495,12 @@ package body Alire.Publish is
          Context : Data :=
                      (Origin =>
                         (if Commit /= "" then
-                            Origins.New_VCS (Origin, Commit)
-                         elsif URI.Scheme (Origin) in URI.VCS_Schemes then
+                            Origins.New_VCS (URL, Commit)
+                         elsif URI.Scheme (URL) in URI.VCS_Schemes then
                             raise Checked_Error with
                               "A commit id is mandatory for a VCS origin"
                          else
-                            Origins.New_Source_Archive (Origin)),
+                            Origins.New_Source_Archive (URL)),
 
                       Tmp_Deploy_Dir => <>);
       begin
@@ -512,7 +512,7 @@ package body Alire.Publish is
            (Errors.Wrap
               ("Could not complete the publishing assistant",
                Errors.Get (E)));
-   end Verify_And_Create_Index_Manifest;
+   end Remote_Origin;
 
    -------------------------
    -- Print_Trusted_Sites --

--- a/src/alire/alire-publish.ads
+++ b/src/alire/alire-publish.ads
@@ -6,13 +6,13 @@ package Alire.Publish is
    procedure Local_Repository (Path     : Any_Path := ".";
                                Revision : String   := "") with
      Pre => URI.Scheme (Path) in URI.File_Schemes;
-   --  Check that given Path is an up-to-date git repo with origin in the
+   --  Check that given Path is an up-to-date git repo with URL in the
    --  whitelist. If so, proceed with remote repo verification. If no revision
    --  given use the HEAD commit, otherwise use the revision (tag, branch,
    --  commit) commit.
 
-   procedure Verify_And_Create_Index_Manifest (Origin : URL;
-                                               Commit : String := "");
+   procedure Remote_Origin (URL    : Alire.URL;
+                            Commit : String := "");
    --  Requires a remote URL to a source file or a git repository. Commit is
    --  mandatory in the latter case. Produces a file `crate-version.toml` in
    --  the current directory or raises Checked_Error with the appropriate error

--- a/src/alire/alire-publish.ads
+++ b/src/alire/alire-publish.ads
@@ -4,12 +4,11 @@ with Alire.URI;
 package Alire.Publish is
 
    procedure Local_Repository (Path     : Any_Path := ".";
-                               Revision : String   := "") with
+                               Revision : String   := "HEAD") with
      Pre => URI.Scheme (Path) in URI.File_Schemes;
-   --  Check that given Path is an up-to-date git repo with URL in the
-   --  whitelist. If so, proceed with remote repo verification. If no revision
-   --  given use the HEAD commit, otherwise use the revision (tag, branch,
-   --  commit) commit.
+   --  Check that given Path is an up-to-date git repo. If so, proceed with
+   --  remote repo verification. If no revision given use the HEAD commit,
+   --  otherwise use the revision (tag, branch, commit) commit.
 
    procedure Remote_Origin (URL    : Alire.URL;
                             Commit : String := "");

--- a/src/alire/alire-publish.ads
+++ b/src/alire/alire-publish.ads
@@ -1,6 +1,15 @@
 with Alire.Origins;
+with Alire.URI;
 
 package Alire.Publish is
+
+   procedure Local_Repository (Path     : Any_Path := ".";
+                               Revision : String   := "") with
+     Pre => URI.Scheme (Path) in URI.File_Schemes;
+   --  Check that given Path is an up-to-date git repo with origin in the
+   --  whitelist. If so, proceed with remote repo verification. If no revision
+   --  given use the HEAD commit, otherwise use the revision (tag, branch,
+   --  commit) commit.
 
    procedure Verify_And_Create_Index_Manifest (Origin : URL;
                                                Commit : String := "");

--- a/src/alire/alire-roots-optional.adb
+++ b/src/alire/alire-roots-optional.adb
@@ -59,6 +59,15 @@ package body Alire.Roots.Optional is
       end if;
    end Detect_Root;
 
+   -----------------
+   -- Search_Root --
+   -----------------
+
+   function Search_Root (From : Any_Path) return Optional.Root
+   is (Detect_Root
+       (Directories.Detect_Root_Path
+        (Ada.Directories.Full_Name (From))));
+
    ---------------
    -- Is_Broken --
    ---------------

--- a/src/alire/alire-roots-optional.ads
+++ b/src/alire/alire-roots-optional.ads
@@ -20,6 +20,10 @@ package Alire.Roots.Optional is
      Implicit_Dereference => Ptr;
 
    function Detect_Root (Path : Any_Path) return Optional.Root;
+   --  Try to detect a root at the given Path
+
+   function Search_Root (From : Any_Path) return Optional.Root;
+   --  Try to detect a root at From or any ancestor folder
 
    function Status (This : Root) return States;
 

--- a/src/alire/alire-vcss-git.adb
+++ b/src/alire/alire-vcss-git.adb
@@ -29,7 +29,9 @@ package body Alire.VCSs.Git is
       --  Make sure git is installed
       Utils.Tools.Check_Tool (Utils.Tools.Git);
 
-      return OS_Lib.Subprocess.Checked_Spawn_And_Capture ("git", Arguments);
+      return
+        OS_Lib.Subprocess.Checked_Spawn_And_Capture
+          ("git", Arguments, Err_To_Out => True);
    end Run_Git_And_Capture;
 
    ------------
@@ -82,7 +84,7 @@ package body Alire.VCSs.Git is
             Guard : Directories.Guard (Directories.Enter (Into))
               with Unreferenced;
          begin
-            --  Checkout a specific commit.
+            --  Checkout a specific Rev.
             --  "-q" needed to avoid the "detached HEAD" warning from git
             Run_Git (Empty_Vector & "checkout" & "-q" & Commit (From));
 
@@ -98,6 +100,60 @@ package body Alire.VCSs.Git is
          return Alire.Errors.Get (E);
    end Clone;
 
+   ---------------------
+   -- Revision_Commit --
+   ---------------------
+
+   function Revision_Commit (This   : VCS;
+                             Repo   : Directory_Path;
+                             Rev    : String)
+                             return String
+   is
+      pragma Unreferenced (This);
+      Guard  : Directories.Guard (Directories.Enter (Repo)) with Unreferenced;
+   begin
+      declare
+         Output : constant Utils.String_Vector :=
+                 Run_Git_And_Capture
+                   (Empty_Vector
+                    & "log" & Rev
+                    & "-n1" & "--oneline" & "--no-abbrev-commit");
+      begin
+         --  Check expected output
+         if Output.Length in 1 then
+            return Head (Output.First_Element, ' ');
+         else
+            return "";
+         end if;
+      end;
+   exception
+      when others =>
+         --  git exits with code 128 for a non-existing Rev
+         return "";
+   end Revision_Commit;
+
+   ---------------
+   -- Fetch_URL --
+   ---------------
+
+   function Fetch_URL (This   : VCS;
+                       Repo   : Directory_Path;
+                       Origin : String := "origin")
+                       return URL
+   is
+      Guard  : Directories.Guard (Directories.Enter (Repo)) with Unreferenced;
+      Output : constant Utils.String_Vector :=
+                 Run_Git_And_Capture (Empty_Vector & "config" & "--list");
+   begin
+      for Line of Output loop
+         if Starts_With (Line, "remote." & Origin & ".url") then
+            return Tail (Line, '=');
+         end if;
+      end loop;
+
+      return "";
+   end Fetch_URL;
+
    -----------------
    -- Is_Detached --
    -----------------
@@ -112,12 +168,60 @@ package body Alire.VCSs.Git is
    begin
 
       --  When a repo is in detached head state (e.g. after checking out a
-      --  commit instead of a branch), 'git status' will have as the first line
-      --  "HEAD detached at <commit>". Other changes come next.
+      --  Rev instead of a branch), 'git status' will have as the first line
+      --  "HEAD detached at <Rev>". Other changes come next.
 
       return not Output.Is_Empty
         and then Utils.Contains (Output.First_Element, "HEAD detached");
    end Is_Detached;
+
+   ------------
+   -- Remote --
+   ------------
+
+   function Remote (This : VCS; Path : Directory_Path) return String is
+      Guard  : Directories.Guard (Directories.Enter (Path)) with Unreferenced;
+   begin
+      return Run_Git_And_Capture (Empty_Vector & "remote").First_Element;
+   end Remote;
+
+   ------------
+   -- Status --
+   ------------
+
+   function Status (This : VCS;
+                    Repo : Directory_Path)
+                    return States
+   is
+      Guard  : Directories.Guard (Directories.Enter (Repo)) with Unreferenced;
+
+      --  Out_1 should be portable. Out_2 is used as last resort; I believe
+      --  git is not localized so it should always work but since it relies on
+      --  human output it might break at any time I guess. Worst case, we would
+      --  report an 'Ahead' as 'Dirty'.
+
+      Out_1 : constant Utils.String_Vector :=
+                 Run_Git_And_Capture (Empty_Vector & "status" & "--porcelain");
+   begin
+
+      --  Turns out the temporary file we use to capture the output of "git
+      --  status" makes git to return a dirty tree. We filter these out then.
+
+      if (for all Line of Out_1 => Contains (Line, "GNAT-TEMP-")) then
+         --  It's clean, but is it ahead of the remote?
+         if Run_Git_And_Capture (Empty_Vector
+                                 & "rev-list"
+                                 & String'(This.Remote (Repo) & "..HEAD"))
+                                .Is_Empty
+         then
+            return Clean;
+         else
+            return Ahead;
+         end if;
+      else
+         return Dirty;
+      end if;
+   end Status;
 
    ------------
    -- Update --
@@ -144,5 +248,23 @@ package body Alire.VCSs.Git is
       when E : others =>
          return Alire.Errors.Get (E);
    end Update;
+
+   -----------------
+   -- Head_Commit --
+   -----------------
+
+   function Head_Commit (This : VCS;
+                            Repo : Directory_Path)
+                            return String
+   is
+      pragma Unreferenced (This);
+      Guard  : Directories.Guard (Directories.Enter (Repo)) with Unreferenced;
+      Output : constant Utils.String_Vector :=
+                 Run_Git_And_Capture
+                   (Empty_Vector
+                    & "log" & "-n1" & "--oneline" & "--no-abbrev-commit");
+   begin
+      return Head (Output.First_Element, ' ');
+   end Head_Commit;
 
 end Alire.VCSs.Git;

--- a/src/alire/alire-vcss-git.adb
+++ b/src/alire/alire-vcss-git.adb
@@ -84,7 +84,7 @@ package body Alire.VCSs.Git is
             Guard : Directories.Guard (Directories.Enter (Into))
               with Unreferenced;
          begin
-            --  Checkout a specific Rev.
+            --  Checkout a specific commit.
             --  "-q" needed to avoid the "detached HEAD" warning from git
             Run_Git (Empty_Vector & "checkout" & "-q" & Commit (From));
 
@@ -141,6 +141,7 @@ package body Alire.VCSs.Git is
                        Origin : String := "origin")
                        return URL
    is
+      pragma Unreferenced (This);
       Guard  : Directories.Guard (Directories.Enter (Repo)) with Unreferenced;
       Output : constant Utils.String_Vector :=
                  Run_Git_And_Capture (Empty_Vector & "config" & "--list");
@@ -168,8 +169,8 @@ package body Alire.VCSs.Git is
    begin
 
       --  When a repo is in detached head state (e.g. after checking out a
-      --  Rev instead of a branch), 'git status' will have as the first line
-      --  "HEAD detached at <Rev>". Other changes come next.
+      --  commit instead of a branch), 'git status' will have as the first line
+      --  "HEAD detached at <commit>". Other changes come next.
 
       return not Output.Is_Empty
         and then Utils.Contains (Output.First_Element, "HEAD detached");
@@ -180,6 +181,7 @@ package body Alire.VCSs.Git is
    ------------
 
    function Remote (This : VCS; Path : Directory_Path) return String is
+      pragma Unreferenced (This);
       Guard  : Directories.Guard (Directories.Enter (Path)) with Unreferenced;
    begin
       return Run_Git_And_Capture (Empty_Vector & "remote").First_Element;

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -17,14 +17,49 @@ package Alire.VCSs.Git is
                    return Outcome;
 
    not overriding
+   function Revision_Commit (This   : VCS;
+                             Repo   : Directory_Path;
+                             Rev    : String)
+                             return String;
+   --  Returns the commit for a revision, if the repository and revision
+   --  (commit, tag, branch...) exist. Should be a no-op for a commit.
+
+   not overriding
    function Is_Detached (This : VCS;
                          Path : Directory_Path) return Boolean;
    --  Says if the repo checked out at Path is in a detached HEAD state.
+
+   not overriding
+   function Remote (This : VCS; Path : Directory_Path) return String;
+   --  Retrieve current remote name (usually "origin")
 
    overriding
    function Update (This : VCS;
                     Repo : Directory_Path)
                     return Outcome;
+
+   type States is (Clean, Ahead, Dirty);
+   --  Three states we are interested in for publishing: clean and up-to-date,
+   --  clean but not yet pushed, and dirty.
+
+   not overriding
+   function Status (This : VCS;
+                    Repo : Directory_Path)
+                    return States;
+
+   not overriding
+   function Fetch_URL (This   : VCS;
+                       Repo   : Directory_Path;
+                       Origin : String := "origin")
+                       return URL;
+   --  Retrieve the "fetch" url of the given origin, or "" if no repo, no
+   --  origin, or any other unforeseen circumstance.
+
+   not overriding
+   function Head_Commit (This : VCS;
+                         Repo : Directory_Path)
+                         return String;
+   --  Obtain the currently checked out Rev in the repository
 
 private
 

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -30,6 +30,11 @@ package Alire.VCSs.Git is
    --  Says if the repo checked out at Path is in a detached HEAD state.
 
    not overriding
+   function Is_Repository (This : VCS;
+                           Path : Directory_Path) return Boolean;
+   --  Check if a repo exists at Path
+
+   not overriding
    function Remote (This : VCS; Path : Directory_Path) return String;
    --  Retrieve current remote name (usually "origin")
 

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -36,8 +36,8 @@ package body Alr.Commands.Publish is
                   Alire.Publish.Local_Repository (Path     => URL,
                                                   Revision => Revision);
                else
-                  Alire.Publish.Verify_And_Create_Index_Manifest
-                    (Origin => URL,
+                  Alire.Publish.Remote_Origin
+                    (URL    => URL,
                      Commit => Revision); -- TODO: allow non-commits
                end if;
             end;

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -1,3 +1,4 @@
+with Alire.Origins;
 with Alire.Publish;
 with Alire.URI;
 
@@ -30,11 +31,20 @@ package body Alr.Commands.Publish is
             --  Choose between local path or remote
 
             declare
+               use Alire.Origins;
                URL : constant String := Argument (1);
             begin
                if URI.Scheme (URL) in URI.File_Schemes then
-                  Alire.Publish.Local_Repository (Path     => URL,
-                                                  Revision => Revision);
+                  if Archive_Format (URI.Local_Path (URL)) /= Unknown then
+                     --  This is a local tarball posing as a remote. Will fail
+                     --  unless forced.
+                     Alire.Publish.Remote_Origin (URL    => URL,
+                                                  Commit => Revision);
+                  else
+                     --  Otherwise this is publishing based on local repo
+                     Alire.Publish.Local_Repository (Path     => URL,
+                                                     Revision => Revision);
+                  end if;
                else
                   Alire.Publish.Remote_Origin
                     (URL    => URL,

--- a/src/alr/alr-commands-publish.ads
+++ b/src/alr/alr-commands-publish.ads
@@ -31,7 +31,7 @@ package Alr.Commands.Publish is
 
    overriding
    function Usage_Custom_Parameters (Cmd : Command) return String
-   is (Switch_Prepare & " <URL> [commit]");
+   is (Switch_Prepare & " [<URL> [commit]]");
 
 private
 

--- a/testsuite/drivers/helpers.py
+++ b/testsuite/drivers/helpers.py
@@ -85,7 +85,7 @@ def init_git_repo(path):
     head_commit = run(["git", "log", "-n1", "--no-abbrev", "--oneline"],
                       capture_output=True).stdout.split()[0]
     os.chdir(start_cwd)
-    return head_commit
+    return head_commit.decode()
 
 
 def zip_dir(path, filename):

--- a/testsuite/drivers/helpers.py
+++ b/testsuite/drivers/helpers.py
@@ -80,6 +80,11 @@ def init_git_repo(path):
         .returncode == 0
     assert run(["git", "config", "user.name", "Alire Testsuite"]) \
         .returncode == 0
+
+    # Workaround for Windows, where somehow we get undeletable files in temps:
+    with open(".gitignore", "wt") as file:
+        file.write("*.tmp\n")
+
     assert run(["git", "add", "."]).returncode == 0
     assert run(["git", "commit", "-m", "repo created"]).returncode == 0
     head_commit = run(["git", "log", "-n1", "--no-abbrev", "--oneline"],

--- a/testsuite/tests/publish/local-repo/test.py
+++ b/testsuite/tests/publish/local-repo/test.py
@@ -5,6 +5,7 @@ Tests for proper publishing using a local repo as reference
 from drivers.alr import init_local_crate, run_alr
 from drivers.asserts import assert_match
 from drivers.helpers import init_git_repo
+from glob import glob
 from shutil import rmtree
 from subprocess import run
 
@@ -16,45 +17,43 @@ def verify_manifest():
     assert os.path.isfile(target), \
         "Index manifest not found at expected location"
     # Clean up for next test
-    shutil.rmtree(os.path.join("alire", "releases"))
+    rmtree(os.path.join("alire", "releases"))
 
 
 # Prepare our "remote" repo
 init_local_crate("xxx", enter=False)
 head_commit = init_git_repo("xxx")
 
-# Clone to a "local" repo
+# Clone to a "local" repo and set minimal config
 assert run(["git", "clone", "xxx", "xxx_local"]).returncode == 0
 os.chdir("xxx_local")
+assert run(["git", "config", "user.email", "alr@testing.com"]).returncode == 0
+assert run(["git", "config", "user.name", "Alire Testsuite"]).returncode == 0
 
 # Tests with different default arguments that must all succeed
-run_alr("publish")
+run_alr("--force", "publish")
 verify_manifest()
 
-run_alr("publish", ".")
+run_alr("--force", "publish", ".")
 verify_manifest()
 
-run_alr("publish", ".", "master")
+run_alr("--force", "publish", ".", "master")
 verify_manifest()
 
-run_alr("publish", ".", "HEAD")
+run_alr("--force", "publish", ".", "HEAD")
 verify_manifest()
 
 # Verify that a dirty repo precludes publishing
 with open("lasagna", "wt") as file:
     file.write("wanted\n")
 
-p = run_alr("publish", complain_or_error=False)
+p = run_alr("--force", "publish", complain_on_error=False)
 assert_match(".*git status reports working tree not clean.*", p.out)
 
 # Even if changes are commited but not pushed
 assert run(["git", "add", "."]).returncode == 0
 assert run(["git", "commit", "-a", "-m", "please"]).returncode == 0
-p = run_alr("publish", complain_or_error=False)
+p = run_alr("--force", "publish", complain_on_error=False)
 assert_match(".*Repository has commits yet to be pushed.*", p.out)
-
-# It works again after push
-assert run(["git", "push"]).returncode == 0
-run_alr("publish")
 
 print('SUCCESS')

--- a/testsuite/tests/publish/local-repo/test.py
+++ b/testsuite/tests/publish/local-repo/test.py
@@ -1,0 +1,60 @@
+"""
+Tests for proper publishing using a local repo as reference
+"""
+
+from drivers.alr import init_local_crate, run_alr
+from drivers.asserts import assert_match
+from drivers.helpers import init_git_repo
+from shutil import rmtree
+from subprocess import run
+
+import os
+
+
+def verify_manifest():
+    target = os.path.join("alire", "releases", "xxx-0.0.0.toml")
+    assert os.path.isfile(target), \
+        "Index manifest not found at expected location"
+    # Clean up for next test
+    shutil.rmtree(os.path.join("alire", "releases"))
+
+
+# Prepare our "remote" repo
+init_local_crate("xxx", enter=False)
+head_commit = init_git_repo("xxx")
+
+# Clone to a "local" repo
+assert run(["git", "clone", "xxx", "xxx_local"]).returncode == 0
+os.chdir("xxx_local")
+
+# Tests with different default arguments that must all succeed
+run_alr("publish")
+verify_manifest()
+
+run_alr("publish", ".")
+verify_manifest()
+
+run_alr("publish", ".", "master")
+verify_manifest()
+
+run_alr("publish", ".", "HEAD")
+verify_manifest()
+
+# Verify that a dirty repo precludes publishing
+with open("lasagna", "wt") as file:
+    file.write("wanted\n")
+
+p = run_alr("publish", complain_or_error=False)
+assert_match(".*git status reports working tree not clean.*", p.out)
+
+# Even if changes are commited but not pushed
+assert run(["git", "add", "."]).returncode == 0
+assert run(["git", "commit", "-a", "-m", "please"]).returncode == 0
+p = run_alr("publish", complain_or_error=False)
+assert_match(".*Repository has commits yet to be pushed.*", p.out)
+
+# It works again after push
+assert run(["git", "push"]).returncode == 0
+run_alr("publish")
+
+print('SUCCESS')

--- a/testsuite/tests/publish/local-repo/test.yaml
+++ b/testsuite/tests/publish/local-repo/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    basic_index:
+        in_fixtures: true

--- a/testsuite/tests/publish/remote-origin/test.py
+++ b/testsuite/tests/publish/remote-origin/test.py
@@ -48,7 +48,7 @@ rmtree("alire")
 
 # Same test, using directly the source repository
 target = os.path.join(os.getcwd(), "xxx")
-run_alr("publish", f"git+file:{target}", head_commit.decode(), "--force")
+run_alr("publish", f"git+file:{target}", head_commit, "--force")
 verify_manifest()
 
 # Copy the new index manifest into the index


### PR DESCRIPTION
This PR implements the shortcuts described in #512 in [this comment](https://github.com/alire-project/alire/pull/512#issuecomment-688419434) to use the local repository as reference for publishing.

We accept:

`alr publish [<path> [revision]]`

Default revision is `HEAD` and default path is `.`. The revision is converted to its commit, so it works for (local) tags and branches too. Then we continue as in #512 with the remote origin URL and the commit.

We check the path to be inside a root that is also a clean git repository.

With this PR I'd say we have a complete "phase 2" (#227), that is, assisted publishing when the remote is ready, so I'd say to write tests for the PRs that are currently open and merge all of them together.