### PR TITLE
Feedback line when non-empty alire.lock created

### DIFF
--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -404,6 +404,7 @@ package body Alire.Roots is
          --  Show changes and optionally ask user to apply them
 
          if Silent then
+            Trace.Info ("Dependencies automatically updated as follows:");
             Diff.Print;
          elsif not Utils.User_Input.Confirm_Solution_Changes (Diff) then
             Trace.Detail ("Update abandoned.");


### PR DESCRIPTION
Otherwise the changes are listed without context and it's a bit confusing. This only happens when no previous `alire.lock` exists (e.g. after cloning a crate manually). Otherwise, a `"Changes to dependency solution:"` is already printed.

`Silent` in this context means that it's an automatic update without requesting confirmations (because initially this was done without showing any feedback, but currently we always print dependency changes).