### PR TITLE
Switch from devel- to stable- index branch

### DIFF
--- a/src/alire/alire-index.ads
+++ b/src/alire/alire-index.ads
@@ -43,7 +43,7 @@ package Alire.Index is
      and then Branch_String (Branch_String'Last) /= '-'
      and then (for some C of Branch_String => C = '-');
 
-   Community_Branch : constant String := "devel-0.4";
+   Community_Branch : constant String := "stable-0.4";
    --  The branch used for the community index
 
    Version : constant Semantic_Versioning.Version :=


### PR DESCRIPTION
We rely on `stable-0.4` until new features are required in the index format.