### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -9,7 +9,7 @@ with Simple_Logging;
 
 package Alire with Preelaborate is
 
-   Version : constant String := "0.7.0-dev";
+   Version : constant String := "0.7.1";
 
    Checked_Error : exception;
    --  A Checked_Error is an explicitly diagnosed error condition, usually in


### PR DESCRIPTION
I'd say we have no urgent fixes pending, so we could make a new release with the recent patches for bugs reported since 0.7. Also to have a proper different version for the beta binary. 

After that I would merge your #564 to ensure `master` and `0.7-beta` have different versions, and then process the remaining PRs.