### PR TITLE
Add switch to print the list of trusted git sites

### DIFF
--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -24,6 +24,13 @@ package body Alire.Publish is
    package Semver renames Semantic_Versioning;
    package TTY renames Utils.TTY;
 
+   Trusted_Sites : constant Utils.String_Vector :=
+                     Utils.Empty_Vector
+                       .Append ("bitbucket.org")
+                       .Append ("github.com")
+                       .Append ("gitlab.com")
+                       .Append ("sf.net");
+
    type Data is limited record
       Origin : Origins.Origin := Origins.New_External ("undefined");
       --  We use external as "undefined" until a proper origin is provided.
@@ -192,6 +199,20 @@ package body Alire.Publish is
       end if;
 
       Log_Success ("Origin is of supported kind: " & Context.Origin.Kind'Img);
+
+      if Context.Origin.Kind in Origins.VCS_Kinds then
+         if (for some Site of Trusted_Sites =>
+               URI.Authority (Context.Origin.URL) = Site or else
+               Utils.Ends_With (URI.Authority (Context.Origin.URL),
+                                "." & Site))
+         then
+            Log_Success ("Origin is hosted on trusted site: "
+                         & URI.Authority (Context.Origin.URL));
+         else
+            Raise_Checked_Error ("Origin is hosted on unknown site: "
+                                 & URI.Authority (Context.Origin.URL));
+         end if;
+      end if;
 
    end Verify_Origin;
 

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -201,7 +201,14 @@ package body Alire.Publish is
       Log_Success ("Origin is of supported kind: " & Context.Origin.Kind'Img);
 
       if Context.Origin.Kind in Origins.VCS_Kinds then
-         if (for some Site of Trusted_Sites =>
+
+         --  Check an VCS origin is from a trusted site, unless we are forcing
+         --  a local repository.
+
+         if (Force and then
+             URI.Scheme (Context.Origin.URL) in URI.File_Schemes)
+           or else
+            (for some Site of Trusted_Sites =>
                URI.Authority (Context.Origin.URL) = Site or else
                Utils.Ends_With (URI.Authority (Context.Origin.URL),
                                 "." & Site))

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -311,4 +311,15 @@ package body Alire.Publish is
                Errors.Get (E)));
    end Verify_And_Create_Index_Manifest;
 
+   -------------------------
+   -- Print_Trusted_Sites --
+   -------------------------
+
+   procedure Print_Trusted_Sites is
+   begin
+      for Site of Trusted_Sites loop
+         Trace.Always (Site);
+      end loop;
+   end Print_Trusted_Sites;
+
 end Alire.Publish;

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -206,7 +206,10 @@ package body Alire.Publish is
          --  a local repository.
 
          if (Force and then
-             URI.Scheme (Context.Origin.URL) in URI.File_Schemes)
+             URI.Scheme (Context.Origin.URL) in URI.File_Schemes | URI.Unknown)
+             --  We are forcing, so we accept an unknown scheme (this happens
+             --  for local file on Windows, where drive letters are interpreted
+             --  as the scheme).
            or else
             (for some Site of Trusted_Sites =>
                URI.Authority (Context.Origin.URL) = Site or else

--- a/src/alire/alire-publish.ads
+++ b/src/alire/alire-publish.ads
@@ -9,4 +9,7 @@ package Alire.Publish is
    --  the current directory or raises Checked_Error with the appropriate error
    --  message set.
 
+   procedure Print_Trusted_Sites;
+   --  Print our list of allowed sites to host git releases
+
 end Alire.Publish;

--- a/src/alire/alire-uri.ads
+++ b/src/alire/alire-uri.ads
@@ -60,6 +60,8 @@ package Alire.URI with Preelaborate is
    function Scheme (This : URL) return Schemes;
    --  Extract the Scheme part of a URL
 
+   function Authority (This : URL) return String;
+
    function Local_Path (This : URL) return String
      with Pre => Scheme (This) in None | File
      or else raise Checked_Error with Errors.Set
@@ -84,6 +86,13 @@ private
    package U renames Standard.URI;
 
    function L (Str : String) return String renames Utils.To_Lower_Case;
+
+   ---------------
+   -- Authority --
+   ---------------
+
+   function Authority (This : URL) return String
+   is (U.Extract (This, U.Authority));
 
    ----------------
    -- Local_Path --

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -24,6 +24,9 @@ package body Alr.Commands.Publish is
                           else ""));
          end if;
 
+      elsif Cmd.Print_Trusted then
+         Alire.Publish.Print_Trusted_Sites;
+
       else
          Trace.Warning
            ("No publishing subcommand given, defaulting to "
@@ -44,6 +47,12 @@ package body Alr.Commands.Publish is
    is
       use GNAT.Command_Line;
    begin
+      Define_Switch
+        (Config,
+         Cmd.Print_Trusted'Access,
+         "", "--trusted-sites",
+         "Print a list of trusted git repository sites");
+
       Define_Switch
         (Config,
          Cmd.Prepare'Access,

--- a/src/alr/alr-commands-publish.ads
+++ b/src/alr/alr-commands-publish.ads
@@ -39,6 +39,8 @@ private
       Prepare : aliased Boolean := False;
       --  Start the assistant with ready sources and manifest; only verify and
       --  add the origin.
+
+      Print_Trusted : aliased Boolean := False;
    end record;
 
 end Alr.Commands.Publish;

--- a/testsuite/tests/publish/check-trusted/test.py
+++ b/testsuite/tests/publish/check-trusted/test.py
@@ -1,0 +1,15 @@
+"""
+Tests that the "trusted repos" list is applied
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+
+# Try with obvious bad site and slight variations before/after
+for domain in ["badsite.com", "ggithub.com", "github.comm"]:
+    p = run_alr("publish", f"http://{domain}/repo.git",
+                "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                complain_on_error=False)
+    assert_match(".*Origin is hosted on unknown site.*", p.out)
+
+print('SUCCESS')

--- a/testsuite/tests/publish/check-trusted/test.yaml
+++ b/testsuite/tests/publish/check-trusted/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
This way we can update the list without breaking documentation.