### PR TITLE
Enable verbose spawn only if -v is in effect

### DIFF
--- a/src/alire/alire-os_lib-subprocess.adb
+++ b/src/alire/alire-os_lib-subprocess.adb
@@ -176,7 +176,9 @@ package body Alire.OS_Lib.Subprocess is
       use GNAT.OS_Lib;
 
       Extra    : constant String_Vector :=
-        (if Understands_Verbose then Empty_Vector & "-v" else Empty_Vector);
+                   (if Understands_Verbose and then Log_Level > Info
+                    then Empty_Vector & "-v"
+                    else Empty_Vector);
 
       Full_Args : constant String_Vector := Extra & Arguments;
       Arg_List : Argument_List_Access := To_Argument_List (Full_Args);


### PR DESCRIPTION
For spawned commands that understand `-v`, we were adding it no matter if `alr` itself was called with `-v`. With this patch, the spawned commands are verbose only if `alr` itself is.

Fixes #642.