### PR TITLE
More informative error for missing gprbuild

### DIFF
--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -1,3 +1,4 @@
+with Alire.Errors;
 with Alire.Paths;
 with Alire.Properties.Actions.Executor;
 
@@ -61,7 +62,11 @@ package body Alr.Commands.Build is
          end loop;
 
       exception
-         when others =>
+         when E : Alire.Checked_Error =>
+            Trace.Error (Alire.Errors.Get (E, Clear => False));
+            return False;
+         when E : others =>
+            Alire.Log_Exception (E);
             return False;
       end;
 

--- a/src/alr/alr-spawn.adb
+++ b/src/alr/alr-spawn.adb
@@ -1,9 +1,12 @@
 with Alire.OS_Lib.Subprocess;
 with Alire.Paths;
+with Alire.Utils.TTY;
 
 with Alr.Commands;
 
 package body Alr.Spawn is
+
+   package TTY renames Alire.Utils.TTY;
 
    -------------
    -- Command --
@@ -37,6 +40,12 @@ package body Alr.Spawn is
       Relocate : constant String :=
         "--relocate-build-tree=" & Alire.Paths.Build_Folder;
    begin
+      if Alire.OS_Lib.Subprocess.Locate_In_Path ("gprbuild") = "" then
+         Alire.Raise_Checked_Error
+           ("Cannot locate " & TTY.Emph ("gprbuild") & ", please check that " &
+            "you have a GNAT and GPRbuild installation in your environment.");
+      end if;
+
       Command ("gprbuild",
                Empty_Vector &
                  "-gnatwU" &


### PR DESCRIPTION
Following report on telegram.

I think we removed this check at some point because of some issue with cross-compiling, but now I cannot make sense of that. In any case, the check is now done just before calling `gprbuild` so at that point it is really needed.