### PR TITLE
Gather user info during `alr init` for manifest creation

### DIFF
--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -110,6 +110,17 @@ package Alire.Config is
    procedure Print_Builtins_Doc;
    --  Print a Markdown documentation for the built-in configuration options
 
+   package Keys is
+
+      --  A few predefined keys that are used in several places. This list is
+      --  not exhaustive.
+
+      User_Email        : constant Config_Key := "user.email";
+      User_Name         : constant Config_Key := "user.name";
+      User_Github_Login : constant Config_Key := "user.github_login";
+
+   end Keys;
+
 private
 
    function Load_Config_File (Path : Absolute_Path) return TOML.TOML_Value;

--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -174,15 +174,15 @@ private
 
    Builtins : constant array (Natural range <>) of Builtin_Entry :=
      (
-      (+"user.name",
+      (+Keys.User_Name,
        Cfg_String,
        +("User full name. Used for the authors and " &
           "maintainers field of a new crate.")),
-      (+"user.email",
+      (+Keys.User_Email,
        Cfg_Email,
        +("User email address. Used for the authors and" &
            " maintainers field of a new crate.")),
-      (+"user.github_login",
+      (+Keys.User_Github_Login,
        Cfg_GitHub_Login,
        +("User GitHub login/username. Used to for the maintainers-logins " &
            "field of a new crate.")),

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -5,10 +5,10 @@ with Ada.Text_IO;
 with Alire.Crates;
 with Alire.Defaults;
 with Alire.Errors;
+with Alire.Properties.Bool;
 with Alire.Requisites.Booleans;
 with Alire.TOML_Load;
 with Alire.Utils.YAML;
-with Alire.Properties.Bool;
 
 with GNAT.IO; -- To keep preelaborable
 
@@ -39,13 +39,7 @@ package body Alire.Releases is
    function Default_Properties return Conditional.Properties
    is (Conditional.For_Properties.New_Value
        (New_Label (Description,
-                   Defaults.Description)) and
-       Conditional.For_Properties.New_Value
-       (New_Label (Maintainer,
-                   Defaults.Maintainer)) and
-       Conditional.For_Properties.New_Value
-       (New_Label (Maintainers_Logins,
-                   Defaults.Maintainer_Login)));
+                   Defaults.Description)));
 
    ---------------
    -- Extending --

--- a/src/alire/alire-utils-user_input.adb
+++ b/src/alire/alire-utils-user_input.adb
@@ -178,17 +178,18 @@ package body Alire.Utils.User_Input is
 
    begin
       loop
-         TIO.Put_Line (Question);
+         TIO.Put_Line (Question & " (" & "default: '" & Default & "')");
 
          if Not_Interactive or else not Is_TTY then
             return Use_Default;
          end if;
 
-         TIO.Put_Line ("Default: '" & Default & "'");
-
          --  Flush the input that the user may have entered by mistake before
          --  the question is asked.
          Flush_TTY;
+
+         --  Print a prompt
+         TIO.Put ("> ");
 
          --  Get user input
          declare

--- a/src/alire/alire-utils-user_input.adb
+++ b/src/alire/alire-utils-user_input.adb
@@ -184,12 +184,12 @@ package body Alire.Utils.User_Input is
             return Use_Default;
          end if;
 
+         --  Print a prompt
+         TIO.Put ("> ");
+
          --  Flush the input that the user may have entered by mistake before
          --  the question is asked.
          Flush_TTY;
-
-         --  Print a prompt
-         TIO.Put ("> ");
 
          --  Get user input
          declare

--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -1,7 +1,6 @@
 with Ada.Command_Line;
 
 with Ada.Streams.Stream_IO;
-with Ada.Strings.Maps;
 
 with GNAT.Case_Util;
 with GNAT.OS_Lib;
@@ -268,6 +267,14 @@ package body Alire.Utils is
       end return;
    end Indent;
 
+   -------------------------------
+   -- Is_Valid_Full_Person_Name --
+   -------------------------------
+
+   function Is_Valid_Full_Person_Name (Name : String) return Boolean
+   is (for all C of Name =>
+          C not in Character'Val (0) .. Character'Val (31) | '\');
+
    ------------------------------
    -- Is_Valid_GitHub_Username --
    ------------------------------
@@ -312,10 +319,10 @@ package body Alire.Utils is
       if First = 0 then
          return Text;
       else
-         return Replace
-           (Replace_Slice (Text, First, First + Match'Length - 1, Subst),
-            Match,
-            Subst);
+         return
+           Text (Text'First .. First - 1)
+           & Subst
+           & Replace (Text (First + Match'Length .. Text'Last), Match, Subst);
       end if;
    end Replace;
 

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -4,6 +4,7 @@ with Ada.Containers.Indefinite_Vectors;
 with Ada.Finalization;
 
 private with Ada.Strings.Fixed;
+private with Ada.Strings.Maps;
 
 package Alire.Utils with Preelaborate is
 
@@ -30,6 +31,9 @@ package Alire.Utils with Preelaborate is
 
    function Count_True (Booleans : Boolean_Array) return Natural;
 
+   function Is_Valid_Full_Person_Name (Name : String) return Boolean;
+   --  Validate that a name does not contain control/escape characters
+
    function Is_Valid_GitHub_Username (User : String) return Boolean;
    --  Check username is valid according to
    --  https://github.com/shinnn/github-username-regex
@@ -55,8 +59,8 @@ package Alire.Utils with Preelaborate is
    --  If Str contains Separator, the rhs is returned
    --  Otherwise ""
 
-   function Trim (S : String) return String;
-   --  Remove spaces at S extremes
+   function Trim (S : String; Target : Character := ' ') return String;
+   --  Remove Target at S extremes
 
    function Starts_With (Full_String, Substring : String) return Boolean is
      (Full_String'Length >= Substring'Length
@@ -75,6 +79,7 @@ package Alire.Utils with Preelaborate is
                      Match : String;
                      Subst : String)
                      return String;
+   --  Replace all occurrences of Match in Text with Subst
 
    type Halves is (Head, Tail);
 
@@ -201,7 +206,10 @@ private
    function Quote (S : String) return String is
      ("""" & S & """");
 
-   function Trim (S : String) return String is
-     (Ada.Strings.Fixed.Trim (S, Ada.Strings.Both));
+   function Trim (S : String; Target : Character := ' ') return String is
+     (Ada.Strings.Fixed.Trim
+        (S,
+         Left  => Ada.Strings.Maps.To_Set (Target),
+         Right => Ada.Strings.Maps.To_Set (Target)));
 
 end Alire.Utils;

--- a/src/alr/alr-utils.ads
+++ b/src/alr/alr-utils.ads
@@ -35,7 +35,8 @@ package Alr.Utils is
    --  If Str contains Separator, the rhs is returned
    --  Otherwise ""
 
-   function Trim (S : String) return String renames Alire.Utils.Trim;
+   function Trim (S : String; Target : Character := ' ')
+                  return String renames Alire.Utils.Trim;
 
    --  General containers
 

--- a/testsuite/tests/init/user-input-validation/test.py
+++ b/testsuite/tests/init/user-input-validation/test.py
@@ -1,0 +1,25 @@
+"""
+Check that a crate initialized with funny user name is loadable
+"""
+
+import os.path
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+from drivers.helpers import content_of
+
+# Preconfigure needed fields
+name = "Äl O'Reilly O\"Raro"
+run_alr("config", "--global", "--set", "user.email", "abc@de.com")
+run_alr("config", "--global", "--set", "user.github_login", "abcde")
+run_alr("config", "--global", "--set", "user.name", name)
+
+# Create crate
+run_alr("init", "--bin", "xxx")
+
+# Check that it can be shown, which will load the manifest
+os.chdir("xxx")
+p = run_alr("show")
+assert name in p.out, f"Unexpected output: {p.out}"
+
+print('SUCCESS')

--- a/testsuite/tests/init/user-input-validation/test.yaml
+++ b/testsuite/tests/init/user-input-validation/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    basic_index: # needed to avoid cloning the community index
+        in_fixtures: true

--- a/testsuite/tests/misc/clean-end/test.py
+++ b/testsuite/tests/misc/clean-end/test.py
@@ -17,8 +17,8 @@ assert_match(".*Cannot continue with invalid session:.*"  # skip logging prefix
              run_alr('with', quiet=False, complain_on_error=False).out)
 
 # Commands within a trivial session
-assert_eq("",
-          run_alr('init', '--bin', 'xxx').out)
+assert_match(".*initialized successfully.*",
+             run_alr('init', '--bin', 'xxx', quiet=False).out)
 os.chdir('xxx')
 
 assert_eq("",

--- a/testsuite/tests/workflows/init-options/test.py
+++ b/testsuite/tests/workflows/init-options/test.py
@@ -44,14 +44,17 @@ compare(contents('yyy'), ['yyy/alire',
 os.chdir('yyy')
 run_alr('init', '--bin', '--no-skel', 'yyy')
 
-# Init in place with existing crate
+# Init in place with existing crate FAIL (we do not overwrite files)
 os.chdir('yyy')
-run_alr('init', '--bin', '--in-place', '--no-skel', 'yyy')
+p = run_alr('init', '--bin', '--in-place', '--no-skel', 'yyy',
+            complain_on_error=False)
+assert_match(".*alire.toml already exists.*", p.out)
 
 # Init in place with existing invalid crate will FAIL
 with open('alire.toml', 'w') as f:
     f.write("plop")
-p = run_alr('init', '--bin', '--in-place', '--no-skel', 'yyy', complain_on_error=False)
+p = run_alr('init', '--bin', '--in-place', '--no-skel', 'yyy',
+            complain_on_error=False)
 assert_match(".*Invalid TOML contents.*", p.out)
 
 os.chdir(test_dir)


### PR DESCRIPTION
~This is still in flux, depending on previous PRs, so don't review yet (or check only the last commit).~

In the end I find more convenient in this particular instance to create the manifest by hand, since it is simple and intended for user reading, so we can format it as we please. So this PR changes from `To_TOML` export to plain `Put_Line` creation. We still use TOML functions to ensure the strings are properly encoded.

I have reformatted the layout of the `User_Input.Query_String` function, because I found the original interaction a bit confusing. If you want to go back to your previous version just say and I will revert that change.

Implements   #455.