### PR TITLE
--skip-build switch to skip the publish build check

### DIFF
--- a/src/alire/alire-origins.ads
+++ b/src/alire/alire-origins.ads
@@ -64,6 +64,9 @@ package Alire.Origins with Preelaborate is
    function Archive_Format (Name : String) return Source_Archive_Format;
    --  Guess the format of a source archive from its file name.
 
+   function Get_URL (This : Origin) return Alire.URL with
+     Pre => This.Kind in Filesystem | Source_Archive | VCS_Kinds;
+
    function Is_System (This : Origin) return Boolean is (This.Kind = System);
    function Package_Name (This : Origin) return String
      with Pre => This.Kind = System;
@@ -270,6 +273,13 @@ private
          then " with hash " & This.Image_Of_Hashes
          else " with hashes " & This.Image_Of_Hashes)
      );
+
+   function Get_URL (This : Origin) return Alire.URL
+   is (case This.Kind is
+          when Filesystem     => This.Path,
+          when Source_Archive => This.Archive_URL,
+          when VCS_Kinds      => This.URL,
+          when others         => raise Checked_Error with "Origin has no URL");
 
    Prefix_External : aliased constant String := "external:";
    Prefix_Git      : aliased constant String := "git+";

--- a/src/alire/alire-publish.ads
+++ b/src/alire/alire-publish.ads
@@ -3,15 +3,21 @@ with Alire.URI;
 
 package Alire.Publish is
 
+   type All_Options is record
+      Skip_Build : Boolean := False;
+   end record;
+
    procedure Local_Repository (Path     : Any_Path := ".";
-                               Revision : String   := "HEAD") with
+                               Revision : String   := "HEAD";
+                               Options  : All_Options := (others => <>)) with
      Pre => URI.Scheme (Path) in URI.File_Schemes;
    --  Check that given Path is an up-to-date git repo. If so, proceed with
    --  remote repo verification. If no revision given use the HEAD commit,
    --  otherwise use the revision (tag, branch, commit) commit.
 
-   procedure Remote_Origin (URL    : Alire.URL;
-                            Commit : String := "");
+   procedure Remote_Origin (URL     : Alire.URL;
+                            Commit  : String := "";
+                            Options : All_Options := (others => <>));
    --  Requires a remote URL to a source file or a git repository. Commit is
    --  mandatory in the latter case. Produces a file `crate-version.toml` in
    --  the current directory or raises Checked_Error with the appropriate error

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -16,10 +16,13 @@ package body Alr.Commands.Publish is
       function Revision return String
       is (if Num_Arguments >= 2 then Argument (2) else "");
 
+      Options : constant Alire.Publish.All_Options :=
+                  (Skip_Build => Cmd.Skip_Build);
+
    begin
       if Cmd.Prepare then
          if Num_Arguments < 1 then
-            Alire.Publish.Local_Repository;
+            Alire.Publish.Local_Repository (Options => Options);
 
          elsif Num_Arguments > 2 then
             Reportaise_Wrong_Arguments
@@ -38,17 +41,20 @@ package body Alr.Commands.Publish is
                   if Archive_Format (URI.Local_Path (URL)) /= Unknown then
                      --  This is a local tarball posing as a remote. Will fail
                      --  unless forced.
-                     Alire.Publish.Remote_Origin (URL    => URL,
-                                                  Commit => Revision);
+                     Alire.Publish.Remote_Origin (URL     => URL,
+                                                  Commit  => Revision,
+                                                  Options => Options);
                   else
                      --  Otherwise this is publishing based on local repo
                      Alire.Publish.Local_Repository (Path     => URL,
-                                                     Revision => Revision);
+                                                     Revision => Revision,
+                                                     Options  => Options);
                   end if;
                else
                   Alire.Publish.Remote_Origin
-                    (URL    => URL,
-                     Commit => Revision); -- TODO: allow non-commits
+                    (URL     => URL,
+                     Commit  => Revision, -- TODO: allow non-commits
+                     Options => Options);
                end if;
             end;
 
@@ -88,6 +94,12 @@ package body Alr.Commands.Publish is
          Cmd.Prepare'Access,
          "", Switch_Prepare,
          "Start the publishing assistant using a ready remote origin");
+
+      Define_Switch
+        (Config,
+         Cmd.Skip_Build'Access,
+         "", "--skip-build",
+         "Skip the build check step");
    end Setup_Switches;
 
 end Alr.Commands.Publish;

--- a/src/alr/alr-commands-publish.ads
+++ b/src/alr/alr-commands-publish.ads
@@ -41,6 +41,9 @@ private
       --  add the origin.
 
       Print_Trusted : aliased Boolean := False;
+
+      Skip_Build : aliased Boolean := False;
+      --  Skip the build check
    end record;
 
 end Alr.Commands.Publish;


### PR DESCRIPTION
Via an options record that can grow in the future for more tweaks.

Also some convenience refactoring to more easily retrieve an origin URL.