### PR TITLE
Add arch-rolling docker image to CI

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -21,6 +21,7 @@ jobs:
             - centos-latest-community-latest # Test unsupported package manager 
             - debian-stable                  # Test current stable Debian compiler
             - ubuntu-lts                     # Test current LTS Ubuntu compiler
+            - arch-rolling                   # Test Arch compiler (closest to FSF?)
 
     steps:
     - name: Check out repository


### PR DESCRIPTION
From my understanding of the Arch distribution, the GNAT version in Arch should be the most up-to-date with upstream FSF, when compared to release-based distributions.

Also #600 can be tested already on Arch.