### PR TITLE
Saner defaults for the dependency solver

### DIFF
--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -170,6 +170,9 @@ package body Alire.Solutions is
       function Compare_Versions (This, Than : Solution) return Comparison is
       begin
 
+         --  TODO: instead of using the first discrepancy, we should count all
+         --  differences and see which one is globally "newer".
+
          --  Check releases in both only
 
          for Rel of This.Releases loop

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -237,9 +237,12 @@ package body Alr.Commands.Withing is
               Root.Current.Path,
               Platform.Properties);
          New_Solution : constant Alire.Solutions.Solution :=
-                          Alire.Solver.Resolve (New_Deps,
-                                                Platform.Properties,
-                                                Old_Solution);
+                          Alire.Solver.Resolve
+                            (New_Deps,
+                             Platform.Properties,
+                             Old_Solution,
+                             Options => (Age    => Query_Policy,
+                                         others => <>));
 
          Deps_Diff : constant Alire.Dependencies.Diffs.Diff :=
                        Alire.Dependencies.Diffs.Between (Old_Deps, New_Deps);


### PR DESCRIPTION
We were needlessly exploring the whole solution space, even when the best complete solution had been already found.

With this patch, dependencies with valid solutions should be solved much faster.

There are still situations in which the solver can take a long time: when there are already many crates in dependencies, that contain many releases, and a new unsolvable dependency is added, which will force exploring all possible solutions as no complete one exists. There are ways of improving this behavior but I will work on that in a later PR.