### PR TITLE
Separate workflow to test unsupported package manager platform

### DIFF
--- a/.github/workflows/ci-unsupported.yml
+++ b/.github/workflows/ci-unsupported.yml
@@ -1,0 +1,51 @@
+# The purpose of this CI is to run tests in a platform where there is no
+# detected native package manager
+
+name: CI unsupported
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+      - '**.rst'
+      - '**.txt'
+
+jobs:
+
+  build:
+    name: CI on unsupported Linux
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Install toolchain
+      uses: ada-actions/toolchain@ce2020
+      with:
+        distrib: community
+    
+    - name: Install Python 3.x (required for the testsuite)
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Remove identifying file from OS
+      run: sudo rm -f /etc/os-release
+
+    - name: Run test script
+      run: scripts/ci-github.sh
+      shell: bash
+      env:
+        BRANCH: ${{ github.base_ref }}
+    
+    - name: Upload logs (if failed)
+      if: failure()
+      uses: actions/upload-artifact@master
+      with:
+        name: e3-log-unsupported.zip
+        path: testsuite/out

--- a/.github/workflows/ci-unsupported.yml
+++ b/.github/workflows/ci-unsupported.yml
@@ -34,14 +34,12 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Remove identifying file from OS
-      run: sudo rm -f /etc/os-release
-
     - name: Run test script
       run: scripts/ci-github.sh
       shell: bash
       env:
         BRANCH: ${{ github.base_ref }}
+        ALIRE_DISABLE_DISTRO: true
     
     - name: Upload logs (if failed)
       if: failure()

--- a/scripts/ci-github.sh
+++ b/scripts/ci-github.sh
@@ -17,6 +17,11 @@ export PATH+=:${PWD}/bin
 # Build alr
 gprbuild -j0 -p -P alr_env
 
+# Disable distro detection if supported
+if [ "${ALIRE_DISABLE_DISTRO:-}" == "true" ]; then
+   alr config --global --set distribution.disable_detection true
+fi
+
 # For the record
 echo ENVIRONMENT:
 env | sort

--- a/src/alire/alire-config.adb
+++ b/src/alire/alire-config.adb
@@ -4,7 +4,6 @@ with Ada.Text_IO;
 
 with GNAT.Regexp;
 
-with Alire.Directories;
 with Alire.Environment;
 with Alire.Platform;
 
@@ -360,7 +359,7 @@ package body Alire.Config is
 
       for Lvl in Level loop
 
-         if Lvl /= Local or else Root.Current.Is_Valid then
+         if Lvl /= Local or else Directories.Detect_Root_Path /= "" then
             declare
                Config : constant TOML_Value :=
                  Load_Config_File (Filepath (Lvl));
@@ -371,6 +370,15 @@ package body Alire.Config is
             end;
          end if;
       end loop;
+
+      --  Set variables elsewhere
+
+      Platform.Disable_Distribution_Detection :=
+        Get (Keys.Distribution_Disable_Detection, False);
+      if Platform.Disable_Distribution_Detection then
+         Trace.Debug ("Distribution detection disabled by configuration");
+      end if;
+
    end Load_Config;
 
    ----------------------

--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -125,6 +125,11 @@ package Alire.Config is
 
       Editor_Cmd  : constant Config_Key := "editor.cmd";
 
+      Distribution_Disable_Detection : constant Config_Key :=
+                                         "distribution.disable_detection";
+      --  When set to True, distro will be reported as unknown, and in turn no
+      --  native package manager will be used.
+
    end Keys;
 
 private
@@ -224,7 +229,12 @@ private
        +("If true, Alire will not attempt to update dependencies even after "
          & "the manifest is manually edited, or when no valid solution has "
          & "been ever computed. All updates have to be manually requested "
-         & "through `alr update`"))
+         & "through `alr update`")),
+
+      (+Keys.Distribution_Disable_Detection,
+       Cfg_Bool,
+       +("If true, Alire will report an unknown distribution and will not"
+         & " attempt to use the system package manager."))
 
      );
 

--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -1,5 +1,5 @@
+with Alire.Directories;
 with Alire.OS_Lib; use Alire.OS_Lib.Operators;
-with Alire.Root;
 with Alire.Utils;
 
 with TOML;
@@ -70,7 +70,7 @@ package Alire.Config is
    type Level is (Global, Local);
 
    function Filepath (Lvl : Level) return Absolute_Path
-     with Pre => Lvl /= Local or else Alire.Root.Current.Is_Valid;
+     with Pre => Lvl /= Local or else Directories.Detect_Root_Path /= "";
    --  Return path of the configuration file coresponding to the given
    --  configuration level.
 
@@ -135,7 +135,9 @@ package Alire.Config is
 private
 
    procedure Load_Config;
-   --  Clear an reload all configuration
+   --  Clear an reload all configuration. Also set some values elsewhere used
+   --  to break circularities. Bottom line, this procedure must leave the
+   --  program-wide configuration ready.
 
    function Load_Config_File (Path : Absolute_Path) return TOML.TOML_Value;
    --  Load a TOML config file and return No_TOML_Value if the file is invalid

--- a/src/alire/alire-platform.ads
+++ b/src/alire/alire-platform.ads
@@ -3,7 +3,9 @@ with Alire.Environment;
 
 package Alire.Platform is
 
-   --  Alr.Platforms will be progressively migrated in here as needed
+   --  Alr.Platforms will be progressively migrated in here as needed.
+
+   --  These specs must be fulfilled by bodies in each different OS we support.
 
    function Default_Config_Folder return String;
    --  Default configuration folder where indexes are stored.
@@ -11,7 +13,8 @@ package Alire.Platform is
    --  There are none currently (except for the index, alr is stateless)
    --  ${XDG_CONFIG_HOME:-.config}/alire
 
-   function Distribution return Platforms.Distributions;
+   function Detected_Distribution return Platforms.Distributions;
+   --  Must return the actual detected distribution
 
    function Distribution_Root return Absolute_Path;
    --  Root directory of the distribution
@@ -22,8 +25,22 @@ package Alire.Platform is
    --------------------------------
    -- Portable derived utilities --
    --------------------------------
+   --  Beyond this point, nothing has to be done in the body
+
+   Disable_Distribution_Detection : Boolean := False with Atomic;
+
+   function Distribution return Platforms.Distributions;
+   --  Cooked distribution that may return Unknown if detection was disabled
+   --  via config.
 
    function Distribution_Is_Known return Boolean is
       (Platforms."/=" (Distribution, Platforms.Distro_Unknown));
+
+private
+
+   function Distribution return Platforms.Distributions
+   is (if Disable_Distribution_Detection
+       then Platforms.Distro_Unknown
+       else Detected_Distribution);
 
 end Alire.Platform;

--- a/src/alire/os_linux/alire-platform.adb
+++ b/src/alire/os_linux/alire-platform.adb
@@ -1,4 +1,3 @@
-with Alire.Config;
 with Alire.OS_Lib.Subprocess;
 with Alire.Utils;
 with GNAT.Regpat;
@@ -27,16 +26,11 @@ package body Alire.Platform is
    Cached_Distro : Alire.Platforms.Distributions;
    Distro_Cached : Boolean := False;
 
-   function Distribution return Platforms.Distributions is
+   function Detected_Distribution return Platforms.Distributions is
       use Alire.OS_Lib;
       use all type Alire.Platforms.Distributions;
    begin
       if Distro_Cached then
-         return Cached_Distro;
-      elsif Config.Get (Config.Keys.Distribution_Disable_Detection, False) then
-         Trace.Debug ("Distribution detection disabled by configuration");
-         Distro_Cached := True;
-         Cached_Distro := Distro_Unknown;
          return Cached_Distro;
       elsif not GNAT.OS_Lib.Is_Regular_File (OS_Identity_File) then
          Trace.Debug ("Distribution identity file not found: "
@@ -129,7 +123,7 @@ package body Alire.Platform is
          Trace.Debug ("Unable to detect distribution:");
          Log_Exception (E);
          return Distro_Unknown;
-   end Distribution;
+   end Detected_Distribution;
 
    -----------------------
    -- Distribution_Root --

--- a/src/alire/os_linux/alire-platform.adb
+++ b/src/alire/os_linux/alire-platform.adb
@@ -1,3 +1,4 @@
+with Alire.Config;
 with Alire.OS_Lib.Subprocess;
 with Alire.Utils;
 with GNAT.Regpat;
@@ -32,7 +33,14 @@ package body Alire.Platform is
    begin
       if Distro_Cached then
          return Cached_Distro;
+      elsif Config.Get (Config.Keys.Distribution_Disable_Detection, False) then
+         Trace.Debug ("Distribution detection disabled by configuration");
+         Distro_Cached := True;
+         Cached_Distro := Distro_Unknown;
+         return Cached_Distro;
       elsif not GNAT.OS_Lib.Is_Regular_File (OS_Identity_File) then
+         Trace.Debug ("Distribution identity file not found: "
+                      & OS_Identity_File);
          Distro_Cached := True;
          Cached_Distro := Distro_Unknown;
          return Cached_Distro;

--- a/src/alire/os_macos/alire-platform.adb
+++ b/src/alire/os_macos/alire-platform.adb
@@ -19,7 +19,7 @@ package body Alire.Platform is
    -- Distribution --
    ------------------
 
-   function Distribution return Platforms.Distributions is
+   function Detected_Distribution return Platforms.Distributions is
       (Platforms.Distro_Unknown);
 
    -----------------------

--- a/src/alire/os_windows/alire-platform.adb
+++ b/src/alire/os_windows/alire-platform.adb
@@ -80,14 +80,14 @@ package body Alire.Platform is
    -- Distribution --
    ------------------
 
-   function Distribution return Platforms.Distributions is
+   function Detected_Distribution return Platforms.Distributions is
    begin
       if not Distrib_Detected then
          Detect_Distrib;
       end if;
 
       return Distrib;
-   end Distribution;
+   end Detected_Distribution;
 
    -----------------------
    -- Distribution_Root --

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -37,6 +37,12 @@ def prepare_env(config_dir, env):
     mkdir(config_dir)
     env['ALR_CONFIG'] = config_dir
 
+    # If distro detection is disabled via environment, configure so in alr
+    if "ALIRE_DISABLE_DISTRO" in env:
+        if env["ALIRE_DISABLE_DISTRO"] == "true":
+            run_alr("config", "--global",
+                    "--set", "distribution.disable_detection", "true")
+
 
 def run_alr(*args, **kwargs):
     """

--- a/testsuite/tests/config/distro-disable/test.py
+++ b/testsuite/tests/config/distro-disable/test.py
@@ -1,0 +1,16 @@
+"""
+Verify that disabling distro detection works as intended
+"""
+
+import os
+
+from glob import glob
+
+from drivers.alr import run_alr, distro_is_known
+
+run_alr("config", "--global",
+        "--set", "distribution.disable_detection", "true")
+
+assert not distro_is_known(), "Unexpected distro detection"
+
+print('SUCCESS')

--- a/testsuite/tests/config/distro-disable/test.yaml
+++ b/testsuite/tests/config/distro-disable/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}

--- a/testsuite/tests/workflows/init-options/test.py
+++ b/testsuite/tests/workflows/init-options/test.py
@@ -52,12 +52,12 @@ p = run_alr('init', '--bin', '--in-place', '--no-skel', 'yyy',
             complain_on_error=False, quiet=False)
 assert_match(".*alire.toml already exists.*", p.out)
 
-# Init in place with existing invalid crate will FAIL
+# Init in place with existing invalid crate FAIL (we don't even try to load it)
 with open('alire.toml', 'w') as f:
     f.write("plop")
 p = run_alr('init', '--bin', '--in-place', '--no-skel', 'yyy',
-            complain_on_error=False)
-assert_match(".*Invalid TOML contents.*", p.out)
+            complain_on_error=False, quiet=False)
+assert_match(".*alire.toml already exists.*", p.out)
 
 os.chdir(test_dir)
 


### PR DESCRIPTION
In the end I went for a Linux instead of the suggested Windows in #601 because Windows is at present giving us more problems, with sporadic failures with unidentified causes. Also the test is quicker not requiring the CE setup.

Depends on #621 

This PR adds a new config option, `distribution.disable-detection`, that results in an unknown distribution always being reported.

To break circularity problems, loading the configuration no longer requires to load the manifest, only to locate it. This caused one test to err slightly later (as it does not need the manifest contents), which accounts for the test modification.