### PR TITLE
Feature/windows tar

### DIFF
--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -368,11 +368,12 @@ package body Alire.Publish is
          OS_Lib.Subprocess.Checked_Spawn
            ("tar",
             (if GNATCOLL.OS.Constants.OS in GNATCOLL.OS.Windows
-              then Empty_Vector
-              & "-C" & ".." -- Change to the parent directory
-              & "-czf"
-              else Empty_Vector
-              & "cfj")
+                 and Alire.Platform.Distribution /= Alire.Platforms.Msys2
+             then Empty_Vector
+                  & "-C" & ".." -- Change to the parent directory
+                  & "-czf"
+             else Empty_Vector
+                  & "cfj")
             & Archive --  Destination file at alire/archives/crate-version.tbz2
 
             & String'("--exclude=./alire")
@@ -389,7 +390,7 @@ package body Alire.Publish is
                     & "."
               elsif GNATCOLL.OS.Constants.OS in GNATCOLL.OS.Windows
                 and Alire.Platform.Distribution /= Alire.Platforms.Msys2
-               then Empty_Vector
+              then Empty_Vector
                     & "--exclude=*.git"
                     & "--exclude=*.hg"
                     & "--exclude=*.svn"

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -13,6 +13,8 @@ with Alire.Manifest;
 with Alire.Origins.Deployers;
 with Alire.OS_Lib.Subprocess;
 with Alire.Paths;
+with Alire.Platform;
+with Alire.Platforms;
 with Alire.Properties.From_TOML;
 with Alire.Releases;
 with Alire.Root;
@@ -330,8 +332,8 @@ package body Alire.Publish is
                      Target_Dir
                        / (Milestone
                           & (if Is_Repo
-                            then ".tgz"
-                            else ".tbz2"));
+                             then ".tgz"
+                             else ".tbz2"));
       use Utils.User_Input;
 
       -----------------
@@ -358,6 +360,7 @@ package body Alire.Publish is
       -----------------
 
       procedure Tar_Archive is
+         use type Alire.Platforms.Distributions;
       begin
          pragma Warnings (Off, "condition is always");
          --  To silence our below check for macOS
@@ -384,7 +387,8 @@ package body Alire.Publish is
                     & String'("-s,^./," & Milestone & "/,")
                     --  Prepend empty milestone dir as required for our tars
                     & "."
-               elsif GNATCOLL.OS.Constants.OS in GNATCOLL.OS.Windows
+              elsif GNATCOLL.OS.Constants.OS in GNATCOLL.OS.Windows
+                and Alire.Platform.Distribution /= Alire.Platforms.Msys2
                then Empty_Vector
                     & "--exclude=*.git"
                     & "--exclude=*.hg"

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -329,8 +329,7 @@ package body Alire.Publish is
       Archive    : constant Relative_Path :=
                      Target_Dir
                        / (Milestone
-                          & (if Is_Repo or GNATCOLL.OS.Constants.OS
-                              in GNATCOLL.OS.Windows
+                          & (if Is_Repo
                             then ".tgz"
                             else ".tbz2"));
       use Utils.User_Input;


### PR DESCRIPTION
I have made changes to Alire publish for Windows.
The tar command under Windows needs a different approach in order to create a tar file with the current directory as root.
To do this you can change directory to the parent directory using '-C ..' and provide the directory name as the source for tar.
Also the Windows tar does not support '-s' and it uses a dash for the compression command. (i.e. '-czf' instead of 'cfj')

Note that I previously changed the bzip2 (tbz2) into tgz for Windows, but it appears that this change is not necessary.

The Alire test suite uses Msys2, so my first attempt failed. My fix was intended for running Alire on a Windows system without Msys2.