### PR TITLE
Spelling fixes and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,32 +13,40 @@ a similar role to Rust's `cargo` or OCaml's `opam`.
 
 ### Caveat emptor ###
 
-Documentation at this time is minimal. Expect further efforts in this direction
+Documentation at this time is a work in progress. Expect further efforts in this direction
 until this warning is removed.
 
 ## TL;DR ##
 
 Available for Debian stable / Ubuntu >=17.10 / macOS / Windows
 
-`alr` is undergoing frequent changes in preparation for a first publicly
-announced beta. Hence, the current recommendation is to run the latest `master`
-branch version, and double-check in case of problems that no new PRs have been
-merged since your last compiled version.
+The latest release is version 0.7, which is also the first public beta intended for general testing and feedback gathering towards the 1.0 release. See the [Getting Started](doc/getting-started.md) guide for binary downloads.
 
-To see available crates per platform/compiler, see the
-[alire-crates-ci](https://github.com/alire-project/alire-crates-ci) companion
-repository.
+If, instead, you want to test the latest development version, see [Building from sources](#building-from source).
 
 ## Installation and First Steps ##
 
 See the [Getting Started](doc/getting-started.md) guide.
+
+## Building from sources ##
+
+The build process of `alr` is straighforward and depends only on a recent GNAT Ada 2012 compiler. All dependencies are included as submodules. A project file (`alr_env.gpr`) is provided to drive the build with all necessary configuration (see the macOS extra step below, though).
+
+Follow these steps:
+
+1. Clone the repository: `git clone --recurse-submodules https://github.com/alire-project/alire.git`
+1. Enter the cloned repository folder.
+1. Only on macOS: define the environment variable `OS=macOS`
+1. Build the executable: `gprbuild -j0 -P alr_env`
+
+The binary will be found at `bin/alr`. You can run `alr version` to see version and diagnostics information.
 
 ## Design principles ##
 
 alr is tailored to userspace, in a similar way to Python's virtualenv. A
 project or workspace will contain all its dependencies.
 
-At this time some projects require platform packages. In this case the user
+Some crates benefit from using platform packages. In this case the user
 will be asked to authorize a `sudo` installation through the platform package
 manager.
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -5,25 +5,25 @@
 You can download the last release of Alire at the [GitHub repository](https://github.com/alire-project/alire/releases).
 
 You will also need a GNAT compiler toolchain. On Linux you can usually get it from your
-distribution. Otherwise, and for Windows and MacOS you can download and install
+distribution. Otherwise, and for Windows and macOS you can download and install
 [GNAT Community](https://www.adacore.com/download).
 
 ## `alr` on Linux and macOS
 
 For Linux and macOS, `Alire` is simply provided in an archive. 
 
-Once the archive is extracted you have to add `alr` in the environement `PATH`:
+Once the archive is extracted you have to add `alr` in the environment `PATH`:
 ```bash
 $ export PATH=<PATH_TO_EXTRACTED>/bin/:$PATH
 ```
 
-You will also have to add your GNAT toolchain in the environement`PATH`.
+You will also have to add your GNAT toolchain in the environment`PATH`.
 
 ## `alr` on Windows
 
-For Windows an installer is provided. The installer will create a shortcut to start `PowerShell` with `Alire` in the environement `PATH`.
+For Windows an installer is provided. The installer will create a shortcut to start `PowerShell` with `Alire` in the environment `PATH`.
 
-Inside the `PowerShell` you will also have to add your GNAT toolchain in the environement`PATH`.
+Inside the `PowerShell` you will also have to add your GNAT toolchain in the environment`PATH`.
 For instance with [GNAT Community](https://www.adacore.com/download) at the default location:
 ```powershell
 PS> $env:Path += ";C:\GNAT\2020\bin\;C:\GNAT\2020-arm-elf\bin\"


### PR DESCRIPTION
AFAIK, *macOS* is the capitalization used by Apple.

Updated the README, now that it is not the website frontpage, to reflect the latest release and instructions to build the development version from sources.

If you're ok with these changes, I would merge this PR after the release actually exists.