### PR TITLE
Add handling of arch and arch based distributions

### DIFF
--- a/src/alire/alire-platforms.ads
+++ b/src/alire/alire-platforms.ads
@@ -16,6 +16,7 @@ package Alire.Platforms with Preelaborate is
    type Distributions is (Debian,
                           Ubuntu,
                           Msys2,
+                          Arch,
                           Distro_Unknown);
 
    subtype Known_Distributions is
@@ -31,7 +32,7 @@ package Alire.Platforms with Preelaborate is
 
    Distro_Manager : constant array (Distributions) of Package_Managers :=
      (Debian | Ubuntu => Apt,
-      Msys2           => Pacman,
+      Msys2 | Arch    => Pacman,
       Distro_Unknown  => Packager_Unknown);
 
    type Toolchains is (System,

--- a/src/alire/alire-utils-tools.adb
+++ b/src/alire/alire-utils-tools.adb
@@ -60,7 +60,7 @@ package body Alire.Utils.Tools is
          when Msys2 | Debian | Ubuntu | Arch =>
             return (case Tool is
                        when Easy_Graph =>
-                         (if Distribution /= Msys2
+                         (if Distribution /= Msys2 and Distribution /= Arch
                           then "libgraph-easy-perl"
                           else ""),
                        when Git | Tar | Unzip | Curl => Exec_For_Tool (Tool),

--- a/src/alire/alire-utils-tools.adb
+++ b/src/alire/alire-utils-tools.adb
@@ -57,7 +57,7 @@ package body Alire.Utils.Tools is
             --  Cannot have package for an unknown distribution
             return "";
 
-         when Msys2 | Debian | Ubuntu =>
+         when Msys2 | Debian | Ubuntu | Arch =>
             return (case Tool is
                        when Easy_Graph =>
                          (if Distribution /= Msys2

--- a/src/alire/os_linux/alire-platform.adb
+++ b/src/alire/os_linux/alire-platform.adb
@@ -64,6 +64,7 @@ package body Alire.Platform is
 
             --  If no supported distribution found, fallback to id_like key
             if Cached_Distro = Distro_Unknown then
+               Trace.Debug ("Unknown distro for key 'id', falling back to 'id_like'");
                Cached_Distro := Get_Os_Release_Value_For_Key ("id_like");
             end if;
 

--- a/src/alire/os_linux/alire-platform.adb
+++ b/src/alire/os_linux/alire-platform.adb
@@ -41,30 +41,17 @@ package body Alire.Platform is
                   Normalized : constant String :=
                                  To_Lower_Case (Replace (Line, " ", ""));
                begin
-                  begin
-                     if Starts_With (Normalized, "id=") or else Starts_With (Normalized, "id_like=") then
-                        Cached_Distro :=
-                          Platforms.Distributions'Value
-                            (Tail (Normalized, '='));
-                        Distro_Cached := True;
-                        return Cached_Distro;
-                     end if;
-                  exception
-                     when others =>
-                        null; -- Not a known distro.
-                  end;
-                  begin
-                     if Starts_With (Normalized, "id_like=") then
-                        Cached_Distro :=
-                          Platforms.Distributions'Value
-                            (Tail (Normalized, '='));
-                        Distro_Cached := True;
-                        return Cached_Distro;
-                     end if;
-                  exception
-                     when others =>
-                        null; -- Not a known distro.
-                  end;
+                  if Starts_With (Normalized, "id=") or else
+                    Starts_With (Normalized, "id_like=")
+                  then
+                     Cached_Distro :=
+                       Platforms.Distributions'Value (Tail (Normalized, '='));
+                     Distro_Cached := True;
+                     return Cached_Distro;
+                  end if;
+               exception
+                  when others =>
+                     null; -- Not a known distro.
                end;
             end loop;
 

--- a/src/alire/os_linux/alire-platform.adb
+++ b/src/alire/os_linux/alire-platform.adb
@@ -37,8 +37,7 @@ package body Alire.Platform is
                         Subprocess.Checked_Spawn_And_Capture
                 ("cat", Empty_Vector & "/etc/os-release");
 
-            function Get_Os_Release_Value_For_Key (Key : String;
-                                                   Multiple_Values : Boolean)
+            function Get_Os_Release_Value_For_Key (Key : String)
                                       return Alire.Platforms.Distributions is
 
                use GNAT.Regpat;
@@ -63,20 +62,12 @@ package body Alire.Platform is
                   begin
                      Match (Regexp, Normalized, Matches);
                      if Matches (1) /= No_Match then
-                        if Multiple_Values then
-                           --  Generate Values from space separated items
-                           Values :=
-                             Split (
-                               Normalized
-                                 (Matches (1).First .. Matches (1).Last), ' ');
+                        --  Generate Values from space separated items
+                        Values :=
+                          Split (
+                            Normalized
+                            (Matches (1).First .. Matches (1).Last), ' ');
 
-                        else
-                           --  Generate Values from a single value
-                           Values :=
-                             To_Vector (
-                               Normalized
-                                 (Matches (1).First .. Matches (1).Last));
-                        end if;
                         for Value of Values loop
                            begin
                               return Platforms.Distributions'Value
@@ -100,16 +91,14 @@ package body Alire.Platform is
          begin
             --  First try with id key
             Cached_Distro :=
-              Get_Os_Release_Value_For_Key (Key => "id",
-                                            Multiple_Values => False);
+              Get_Os_Release_Value_For_Key (Key => "id");
 
             --  If no supported distribution found, fallback to id_like key
             if Cached_Distro = Distro_Unknown then
                Trace.Debug
                  ("Unknown distro for key 'id', falling back to 'id_like'");
                Cached_Distro :=
-                 Get_Os_Release_Value_For_Key (Key => "id_like",
-                                               Multiple_Values => True);
+                 Get_Os_Release_Value_For_Key (Key => "id_like");
             end if;
 
             --  Still an unsupported distribution ?

--- a/src/alire/os_linux/alire-platform.adb
+++ b/src/alire/os_linux/alire-platform.adb
@@ -42,8 +42,15 @@ package body Alire.Platform is
                                       return Alire.Platforms.Distributions is
 
                use GNAT.Regpat;
+
+               --  Regexp accepting lines not starting with '#' like:
+               --  key=value
+               --  key='value'
+               --  key='value1 value2'
+               --  key="value"
+               --  key="value1 value2"
                Regexp : constant Pattern_Matcher :=
-                 Compile (Key & "\s*=\s*""?([^""]+)""?");
+                 Compile ("^" & Key & "=[""']?([^""']+)[""']?");
                Matches : Match_Array (1 .. 1);
 
             begin

--- a/src/alire/os_linux/alire-platform.adb
+++ b/src/alire/os_linux/alire-platform.adb
@@ -64,7 +64,8 @@ package body Alire.Platform is
 
             --  If no supported distribution found, fallback to id_like key
             if Cached_Distro = Distro_Unknown then
-               Trace.Debug ("Unknown distro for key 'id', falling back to 'id_like'");
+               Trace.Debug
+                 ("Unknown distro for key 'id', falling back to 'id_like'");
                Cached_Distro := Get_Os_Release_Value_For_Key ("id_like");
             end if;
 

--- a/src/alire/os_linux/alire-platform.adb
+++ b/src/alire/os_linux/alire-platform.adb
@@ -41,15 +41,30 @@ package body Alire.Platform is
                   Normalized : constant String :=
                                  To_Lower_Case (Replace (Line, " ", ""));
                begin
-                  if Starts_With (Normalized, "id=") then
-                     Cached_Distro :=
-                       Platforms.Distributions'Value (Tail (Normalized, '='));
-                     Distro_Cached := True;
-                     return Cached_Distro;
-                  end if;
-               exception
-                  when others =>
-                     exit; -- Not a known distro.
+                  begin
+                     if Starts_With (Normalized, "id=") then
+                        Cached_Distro :=
+                          Platforms.Distributions'Value
+                            (Tail (Normalized, '='));
+                        Distro_Cached := True;
+                        return Cached_Distro;
+                     end if;
+                  exception
+                     when others =>
+                        null; -- Not a known distro.
+                  end;
+                  begin
+                     if Starts_With (Normalized, "id_like=") then
+                        Cached_Distro :=
+                          Platforms.Distributions'Value
+                            (Tail (Normalized, '='));
+                        Distro_Cached := True;
+                        return Cached_Distro;
+                     end if;
+                  exception
+                     when others =>
+                        null; -- Not a known distro.
+                  end;
                end;
             end loop;
 

--- a/src/alire/os_linux/alire-platform.adb
+++ b/src/alire/os_linux/alire-platform.adb
@@ -42,7 +42,7 @@ package body Alire.Platform is
                                  To_Lower_Case (Replace (Line, " ", ""));
                begin
                   begin
-                     if Starts_With (Normalized, "id=") then
+                     if Starts_With (Normalized, "id=") or else Starts_With (Normalized, "id_like=") then
                         Cached_Distro :=
                           Platforms.Distributions'Value
                             (Tail (Normalized, '='));


### PR DESCRIPTION
Hello, this pull request to add detection of Arch (and Arch based) distribution
This is done by analyzing value of "id" and "id_like" attributes in /etc/os-release file.