### PR TITLE
Publish tweaks

### DIFF
--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -459,10 +459,12 @@ package body Alire.Publish is
          when Clean =>
             Log_Success ("Local repository is clean.");
          when Ahead =>
-            Git_Error ("Repository has commits yet to be pushed");
+            Git_Error ("Your branch is ahead of remote" & ASCII.LF &
+                         "Please push local commits to the remove branch.");
          when Dirty =>
-            Git_Error (TTY.Emph ("git status")
-                       & " reports working tree not clean");
+            Git_Error (TTY.Emph ("git status") &
+                         " You have unstaged changes. " &
+                         "Please commit or stash them.");
       end case;
 
       --  If given a revision, extract commit and verify it exists locally

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -440,7 +440,11 @@ package body Alire.Publish is
 
       procedure Git_Error (Msg : String) is
       begin
-         Raise_Checked_Error (Msg & " at " & TTY.URL (Path));
+         if Path /= "." then
+            Raise_Checked_Error (TTY.URL (Path) & ": " & Msg);
+         else
+            Raise_Checked_Error (Msg);
+         end if;
       end Git_Error;
 
    begin

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -20,7 +20,10 @@ package body Alr.Commands.Publish is
                   (Skip_Build => Cmd.Skip_Build);
 
    begin
-      if Cmd.Prepare then
+      if Cmd.Print_Trusted then
+         Alire.Publish.Print_Trusted_Sites;
+
+      else
          if Num_Arguments < 1 then
             Alire.Publish.Local_Repository (Options => Options);
 
@@ -59,16 +62,6 @@ package body Alr.Commands.Publish is
             end;
 
          end if;
-
-      elsif Cmd.Print_Trusted then
-         Alire.Publish.Print_Trusted_Sites;
-
-      else
-         Trace.Warning
-           ("No publishing subcommand given, defaulting to "
-            & Switch_Prepare & " ...");
-         Cmd.Prepare := True;
-         Execute (Cmd);
       end if;
    end Execute;
 
@@ -88,12 +81,6 @@ package body Alr.Commands.Publish is
          Cmd.Print_Trusted'Access,
          "", "--trusted-sites",
          "Print a list of trusted git repository sites");
-
-      Define_Switch
-        (Config,
-         Cmd.Prepare'Access,
-         "", Switch_Prepare,
-         "Start the publishing assistant using a ready remote origin");
 
       Define_Switch
         (Config,

--- a/src/alr/alr-commands-publish.ads
+++ b/src/alr/alr-commands-publish.ads
@@ -2,8 +2,6 @@ package Alr.Commands.Publish is
 
    --  Publish lends a helping hand to automate submission of crates/releases.
 
-   Switch_Prepare : constant String := "--prepare";
-
    type Command is new Commands.Command with private;
 
    overriding
@@ -40,15 +38,11 @@ package Alr.Commands.Publish is
 
    overriding
    function Usage_Custom_Parameters (Cmd : Command) return String
-   is ("[" & Switch_Prepare & "] [<URL> [commit]]");
+   is ("[--skip-build] [<URL> [commit]]");
 
 private
 
    type Command is new Commands.Command with record
-      Prepare : aliased Boolean := False;
-      --  Start the assistant with ready sources and manifest; only verify and
-      --  add the origin.
-
       Print_Trusted : aliased Boolean := False;
 
       Skip_Build : aliased Boolean := False;

--- a/testsuite/tests/publish/local-repo/test.py
+++ b/testsuite/tests/publish/local-repo/test.py
@@ -47,13 +47,15 @@ verify_manifest()
 with open("lasagna", "wt") as file:
     file.write("wanted\n")
 
+assert run(["git", "add", "lasagna"]).returncode == 0
+
 p = run_alr("--force", "publish", complain_on_error=False)
-assert_match(".*git status reports working tree not clean.*", p.out)
+assert_match(".*You have unstaged changes.*", p.out)
 
 # Even if changes are committed but not pushed
 assert run(["git", "add", "."]).returncode == 0
 assert run(["git", "commit", "-a", "-m", "please"]).returncode == 0
 p = run_alr("--force", "publish", complain_on_error=False)
-assert_match(".*Repository has commits yet to be pushed.*", p.out)
+assert_match(".*Your branch is ahead of remote.*", p.out)
 
 print('SUCCESS')


### PR DESCRIPTION
 - alr init: add compiler option controls to template project
 - Alire.Publish: use error message similar to the git messages
 - Alire.Publish: Do not print repo path if using CWD
 - Alire.VCSs.Git: change status detection
 - Alr.Commands.Publish: remove --prepare switch 