### PR TITLE
Added alire.toml so alr can build/edit itself

### DIFF
--- a/.github/workflows/ci-self.yml
+++ b/.github/workflows/ci-self.yml
@@ -1,0 +1,38 @@
+# An action to ensure that alr can build itself by running `alr build`.
+# In other words, a check that submodules are in sync with alire.toml
+
+name: CI alr build
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+      - '**.rst'
+      - '**.txt'
+  release:
+    types: [created]
+
+jobs:
+
+  build:
+    name: Self-build with `alr build`
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Install toolchain
+      uses: ada-actions/toolchain@ce2020
+      with:
+        distrib: community
+
+    - name: Install alr
+      uses: alire-project/setup-alire@latest-stable
+
+    - name: Self-build alr
+      run: alr build

--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,13 @@
 *.db
 *.db-???
 *.idea
+*.lock
 *.xml
 *.pyc
 
 .*sw?
 
+alire/
 bin
 lib
 obj

--- a/alire.toml
+++ b/alire.toml
@@ -9,9 +9,9 @@ description = "Command-line tool from the Alire project"
 # builds are uniquely identified without requiring manual editing or other
 # preprocessing. We could also include info about all dependencies exact
 # versions and environment used during the build.
-version = "0.7.1-dev"
+version = "0.8-dev"
 
-authors = ["Alejandro R. Mosteo", "Fabien Chouteau"]
+authors = ["Alejandro R. Mosteo", "Fabien Chouteau", "Pierre-Marie de Rodat"]
 maintainers = ["alejandro@mosteo.com", "chouteau@adacore.com"]
 maintainers-logins = ["mosteo", "Fabien-Chouteau"]
 

--- a/alire.toml
+++ b/alire.toml
@@ -1,0 +1,32 @@
+name = "alr"
+description = "Command-line tool from the Alire project"
+
+# Since the solved dependencies may vary from the submodules pinned to a commit
+# in ./deps, the result of `alr build` might differ from the same code built by
+# GitHub actions. We might want to add, down the road, a way to propagate the
+# version defined here into Ada code (perhaps by generating a metadata package
+# before `alr build` that the code being built can "with" if so desired), so
+# builds are uniquely identified without requiring manual editing or other
+# preprocessing. We could also include info about all dependencies exact
+# versions and environment used during the build.
+version = "0.7.1-dev"
+
+authors = ["Alejandro R. Mosteo", "Fabien Chouteau"]
+maintainers = ["alejandro@mosteo.com", "chouteau@adacore.com"]
+maintainers-logins = ["mosteo", "Fabien-Chouteau"]
+
+# At some point we should have a separate alire/libalire crate for use of
+# alire.gpr only.
+project-files = ["alr.gpr"]
+executables = ["alr"]
+
+[[depends-on]]
+aaa = "~0.2.1"
+ada_toml = "~0.1"
+ajunitgen = "^1.0.1"
+ansiada = "~0.1"
+gnatcoll = "^21"
+minirest = "~0.1"
+semantic_versioning = "^2"
+simple_logging = "^1.2"
+uri_ada = "^1"


### PR DESCRIPTION
Also bumped the patch number to `0.7.1`, as code changes from now own should appear in a future release, and `0.7-dev` means pre-0.7 according to semantic versioning.