### PR TITLE
Tweaks for detection of git URLs

### DIFF
--- a/src/alire/alire-origins.adb
+++ b/src/alire/alire-origins.adb
@@ -147,6 +147,8 @@ package body Alire.Origins is
                    elsif Scheme in URI.HTTP then -- A plain URL... check VCS
                      (if Utils.Ends_With (Utils.To_Lower_Case (URL), ".git")
                       then URL
+                      elsif URI.Authority (URL) = "github.com" then
+                         URL & ".git"
                       else raise Checked_Error with
                         "ambiguous VCS URL: " & URL)
                    else

--- a/src/alire/alire-origins.ads
+++ b/src/alire/alire-origins.ads
@@ -7,7 +7,7 @@ private with Ada.Strings.Unbounded;
 
 with TOML; use all type TOML.Any_Value_Kind;
 
-package Alire.Origins with Preelaborate is
+package Alire.Origins is
 
    type Kinds is
      (External,       -- A do-nothing origin, with some custom description

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -453,7 +453,6 @@ package body Alire.Publish is
       end if;
 
       if not Git.Is_Repository (Root.Value.Path) then
-         Trace.Always ("ROOT " & Root.Value.Path);
          Git_Error ("no git repository found");
       end if;
 
@@ -542,7 +541,9 @@ package body Alire.Publish is
                       Origin =>
                         (if Commit /= "" then
                             Origins.New_VCS (URL, Commit)
-                         elsif URI.Scheme (URL) in URI.VCS_Schemes then
+                         elsif URI.Scheme (URL) in URI.VCS_Schemes or else
+                               URI.Authority (URL) = "github.com"
+                         then
                             raise Checked_Error with
                               "A commit id is mandatory for a VCS origin"
                          else

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -488,7 +488,16 @@ package body Alire.Publish is
          end if;
 
          declare
-            Fetch_URL : constant String := Git.Fetch_URL (Root.Value.Path);
+            use Utils;
+            Raw_URL   : constant String := Git.Fetch_URL (Root.Value.Path);
+            --  The one reported by the repo, in its public form
+
+            Fetch_URL : constant String :=
+            --  With an added ".git", if it hadn't one. Not usable in local fs.
+                          Raw_URL
+                          & (if Ends_With (To_Lower_Case (Raw_URL), ".git")
+                             then ""
+                             else ".git");
          begin
             --  To allow this call to succeed with local tests, we check
             --  here. For a regular repository we will already have an HTTP
@@ -500,10 +509,14 @@ package body Alire.Publish is
                     ("The remote URL seems to require repository ownership: "
                      & Fetch_URL);
                when URI.None | URI.Unknown =>
-                  Publish.Remote_Origin (URL     => "git+file:" & Fetch_URL,
+                  Publish.Remote_Origin (URL     => "git+file:" & Raw_URL,
                                          Commit  => Commit,
                                          Options => Options);
-               when URI.File | URI.HTTP =>
+               when URI.File =>
+                  Publish.Remote_Origin (URL     => Raw_URL,
+                                         Commit  => Commit,
+                                         Options => Options);
+               when URI.HTTP =>
                   Publish.Remote_Origin (URL     => Fetch_URL,
                                          Commit  => Commit,
                                          Options => Options);
@@ -535,17 +548,24 @@ package body Alire.Publish is
       --  Create origin, which will do more checks, and proceed
 
       declare
+         use Utils;
          Context : Data :=
                      (Options => Options,
 
-                      Origin =>
+                      Origin  =>
+                        --  with commit
                         (if Commit /= "" then
                             Origins.New_VCS (URL, Commit)
+
+                         --  without commit
                          elsif URI.Scheme (URL) in URI.VCS_Schemes or else
-                               URI.Authority (URL) = "github.com"
+                            VCSs.Git.Known_Transformable_Hosts.Contains
+                              (URI.Authority (URL))
                          then
                             raise Checked_Error with
                               "A commit id is mandatory for a VCS origin"
+
+                         --  plain archive
                          else
                             Origins.New_Source_Archive (URL)),
 
@@ -555,6 +575,7 @@ package body Alire.Publish is
       end;
    exception
       when E : Checked_Error | Origins.Unknown_Source_Archive_Format_Error =>
+         Log_Exception (E);
          Raise_Checked_Error
            (Errors.Wrap
               ("Could not complete the publishing assistant",

--- a/src/alire/alire-selftest.adb
+++ b/src/alire/alire-selftest.adb
@@ -1,4 +1,5 @@
 with Alire.Utils;
+with Alire.VCSs.Git;
 
 package body Alire.Selftest is
 
@@ -93,6 +94,34 @@ package body Alire.Selftest is
       pragma Assert (not Valid ((1 .. 40 => 'a')));
    end Check_GitHub_Logins;
 
+   -----------------------
+   -- Check_Git_To_HTTP --
+   -----------------------
+
+   procedure Check_Git_To_HTTP is
+      use VCSs.Git;
+   begin
+      --  Proper transform starting without .git
+      pragma Assert (Transform_To_Public ("git@github.com:user/project") =
+                       "https://github.com/user/project.git");
+
+      --  Proper transform starting with .git
+      pragma Assert (Transform_To_Public ("git@github.com:user/project.git") =
+                       "https://github.com/user/project.git");
+
+      --  GitLab
+      pragma Assert (Transform_To_Public ("git@gitlab.com:user/project") =
+                       "https://gitlab.com/user/project.git");
+
+      --  Unknown site, not transformed
+      pragma Assert (Transform_To_Public ("git@ggithub.com:user/project") =
+                       "git@ggithub.com:user/project");
+
+      --  No-op for HTTPS
+      pragma Assert (Transform_To_Public ("https://github.com/user/project") =
+                       "https://github.com/user/project");
+   end Check_Git_To_HTTP;
+
    ---------
    -- Run --
    ---------
@@ -101,6 +130,7 @@ package body Alire.Selftest is
    begin
       Check_Email_Checks;
       Check_GitHub_Logins;
+      Check_Git_To_HTTP;
 
       Trace.Detail ("Self-checks passed");
    exception

--- a/src/alire/alire-uri.ads
+++ b/src/alire/alire-uri.ads
@@ -37,6 +37,9 @@ package Alire.URI with Preelaborate is
       --  Anything understood by git, expressed as git+<actual protocol>, e.g.:
       --  git+http[s], git+file
 
+      Pure_Git,
+      --  An actual git@host:path URI
+
       Hg,
       SVN,
       --  Same considerations as for Git
@@ -121,6 +124,8 @@ private
           File
        elsif Utils.Starts_With (L (U.Scheme (This)), "git+") then
           Git
+       elsif Utils.Starts_With (L (U.Scheme (This)), "git@") then
+          Pure_Git
        elsif Utils.Starts_With (L (U.Scheme (This)), "hg+") then
           Hg
        elsif Utils.Starts_With (L (U.Scheme (This)), "svn+") then

--- a/src/alire/alire-vcss-git.adb
+++ b/src/alire/alire-vcss-git.adb
@@ -139,7 +139,8 @@ package body Alire.VCSs.Git is
 
    function Fetch_URL (This   : VCS;
                        Repo   : Directory_Path;
-                       Origin : String := "origin")
+                       Origin : String := "origin";
+                       Public : Boolean := True)
                        return URL
    is
 
@@ -172,7 +173,15 @@ package body Alire.VCSs.Git is
    begin
       for Line of Output loop
          if Starts_With (Line, "remote." & Origin & ".url") then
-            return Transform_To_Public (Tail (Line, '='));
+            declare
+               URL : constant Alire.URL := Tail (Line, '=');
+            begin
+               if Public then
+                  return Transform_To_Public (URL);
+               else
+                  return URL;
+               end if;
+            end;
          end if;
       end loop;
 

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -55,10 +55,12 @@ package Alire.VCSs.Git is
    not overriding
    function Fetch_URL (This   : VCS;
                        Repo   : Directory_Path;
-                       Origin : String := "origin")
+                       Origin : String := "origin";
+                       Public : Boolean := True)
                        return URL;
    --  Retrieve the "fetch" url of the given origin, or "" if no repo, no
-   --  origin, or any other unforeseen circumstance.
+   --  origin, or any other unforeseen circumstance. If Public, a git@github
+   --  private URL is transformed into its equivalent https:// public URL.
 
    not overriding
    function Head_Commit (This : VCS;

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -1,4 +1,9 @@
+with Alire.Utils;
+
 package Alire.VCSs.Git is
+
+   Known_Transformable_Hosts : constant Utils.String_Vector;
+   --  Known hosts that honor the git@ --> https:// transformation
 
    type VCS (<>) is new VCSs.VCS with private;
 
@@ -68,10 +73,21 @@ package Alire.VCSs.Git is
                          return String;
    --  Obtain the currently checked out Rev in the repository
 
+   function Transform_To_Public (Remote : String) return URL;
+   --  For a Known_Transformable_Host, return the https:// equivalent of a
+   --  git@... address. Otherwise return Remote unmodified.
+
 private
 
    type VCS is new VCSs.VCS with null record;
 
    function Handler return VCS is (null record);
+
+   use Utils;
+
+   Known_Transformable_Hosts : constant String_Vector :=
+                                 Empty_Vector
+                                 & "github.com"
+                                 & "gitlab.com";
 
 end Alire.VCSs.Git;

--- a/testsuite/tests/publish/bad-arguments/test.py
+++ b/testsuite/tests/publish/bad-arguments/test.py
@@ -17,8 +17,25 @@ assert_match(".*Expected a VCS origin but got.*", p.out)
 p = run_alr("publish", "fake.zip", "deadbeef", complain_on_error=False)
 assert_match(".*unknown VCS URL.*", p.out)
 
+# Missing commit for git remotes
+p = run_alr("publish", "git+http://github.com/repo",
+            complain_on_error=False)
+assert_match(".*commit id is mandatory for a VCS origin.*", p.out)
+
+# Detect github case and give more precise error. This serves also to check
+# that github remotes without leading git+ or trailing .git are accepted.
+p = run_alr("publish", "https://github.com/missingext",
+            complain_on_error=False)
+assert_match(".*commit id is mandatory for a VCS origin.*", p.out)
+
+# Bad commit length
+p = run_alr("publish", "git+http://github.com/repo", "deadbeef",
+            complain_on_error=False)
+assert_match(".*invalid git commit id, 40 digits hexadecimal expected.*",
+             p.out)
+
 # VCS without transport or extension
-p = run_alr("publish", "http://github.com/badrepo", "deadbeef",
+p = run_alr("publish", "http://somehost.com/badrepo", "deadbeef",
             complain_on_error=False)
 assert_match(".*ambiguous VCS URL.*", p.out)
 


### PR DESCRIPTION
- A leading `git+` or trailing `.git` is no longer required for a plain `https://` URL. This is detected for remote URLs on github and gitlab, or any local repository.
- A private `git@github`, `git@gitlab` URL is transformed into its public `https://` counterpart. I've been unable to determine if this transformation is valid in general, so for now there's an explicit list.