### PR TITLE
Refactor update logic from Alr into Alire

### DIFF
--- a/src/alire/alire-config-edit.adb
+++ b/src/alire/alire-config-edit.adb
@@ -146,4 +146,22 @@ package body Alire.Config.Edit is
       Load_Config; -- Reload with the new set value
    end Set;
 
+   -----------------
+   -- Set_Locally --
+   -----------------
+
+   procedure Set_Locally (Key : Config_Key; Value : String) is
+   begin
+      Set (Filepath (Local), Key, Value);
+   end Set_Locally;
+
+   ------------------
+   -- Set_Globally --
+   ------------------
+
+   procedure Set_Globally (Key : Config_Key; Value : String) is
+   begin
+      Set (Filepath (Global), Key, Value);
+   end Set_Globally;
+
 end Alire.Config.Edit;

--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -4,4 +4,10 @@ package Alire.Config.Edit is
 
    procedure Set (Path : Absolute_Path; Key : Config_Key; Value : String);
 
+   --  Shortcuts that use the standard config locations:
+
+   procedure Set_Locally (Key : Config_Key; Value : String);
+
+   procedure Set_Globally (Key : Config_Key; Value : String);
+
 end Alire.Config.Edit;

--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -115,6 +115,10 @@ package Alire.Config is
       --  A few predefined keys that are used in several places. This list is
       --  not exhaustive.
 
+      Update_Manually   : constant Config_Key := "update-manually-only";
+      --  Used by `get --only` to flag a workspace to not autoupdate itself
+      --  despite having no solution in the lockfile.
+
       User_Email        : constant Config_Key := "user.email";
       User_Name         : constant Config_Key := "user.name";
       User_Github_Login : constant Config_Key := "user.github_login";
@@ -204,7 +208,14 @@ private
        Cfg_Bool,
        +("If true, Alire will automatically add/edit a list of 'with' " &
            "statements in the root GPR project file based on the " &
-           "dependencies of the crate."))
+           "dependencies of the crate.")),
+
+      (+Keys.Update_Manually,
+       Cfg_Bool,
+       +("If true, Alire will not attempt to update dependencies even after "
+         & "the manifest is manually edited, or when no valid solution has "
+         & "been ever computed. All updates have to be manually requested "
+         & "through `alr update`"))
 
      );
 

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -1,11 +1,11 @@
-private with Alire.Containers;
-
 limited with Alire.Environment;
 with Alire.Conditional;
+with Alire.Containers;
 with Alire.Properties;
 with Alire.Releases;
 with Alire.Requisites;
 with Alire.Solutions;
+with Alire.Solver;
 with Alire.Utils;
 
 package Alire.Roots is
@@ -36,15 +36,16 @@ package Alire.Roots is
    --  Path must point to the session folder (parent of alire metadata folder)
 
    procedure Check_Stored (This : Root);
-   --  Check that the Root information exists on disk (paths exist,
-   --  files are at expected places...); otherwise Checked_Error
+   --  Check that the Root information exists on disk (paths exist, manifest
+   --  file is at expected place...); otherwise Checked_Error. Does not check
+   --  for lockfile existence.
 
    function Storage_Error (This : Root) return String;
    --  Returns the error that Check_Stored_Metadata would raise or "" otherwise
 
    function Is_Stored (This : Root) return Boolean
    is (This.Storage_Error = "");
-   --  Check that a root is properly stored
+   --  Check that a root is properly stored (manifest on disk is loadable)
 
    function Environment (This : Root) return Properties.Vector;
    --  Retrieve the environment stored within this root. Environment here
@@ -87,10 +88,16 @@ package Alire.Roots is
    function Release_Base (This : Root; Crate : Crate_Name) return Any_Path;
    --  Find the base folder in which a release can be found for the given root
 
-   function Solution (This : Root) return Solutions.Solution;
+   function Solution (This : Root) return Solutions.Solution with
+     Pre => This.Has_Lockfile;
    --  Returns the solution stored in the lockfile
 
-   function Is_Lockfile_Outdated (This : Root) return Boolean;
+   function Has_Lockfile (This : Root) return Boolean;
+   --  Check the corresponding lockfile storing a solution for the root
+   --  dependencies exists and is loadable.
+
+   function Is_Lockfile_Outdated (This : Root) return Boolean
+     with Pre => This.Has_Lockfile;
    --  Says whether the manifest has been manually edited, and so the lockfile
    --  requires being updated. This currently relies on timestamps, but (TODO)
    --  conceivably we could use checksums to make it more robust against
@@ -108,6 +115,16 @@ package Alire.Roots is
    --  nothing otherwise. We want this when the manifest has been manually
    --  edited but the solution hasn't changed (and so the lockfile hasn't been
    --  regenerated). This way we know the lockfile is valid for the manifest.
+
+   procedure Update_Dependencies
+     (This    : Root;
+      Silent  : Boolean;
+      Options : Solver.Query_Options := Solver.Default_Options;
+      Allowed : Containers.Crate_Name_Sets.Set :=
+        Alire.Containers.Crate_Name_Sets.Empty_Set)
+       with Pre => This.Has_Lockfile;
+   --  Resolve and update all or given crates in a root. When silent, run
+   --  as in non-interactive mode as this is an automatically-triggered update.
 
    --  Files and folders derived from the root path (this obsoletes Alr.Paths):
 

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -214,6 +214,10 @@ package Alire.Solutions is
    function Hints (This : Solution) return Dependency_Map;
    --  Return undetected externals in the solution
 
+   function Is_Attempted (This : Solution) return Boolean with
+     Post => Is_Attempted'Result = (This.Composition /= Unsolved);
+   --  Say if a real attempt at solving has been done
+
    function Is_Better (This, Than : Solution) return Boolean;
    --  Relative ordering to prioritize found solutions. We prefer decreasing
    --  order of Composition (avoid undetected externals/missing dependencies).
@@ -415,6 +419,13 @@ private
 
    function Hints (This : Solution) return Dependency_Map
    is (This.Dependencies_That (States.Is_Hinted'Access));
+
+   ------------------
+   -- Is_Attempted --
+   ------------------
+
+   function Is_Attempted (This : Solution) return Boolean
+   is (This.Composition /= Unsolved);
 
    -----------------
    -- Is_Complete --

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -1,5 +1,6 @@
 with Ada.Directories;
 
+with Alire.Config.Edit;
 with Alire.Dependencies;
 with Alire.Directories;
 with Alire.Index;
@@ -137,17 +138,26 @@ package body Alr.Commands.Get is
          Root_Dir.Keep;
       end;
 
-      if Cmd.Only then
-         Trace.Detail ("By your command, dependencies not resolved nor" &
-                         " retrieved: compilation might fail");
-         return;
-      end if;
-
-      --  Check out rest of dependencies and optionally compile
       declare
          Guard : Folder_Guard (Enter_Folder (Rel.Unique_Folder))
            with Unreferenced;
       begin
+         --  When --only was used, mark as only to be updated manually and bail
+         --  out already.
+
+         if Cmd.Only then
+            Trace.Detail ("By your command, dependencies not resolved nor" &
+                            " retrieved: compilation might fail");
+            Trace.Info ("Because --only was used, automatic dependency" &
+                          " retrieval is disabled in this workspace:" &
+                          " use `alr update` to apply dependency changes");
+            Alire.Config.Edit.Set_Locally
+              (Alire.Config.Keys.Update_Manually, "true");
+            return;
+         end if;
+
+         --  Check out rest of dependencies and optionally compile
+
          Alire.Workspace.Deploy_Dependencies (Solution => Solution);
 
          --  Execute the checked out release post_fetch actions, now that

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -100,7 +100,7 @@ package body Alr.Commands.Publish is
          Cmd.Tar'Access,
          "", "--tar",
          "Start the publishing assistant to create a source archive"
-         & "from a local directory");
+         & " from a local directory");
 
       Define_Switch
         (Config,

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -86,7 +86,7 @@ package Alr.Commands is
    procedure Requires_Valid_Session (Sync : Boolean := True);
    --  Verifies that a valid working dir is in scope. If Sync, enforce that the
    --  manifest, lockfile and dependencies on disk are in sync, by performing
-   --  an update.
+   --  a silent update. If not Sync, only a minimal empty lockfile is created.
 
    ---------------------------
    --  command-line helpers --


### PR DESCRIPTION
Fixes #571.

Took advantage of the changes that were necessary to refactor logic from `Alr.Commands.Update` into `Alire.Roots`, and remove some code duplication.

This unification caused in turn that `alr get --only` changed in behavior when commands are run inside such a workspace. Since `--only` implies that we don't want dependencies, to deal more cleanly with this special case a new local config flag `manual-update-only` is set that skips the autofetch/autoupdate logic.