### PR TITLE
Add --crate <file> option to publish command

### DIFF
--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -61,6 +61,9 @@ package body Alire.Publish is
       --  Place to check the sources
    end record;
 
+   function Crate_File_Name (Context : Data) return String is
+      (+Context.Options.Crate_File_Name);
+
    ---------------
    -- Git_Error --
    ---------------
@@ -188,11 +191,11 @@ package body Alire.Publish is
       --  Check that the maintainer's manifest is at the expected location
 
       if not GNAT.OS_Lib.Is_Regular_File
-        (Context.Tmp_Deploy_Dir.Filename / Roots.Crate_File_Name)
+        (Context.Tmp_Deploy_Dir.Filename / Crate_File_Name (Context))
       then
          Raise_Checked_Error
            ("Remote sources are missing the '"
-            & Roots.Crate_File_Name & "' manifest file.");
+            & Crate_File_Name (Context) & "' manifest file.");
       end if;
 
    end Deploy_Sources;
@@ -207,14 +210,15 @@ package body Alire.Publish is
    --  manifest.
 
    procedure Generate_Index_Manifest (Context : in out Data) is
+      File_Name : constant String := Crate_File_Name (Context);
       User_Manifest : constant Any_Path :=
-                       Context.Tmp_Deploy_Dir.Filename / Roots.Crate_File_Name;
+                       Context.Tmp_Deploy_Dir.Filename / File_Name;
       Workspace     : constant Roots.Optional.Root := Root.Current;
    begin
       if not GNAT.OS_Lib.Is_Read_Accessible_File (User_Manifest) then
          Raise_Checked_Error
            ("User manifest not found at expected location"
-            & " (${SRC_ROOT}/" & Roots.Crate_File_Name & ").");
+            & " (${SRC_ROOT}/" & Crate_File_Name (Context) & ").");
       end if;
 
       declare
@@ -464,16 +468,17 @@ package body Alire.Publish is
 
    procedure Show_And_Confirm (Context : in out Data) with
      Pre => GNAT.OS_Lib.Is_Regular_File
-       (Context.Tmp_Deploy_Dir.Filename / Roots.Crate_File_Name);
+       (Context.Tmp_Deploy_Dir.Filename / Crate_File_Name (Context));
    --  Present the final release information for confirmation by the user,
    --  after checking that no critical information is missing, or the release
    --  already exists.
 
    procedure Show_And_Confirm (Context : in out Data) is
+      File_Name : constant String := Crate_File_Name (Context);
       Release : constant Releases.Release :=
                   Releases
                     .From_Manifest
-                      (Context.Tmp_Deploy_Dir.Filename / Roots.Crate_File_Name,
+                      (Context.Tmp_Deploy_Dir.Filename / File_Name,
                        Manifest.Local)
                     .Replacing (Origin => Context.Origin);
       use all type Utils.User_Input.Answer_Kind;

--- a/src/alire/alire-publish.ads
+++ b/src/alire/alire-publish.ads
@@ -1,10 +1,12 @@
 with Alire.Origins;
 with Alire.URI;
+with Alire.Roots;
 
 package Alire.Publish is
 
    type All_Options is record
       Skip_Build : Boolean := False;
+      Crate_File_Name : UString := +Roots.Crate_File_Name;
    end record;
 
    procedure Directory_Tar (Path     : Any_Path := ".";

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -1,6 +1,7 @@
 with Alire.Origins;
 with Alire.Publish;
 with Alire.URI;
+with Alire.Roots;
 
 package body Alr.Commands.Publish is
 
@@ -17,7 +18,11 @@ package body Alr.Commands.Publish is
       is (if Num_Arguments >= 2 then Argument (2) else "");
 
       Options : constant Alire.Publish.All_Options :=
-                  (Skip_Build => Cmd.Skip_Build);
+        (Skip_Build => Cmd.Skip_Build,
+         Crate_File_Name => Alire."+"
+           ((if Cmd.Crate_File_Name.all /= ""
+            then Cmd.Crate_File_Name.all
+            else Alire.Roots.Crate_File_Name)));
 
    begin
       if Alire.Utils.Count_True ((Cmd.Tar, Cmd.Print_Trusted)) > 1 then
@@ -113,6 +118,12 @@ package body Alr.Commands.Publish is
          Cmd.Skip_Build'Access,
          "", "--skip-build",
          "Skip the build check step");
+
+      Define_Switch
+        (Config,
+         Cmd.Crate_File_Name'Access,
+         "", "--crate=",
+         "Defines the crate file name to use");
    end Setup_Switches;
 
 end Alr.Commands.Publish;

--- a/src/alr/alr-commands-publish.ads
+++ b/src/alr/alr-commands-publish.ads
@@ -1,3 +1,4 @@
+private with GNAT.Strings;
 package Alr.Commands.Publish is
 
    --  Publish lends a helping hand to automate submission of crates/releases.
@@ -40,7 +41,7 @@ package Alr.Commands.Publish is
 
    overriding
    function Usage_Custom_Parameters (Cmd : Command) return String
-   is ("[--skip-build] [--tar] [<URL> [commit]]]");
+   is ("[--skip-build] [--tar] [--crate <file>] [<URL> [commit]]]");
 
 private
 
@@ -49,6 +50,9 @@ private
 
       Skip_Build : aliased Boolean := False;
       --  Skip the build check
+
+      Crate_File_Name : aliased GNAT.Strings.String_Access;
+      --  The Crate file name to use.
 
       Tar        : aliased Boolean := False;
       --  Start the assistant from a local folder to be tar'ed and uploaded


### PR DESCRIPTION
By default the publish command uses Alire.toml and some repositories
may provide different crates, the --crate <file> allows to specify
a crate template name that must be used for the publication.