### PR TITLE
Enable fedora-latest docker image for testing

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -20,6 +20,7 @@ jobs:
         tag: # Those are our dockerhub alire/gnat:tag machines
             - centos-latest-community-latest # Test unsupported package manager 
             - debian-stable                  # Test current stable Debian compiler
+            - fedora-latest                  # Test current Fedora compiler
             - ubuntu-lts                     # Test current LTS Ubuntu compiler
             - arch-rolling                   # Test Arch compiler (closest to FSF?)
 


### PR DESCRIPTION
With the image provided by Christophe in alire-project/dockerfiles#2 we can test that `alr` builds in another popular distro with GNAT support.

This opens the question of what platforms we want to validate in this way. We don't really want to test on distributions with spotty Ada support. We can always disable testing if a distro falls behind, I guess.