### PR TITLE
Avoid unneeded requests to approve changes after editing the manifest

### DIFF
--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -90,6 +90,12 @@ package Alire.Roots is
    function Solution (This : Root) return Solutions.Solution;
    --  Returns the solution stored in the lockfile
 
+   function Is_Lockfile_Outdated (This : Root) return Boolean;
+   --  Says whether the manifest has been manually edited, and so the lockfile
+   --  requires being updated. This currently relies on timestamps, but (TODO)
+   --  conceivably we could use checksums to make it more robust against
+   --  automated changes within the same second.
+
    procedure Sync_Solution_And_Deps (This : Root);
    --  Ensure that dependencies are up to date in regard to the lockfile and
    --  manifest: if the manifest is newer than the lockfile, resolve again,
@@ -97,7 +103,13 @@ package Alire.Roots is
    --  releases in the lockfile are actually on disk (may be missing if cache
    --  was deleted, or the crate was just cloned).
 
-   --  files and folders derived from the root path (this obsoletes Alr.Paths)
+   procedure Sync_Manifest_And_Lockfile_Timestamps (This : Root);
+   --  If the lockfile is older than the manifest, sync their timestamps, do
+   --  nothing otherwise. We want this when the manifest has been manually
+   --  edited but the solution hasn't changed (and so the lockfile hasn't been
+   --  regenerated). This way we know the lockfile is valid for the manifest.
+
+   --  Files and folders derived from the root path (this obsoletes Alr.Paths):
 
    function Working_Folder (This : Root) return Absolute_Path;
    --  The "alire" folder inside the root path

--- a/src/alire/alire-utils-user_input.adb
+++ b/src/alire/alire-utils-user_input.adb
@@ -246,21 +246,22 @@ package body Alire.Utils.User_Input is
       if Changes.Contains_Changes then
          Trace.Log ("Changes to dependency solution:", Level);
          Changes.Print (Changed_Only => Changed_Only);
+
+         Trace.Log ("", Level);
+
+         return UI.Query
+           (Question => "Do you want to proceed?",
+            Valid    => (Yes | No => True,
+                         others   => False),
+            Default  => (if Changes.Latter_Is_Complete or else Alire.Force
+                         then Yes
+                         else No)) = Yes;
       else
          Trace.Log
            ("There are no changes between the former and new solution.",
             Level);
+         return True;
       end if;
-
-      Trace.Log ("", Level);
-
-      return UI.Query
-        (Question => "Do you want to proceed?",
-         Valid    => (Yes | No => True,
-                      others   => False),
-         Default  => (if Changes.Latter_Is_Complete or else Alire.Force
-                      then Yes
-                      else No)) = Yes;
    end Confirm_Solution_Changes;
 
    ---------------------

--- a/src/alire/alire-workspace.adb
+++ b/src/alire/alire-workspace.adb
@@ -334,6 +334,11 @@ package body Alire.Workspace is
          if not Confirm or else
            Utils.User_Input.Confirm_Solution_Changes (Diff)
          then
+            if not Confirm then
+               Trace.Info ("Changes to dependency solution:");
+               Diff.Print (Changed_Only => not Alire.Detailed);
+            end if;
+
             Deploy_Dependencies
               (Root     => Root,
                Solution => Next,

--- a/src/alr/alr-commands-update.adb
+++ b/src/alr/alr-commands-update.adb
@@ -53,7 +53,6 @@ package body Alr.Commands.Update is
                                     others => <>));
          Diff    : constant Alire.Solutions.Diffs.Diff := Old.Changes (Needed);
       begin
-
          --  Early exit when there are no changes
 
          if not Alire.Force and not Diff.Contains_Changes then
@@ -62,6 +61,9 @@ package body Alr.Commands.Update is
                  ("There are missing dependencies"
                   & " (use `alr with --solve` for details).");
             end if;
+
+            Root.Current.Sync_Manifest_And_Lockfile_Timestamps;
+            --  Just in case manual changes in manifest don't modify solution
 
             Trace.Info ("Nothing to update.");
             return;

--- a/testsuite/tests/update/manual-once/test.py
+++ b/testsuite/tests/update/manual-once/test.py
@@ -1,0 +1,42 @@
+"""
+Verify that, after manually touching the manifest, updates happen only once
+"""
+
+from drivers.alr import run_alr, init_local_crate
+from drivers.asserts import assert_eq, assert_match
+
+import os
+
+# There are two scenarios to test: both start with a manual edition of the
+# manifest. Afterwards, the user can either run 'update', which goes straight
+# into applying any changes found; or, they can run any other command, which
+# should also check for changes before doing anything, so the lockfile is in
+# sync with the manifest. We test both here.
+
+
+def prepare_crate(name):
+    """Prepare a crate with outdated lockfile"""
+    init_local_crate(name)
+    # Set the modification time of the lockfile behind that of the manifest
+    info = os.stat("alire.toml")
+    os.utime("alire.lock", (info.st_atime, info.st_mtime - 1))
+
+warning_text = "Detected changes in manifest, updating workspace"
+
+# Test when directly doing an update. Should report no changes.
+prepare_crate("test1")
+p = run_alr("update", quiet=False)
+assert_eq("Nothing to update.\n", p.out)
+# Also check that the modified manifest warning is not shown, as we are
+# requesting the update explicitly:
+assert warning_text not in p.out
+
+# Test when doing other things. Should warn once of possible changes.
+prepare_crate("test2")
+p = run_alr("with", quiet=False)  # First run must warn
+assert_match(warning_text + ".*", p.out)
+p = run_alr("with", quiet=False)  # Second run must not warn
+assert warning_text not in p.out
+
+
+print('SUCCESS')

--- a/testsuite/tests/update/manual-once/test.yaml
+++ b/testsuite/tests/update/manual-once/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
Changes in solutions were being spuriously detected, in situations in which there were no changes. Also, when manual changes didn't affect dependencies, the situation was not corrected either by manual update or automatic check.