### PR TITLE
Publish: Detect missing manifest in remote sources

### DIFF
--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -185,6 +185,16 @@ package body Alire.Publish is
 
       Deployer.Deploy (Context.Tmp_Deploy_Dir.Filename).Assert;
 
+      --  Check that the maintainer's manifest is at the expected location
+
+      if not GNAT.OS_Lib.Is_Regular_File
+        (Context.Tmp_Deploy_Dir.Filename / Roots.Crate_File_Name)
+      then
+         Raise_Checked_Error
+           ("Remote sources are missing the '"
+            & Roots.Crate_File_Name & "' manifest file.");
+      end if;
+
    end Deploy_Sources;
 
    -----------------------------

--- a/testsuite/tests/publish/missing-manifest/test.py
+++ b/testsuite/tests/publish/missing-manifest/test.py
@@ -1,0 +1,36 @@
+"""
+Check detection of a remote without manifest. This was allowed in the past, so
+legacy repositories that ignored the `alire.toml` file may run amok of this
+test.
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+from drivers.helpers import contents, content_of, init_git_repo, zip_dir
+from shutil import copyfile, rmtree
+from zipfile import ZipFile
+
+import os
+
+
+# Prepare a repo and a zipball to be used as "remote", without a manifest
+run_alr("init", "--bin", "xxx")
+# Remove the alire cache
+rmtree(os.path.join("xxx", "alire"))
+# Remove the manifest
+os.remove(os.path.join("xxx", "alire.toml"))
+
+# Create the zip
+zip_dir("xxx", "xxx.zip")
+
+# A "remote" source archive. We force to allow the test to skip the remote
+# check. Curl requires an absolute path to work.
+target = os.path.join(os.getcwd(), "xxx.zip")
+p = run_alr("publish", f"file:{target}", "--force", "--skip-build",
+            complain_on_error=False)
+
+# Should fail reporting the missing manifest
+assert_match(".*Remote sources are missing the 'alire.toml' manifest file.*",
+             p.out)
+
+print('SUCCESS')

--- a/testsuite/tests/publish/missing-manifest/test.yaml
+++ b/testsuite/tests/publish/missing-manifest/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
This could escape our checks when the alire.toml file was in .gitignore, for
example, so we didn't detect the discrepancy between local and remote sources.

Fixes #569 
Fixes #593