### PR TITLE
alr init: add compiler option controls to template project

### DIFF
--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -121,6 +121,7 @@ package body Alr.Commands.Init is
          Put_Line ("      when ""enabled"" => null;");
          Put_Line ("         Style_Checks_Switches :=");
          Put_Line ("           (""-gnatyg"",   -- GNAT Style checks");
+         Put_Line ("            ""-gnaty-d"",  -- Disable no DOS line terminators");
          Put_Line ("            ""-gnatyM80"", -- Maximum line length");
          Put_Line ("            ""-gnatyO"");  -- Overriding subprograms explicitly marked as such");
          Put_Line ("      when others => null;");
@@ -201,9 +202,7 @@ package body Alr.Commands.Init is
 
       procedure Create (Filename : String) is
       begin
-         --  We use TEXT_TRANSLATION=NO to have UNIX line ending for the
-         --  generated code.
-         TIO.Create (File, TIO.Out_File, Filename, "TEXT_TRANSLATION=NO");
+         TIO.Create (File, TIO.Out_File, Filename);
       end Create;
       ------------------
       -- Put_New_Line --

--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -42,6 +42,7 @@ package body Alr.Commands.Init is
 
       File : TIO.File_Type;
 
+      procedure Create (Filename : String);
       procedure Put_New_Line;
       procedure Put_Line (S : String);
       --  Shortcuts to write to File
@@ -65,7 +66,7 @@ package body Alr.Commands.Init is
       begin
          --  Use more than 80 colums for more readable strings
          pragma Style_Checks ("M200");
-         TIO.Create (File, TIO.Out_File, Filename);
+         Create (Filename);
          Put_Line ("project " & Mixed_Name & " is");
          Put_New_Line;
          if For_Library then
@@ -171,7 +172,7 @@ package body Alr.Commands.Init is
          Filename : constant String :=
             +Full_Name (Src_Directory / (+Lower_Name & ".ads"));
       begin
-         TIO.Create (File, TIO.Out_File, Filename);
+         Create (Filename);
          Put_Line ("package " & Mixed_Name & " is");
          Put_New_Line;
          TIO.Put (File, "end " & Mixed_Name & ";");
@@ -186,7 +187,7 @@ package body Alr.Commands.Init is
          Filename : constant String :=
             +Full_Name (Src_Directory / (+Lower_Name & ".adb"));
       begin
-         TIO.Create (File, TIO.Out_File, Filename);
+         Create (Filename);
          Put_Line ("procedure " & Mixed_Name & " is");
          Put_Line ("begin");
          Put_Line ("   null;");
@@ -194,15 +195,23 @@ package body Alr.Commands.Init is
          TIO.Close (File);
       end Generate_Program_Main;
 
+      ------------
+      -- Create --
+      ------------
+
+      procedure Create (Filename : String) is
+      begin
+         --  We use TEXT_TRANSLATION=NO to have UNIX line ending for the
+         --  generated code.
+         TIO.Create (File, TIO.Out_File, Filename, "TEXT_TRANSLATION=NO");
+      end Create;
       ------------------
       -- Put_New_Line --
       ------------------
 
       procedure Put_New_Line is
       begin
-         --  We don't use TIO.New_Line here because we want always want UNIX
-         --  line ending for the generated code.
-         TIO.Put (File, ASCII.LF);
+         TIO.New_Line (File);
       end Put_New_Line;
 
       --------------
@@ -211,10 +220,7 @@ package body Alr.Commands.Init is
 
       procedure Put_Line (S : String) is
       begin
-         --  We don't use TIO.Put_Line here because we want always want UNIX
-         --  line ending for the generated code.
-         TIO.Put (File, S);
-         TIO.Put (File, ASCII.LF);
+         TIO.Put_Line (File, S);
       end Put_Line;
 
    begin

--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -157,7 +157,7 @@ package body Alr.Commands.Init is
          Put_Line ("      for Switches (""Ada"") use (""-Es""); --  Symbolic traceback");
          Put_Line ("   end Binder;");
          Put_New_Line;
-         Put_Line ("end " & Mixed_Name & ";");
+         TIO.Put (File, "end " & Mixed_Name & ";");
          pragma Style_Checks ("M80");
 
          TIO.Close (File);
@@ -174,7 +174,7 @@ package body Alr.Commands.Init is
          TIO.Create (File, TIO.Out_File, Filename);
          Put_Line ("package " & Mixed_Name & " is");
          Put_New_Line;
-         Put_Line ("end " & Mixed_Name & ";");
+         TIO.Put (File, "end " & Mixed_Name & ";");
          TIO.Close (File);
       end Generate_Root_Package;
 
@@ -190,7 +190,7 @@ package body Alr.Commands.Init is
          Put_Line ("procedure " & Mixed_Name & " is");
          Put_Line ("begin");
          Put_Line ("   null;");
-         Put_Line ("end " & Mixed_Name & ";");
+         TIO.Put (File, "end " & Mixed_Name & ";");
          TIO.Close (File);
       end Generate_Program_Main;
 
@@ -200,7 +200,9 @@ package body Alr.Commands.Init is
 
       procedure Put_New_Line is
       begin
-         TIO.New_Line (File);
+         --  We don't use TIO.New_Line here because we want always want UNIX
+         --  line ending for the generated code.
+         TIO.Put (File, ASCII.LF);
       end Put_New_Line;
 
       --------------
@@ -209,7 +211,10 @@ package body Alr.Commands.Init is
 
       procedure Put_Line (S : String) is
       begin
-         TIO.Put_Line (File, S);
+         --  We don't use TIO.Put_Line here because we want always want UNIX
+         --  line ending for the generated code.
+         TIO.Put (File, S);
+         TIO.Put (File, ASCII.LF);
       end Put_Line;
 
    begin

--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -63,6 +63,8 @@ package body Alr.Commands.Init is
          Filename : constant String :=
             +Full_Name (Directory / (+Lower_Name & ".gpr"));
       begin
+         --  Use more than 80 colums for more readable strings
+         pragma Style_Checks ("M200");
          TIO.Create (File, TIO.Out_File, Filename);
          Put_Line ("project " & Mixed_Name & " is");
          Put_New_Line;
@@ -79,30 +81,85 @@ package body Alr.Commands.Init is
             Put_Line ("   type Library_Type_Type is " &
                         "(""relocatable"", ""static"", ""static-pic"");");
             Put_Line ("   Library_Type : Library_Type_Type :=");
-            Put_Line ("     external (""" & Upper_Name & "_LIBRARY_TYPE"",");
-            Put_Line ("               external (""LIBRARY_TYPE"", " &
-                        """static""));");
+            Put_Line ("     external (""" & Upper_Name & "_LIBRARY_TYPE"", external (""LIBRARY_TYPE"", ""static""));");
             Put_Line ("   for Library_Kind use Library_Type;");
          else
             Put_Line ("   for Exec_Dir use ""bin"";");
             Put_Line ("   for Main use (""" & Lower_Name & ".adb"");");
          end if;
          Put_New_Line;
-         Put_Line ("   package Builder is");
-         Put_Line ("      for Switches (""ada"") use (""-j0"", ""-g"");");
-         Put_Line ("   end Builder;");
+         Put_Line ("   type Enabled_Kind is (""enabled"", ""disabled"");");
+         Put_Line ("   Compile_Checks : Enabled_Kind := External (""" & Upper_Name & "_COMPILE_CHECKS"", ""enabled"");");
+         Put_Line ("   Runtime_Checks : Enabled_Kind := External (""" & Upper_Name & "_RUNTIME_CHECKS"", ""enabled"");");
+         Put_Line ("   Style_Checks : Enabled_Kind := External (""" & Upper_Name & "_STYLE_CHECKS"", ""enabled"");");
+         Put_Line ("   Contracts_Checks : Enabled_Kind := External (""" & Upper_Name & "_CONTRACTS"", ""enabled"");");
+         Put_New_Line;
+         Put_Line ("   type Build_Kind is (""debug"", ""optimize"");");
+         Put_Line ("   Build_Mode : Build_Kind := External (""" & Upper_Name & "_BUILD_MODE"", ""debug"");");
+         Put_New_Line;
+         Put_Line ("   Compile_Checks_Switches := ();");
+         Put_Line ("   case Compile_Checks is");
+         Put_Line ("      when ""enabled"" =>");
+         Put_Line ("         Compile_Checks_Switches :=");
+         Put_Line ("           (""-gnatwa"",  -- All warnings");
+         Put_Line ("            ""-gnatVa"",  -- All validity checks");
+         Put_Line ("            ""-gnatwe""); -- Warnings as errors");
+         Put_Line ("      when others => null;");
+         Put_Line ("   end case;");
+         Put_New_Line;
+         Put_Line ("   Runtime_Checks_Switches := ();");
+         Put_Line ("   case Runtime_Checks is");
+         Put_Line ("      when ""enabled"" => null;");
+         Put_Line ("      when others =>");
+         Put_Line ("         Runtime_Checks_Switches :=");
+         Put_Line ("           (""-gnatp""); -- Supress checks");
+         Put_Line ("   end case;");
+         Put_New_Line;
+         Put_Line ("   Style_Checks_Switches := ();");
+         Put_Line ("   case Style_Checks is");
+         Put_Line ("      when ""enabled"" => null;");
+         Put_Line ("         Style_Checks_Switches :=");
+         Put_Line ("           (""-gnatyg"",   -- GNAT Style checks");
+         Put_Line ("            ""-gnatyM80"", -- Maximum line length");
+         Put_Line ("            ""-gnatyO"");  -- Overriding subprograms explicitly marked as such");
+         Put_Line ("      when others => null;");
+         Put_Line ("   end case;");
+         Put_New_Line;
+         Put_Line ("   Contracts_Switches := ();");
+         Put_Line ("   case Contracts_Checks is");
+         Put_Line ("      when ""enabled"" => null;");
+         Put_Line ("         Contracts_Switches :=");
+         Put_Line ("           (""-gnata""); --  Enable assertions and contracts");
+         Put_Line ("      when others =>");
+         Put_Line ("   end case;");
+         Put_New_Line;
+         Put_Line ("   Build_Switches := ();");
+         Put_Line ("   case Build_Mode is");
+         Put_Line ("      when ""optimize"" =>");
+         Put_Line ("         Build_Switches := (""-O3"",     -- Optimization");
+         Put_Line ("                            ""-gnatn""); -- Enable inlining");
+         Put_Line ("      when ""debug"" =>");
+         Put_Line ("         Build_Switches := (""-g"",   -- Debug info");
+         Put_Line ("                            ""-Og""); -- No optimization");
+         Put_Line ("   end case;");
          Put_New_Line;
          Put_Line ("   package Compiler is");
-         Put_Line ("      for Switches (""ada"") use");
-         Put_Line ("        (""-gnatVa"", ""-gnatwa"", ""-g"", ""-O2"",");
-         Put_Line ("         ""-gnata"", ""-gnato"", ""-fstack-check"");");
+         Put_Line ("      for Default_Switches (""Ada"") use");
+         Put_Line ("        Compile_Checks_Switches &");
+         Put_Line ("        Build_Switches &");
+         Put_Line ("        Runtime_Checks_Switches &");
+         Put_Line ("        Style_Checks_Switches &");
+         Put_Line ("        Contracts_Switches &");
+         Put_Line ("        (""-gnatQ"");  -- Don't quit. Generate ALI and tree files even if illegalities");
          Put_Line ("   end Compiler;");
          Put_New_Line;
          Put_Line ("   package Binder is");
-         Put_Line ("      for Switches (""ada"") use (""-Es"");");
+         Put_Line ("      for Switches (""Ada"") use (""-Es""); --  Symbolic traceback");
          Put_Line ("   end Binder;");
          Put_New_Line;
          Put_Line ("end " & Mixed_Name & ";");
+         pragma Style_Checks ("M80");
+
          TIO.Close (File);
       end Generate_Project_File;
 

--- a/testsuite/tests/with/auto-gpr-with/basic/test.py
+++ b/testsuite/tests/with/auto-gpr-with/basic/test.py
@@ -19,11 +19,11 @@ run_alr('with', 'libhello')
 # Re-write the source code by using libhello
 with open("src/myhello.adb", "w") as text_file:
     text_file.write("""
-with Libhello;
+with libhello;
 
 procedure Myhello is
 begin
-   Libhello.Hello_World;
+   libhello.Hello_World;
 end Myhello;
 """)
 

--- a/testsuite/tests/workflows/init-with-pin/test.py
+++ b/testsuite/tests/workflows/init-with-pin/test.py
@@ -36,15 +36,15 @@ assert_eq('libhello 1.0.0\n', p.out)
 # Build and run "xxx"
 with open(os.path.join('src', 'xxx.adb'), 'w') as f:
     f.write("""
-        with Ada.Text_IO;
-        with Libhello;
+with Ada.Text_IO;
+with libhello;
 
-        procedure XXX is
-        begin
-           Ada.Text_IO.Put_Line ("This is XXX...");
-           Libhello.Hello_World;
-        end XXX;
-    """)
+procedure XXX is
+begin
+   Ada.Text_IO.Put_Line ("This is XXX...");
+   libhello.Hello_World;
+end XXX;
+""")
 p = run_alr('run')
 assert_eq('This is XXX...\nHello, world!\n', p.out)
 


### PR DESCRIPTION
User can control compile checks, run-time checks, contracts, style checks.