### PR TITLE
Bump index version to devel-0.5

### DIFF
--- a/src/alire/alire-index.ads
+++ b/src/alire/alire-index.ads
@@ -43,7 +43,7 @@ package Alire.Index is
      and then Branch_String (Branch_String'Last) /= '-'
      and then (for some C of Branch_String => C = '-');
 
-   Community_Branch : constant String := "stable-0.4";
+   Community_Branch : constant String := "devel-0.5";
    --  The branch used for the community index
 
    Version : constant Semantic_Versioning.Version :=

--- a/src/alire/alire-platforms.ads
+++ b/src/alire/alire-platforms.ads
@@ -20,7 +20,8 @@ package Alire.Platforms with Preelaborate is
                           Distro_Unknown);
 
    subtype Known_Distributions is
-     Distributions range Debian .. Distributions'Pred (Distributions'Last);
+     Distributions range Distributions'First ..
+                         Distributions'Pred (Distributions'Last);
 
    type Word_Sizes is (Bits_32,
                        Bits_64,

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -9,7 +9,9 @@ with Simple_Logging;
 
 package Alire with Preelaborate is
 
-   Version : constant String := "0.8.0-dev";
+   Version : constant String := "0.8.1-dev";
+   --  0.8.1-dev: update to devel-0.5 index branch
+   --  0.8.0-dev: post-0.7-beta changes
 
    Checked_Error : exception;
    --  A Checked_Error is an explicitly diagnosed error condition, usually in

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -169,6 +169,7 @@ priority = {}
 url = '{}'
             """.format(name, priority, os.path.join(working_dir, files_dir)))
 
+
 def index_branch():
     """
     Identify the expected index branch from `alr version`
@@ -178,6 +179,7 @@ def index_branch():
         if line.startswith("community index"):
             return line.split(':')[1].strip()
     raise Exception("Unexpected alr output, cannot find index version")
+
 
 def index_version():
     """

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -169,6 +169,22 @@ priority = {}
 url = '{}'
             """.format(name, priority, os.path.join(working_dir, files_dir)))
 
+def index_branch():
+    """
+    Identify the expected index branch from `alr version`
+    """
+    p = run_alr("version", quiet=False)
+    for line in p.out.splitlines():
+        if line.startswith("community index"):
+            return line.split(':')[1].strip()
+    raise Exception("Unexpected alr output, cannot find index version")
+
+def index_version():
+    """
+    Identify the expected index version from `alr version`
+    """
+    return index_branch().split('-')[1]
+
 
 def init_local_crate(name="xxx", binary=True, enter=True):
     """

--- a/testsuite/fix-versions.sh
+++ b/testsuite/fix-versions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-oldversion=0.2
-newversion=0.4
+oldversion=0.4
+newversion=0.5
 
 find . -type f -name index.toml -exec sed -i "s/$oldversion/$newversion/" {} \;

--- a/testsuite/fixtures/basic_index/index.toml
+++ b/testsuite/fixtures/basic_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/fixtures/cases_index/index.toml
+++ b/testsuite/fixtures/cases_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/fixtures/checked_index/index.toml
+++ b/testsuite/fixtures/checked_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/fixtures/git_index/index.toml
+++ b/testsuite/fixtures/git_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/fixtures/native_index/index.toml
+++ b/testsuite/fixtures/native_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/fixtures/run_index/index.toml
+++ b/testsuite/fixtures/run_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/fixtures/solver_index/index.toml
+++ b/testsuite/fixtures/solver_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/skels/local-index/my_index/index/index.toml
+++ b/testsuite/skels/local-index/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/get/backup-user-manifest/my_index/index/index.toml
+++ b/testsuite/tests/get/backup-user-manifest/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/get/build/my_index/index/index.toml
+++ b/testsuite/tests/get/build/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/get/external-tool-dependency/my_index/index.toml
+++ b/testsuite/tests/get/external-tool-dependency/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/get/indirect-link/my_index/index/index.toml
+++ b/testsuite/tests/get/indirect-link/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/bad-action-command/my_index/index/index.toml
+++ b/testsuite/tests/index/bad-action-command/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/bad-index-metadata/my_index/index/index.toml
+++ b/testsuite/tests/index/bad-index-metadata/my_index/index/index.toml
@@ -1,2 +1,2 @@
-version = "0.4"
+version = "0.5"
 badkey = "sneaking around"

--- a/testsuite/tests/index/bad-license/my_index/index/index.toml
+++ b/testsuite/tests/index/bad-license/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/bad-tag/my_index/index/index.toml
+++ b/testsuite/tests/index/bad-tag/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/empty-tag/my_index/index/index.toml
+++ b/testsuite/tests/index/empty-tag/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/environment/my_index/index/index.toml
+++ b/testsuite/tests/index/environment/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/external-available/my_index/index.toml
+++ b/testsuite/tests/index/external-available/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/external-from-output/my_index/index/index.toml
+++ b/testsuite/tests/index/external-from-output/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/external-hint/my_index/index.toml
+++ b/testsuite/tests/index/external-hint/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/external-msys2/my_index/index.toml
+++ b/testsuite/tests/index/external-msys2/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/external-unindexed/my_index/index/index.toml
+++ b/testsuite/tests/index/external-unindexed/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/long-description/my_index/index/index.toml
+++ b/testsuite/tests/index/long-description/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/long-tag/my_index/index/index.toml
+++ b/testsuite/tests/index/long-tag/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/maint-bad-email/my_index/index/index.toml
+++ b/testsuite/tests/index/maint-bad-email/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/maint-bad-login/my_index/index/index.toml
+++ b/testsuite/tests/index/maint-bad-login/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/mismatched-crate/my_index/index/index.toml
+++ b/testsuite/tests/index/mismatched-crate/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/mismatched-parent/my_index/index/index.toml
+++ b/testsuite/tests/index/mismatched-parent/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/origin-filesystem-bad-path/bad_index_1/index.toml
+++ b/testsuite/tests/index/origin-filesystem-bad-path/bad_index_1/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/origin-filesystem-bad-path/bad_index_2/index.toml
+++ b/testsuite/tests/index/origin-filesystem-bad-path/bad_index_2/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/origin-no-archive-name/my_index/index/index.toml
+++ b/testsuite/tests/index/origin-no-archive-name/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/origin-unknown-kind/my_index/index/index.toml
+++ b/testsuite/tests/index/origin-unknown-kind/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/too-long-short-description/my_index/index/index.toml
+++ b/testsuite/tests/index/too-long-short-description/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/index/unexpected-contents/my_index/index/index.toml
+++ b/testsuite/tests/index/unexpected-contents/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/pin/all/my_index/index/index.toml
+++ b/testsuite/tests/pin/all/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/pin/change-type/my_index/index.toml
+++ b/testsuite/tests/pin/change-type/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/pin/downgrade/my_index/index/index.toml
+++ b/testsuite/tests/pin/downgrade/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/pin/pin-dir-with-regular/my_index/index.toml
+++ b/testsuite/tests/pin/pin-dir-with-regular/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/pin/pin-dir/my_index/index.toml
+++ b/testsuite/tests/pin/pin-dir/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/pin/post-update/my_index/index/index.toml
+++ b/testsuite/tests/pin/post-update/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/pin/unneeded-held/my_index/index/index.toml
+++ b/testsuite/tests/pin/unneeded-held/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/printenv/double-set/my_index/index/index.toml
+++ b/testsuite/tests/printenv/double-set/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/printenv/env-during-fetch/my_index/index/index.toml
+++ b/testsuite/tests/printenv/env-during-fetch/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/printenv/linked-paths/my_index/index/index.toml
+++ b/testsuite/tests/printenv/linked-paths/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/publish/check-build/my_index/index/index.toml
+++ b/testsuite/tests/publish/check-build/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/publish/check-properties/my_index/index/index.toml
+++ b/testsuite/tests/publish/check-properties/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/publish/remote-origin/test.py
+++ b/testsuite/tests/publish/remote-origin/test.py
@@ -2,7 +2,7 @@
 Tests for proper publishing of a ready remote origin
 """
 
-from drivers.alr import run_alr
+from drivers.alr import run_alr, index_version
 from drivers.asserts import assert_match
 from drivers.helpers import contents, content_of, init_git_repo, zip_dir
 from shutil import copyfile, rmtree
@@ -22,7 +22,7 @@ def verify_manifest():
 # create and add an index to check the manifest is loadable later on
 os.makedirs(os.path.join("my_index", "xx", "xxx"))
 with open(os.path.join("my_index", "index.toml"), "wt") as index_metadata:
-    index_metadata.write("version = '0.4'\n")
+    index_metadata.write(f"version = '{index_version()}'\n")
 run_alr("index", "--add", "my_index", "--name", "my_index")
 
 # Prepare a repo and a zipball to be used as "remote" targets for publishing

--- a/testsuite/tests/publish/tarball-plaindir/my_index/index/index.toml
+++ b/testsuite/tests/publish/tarball-plaindir/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/publish/tarball-repo/my_index/index/index.toml
+++ b/testsuite/tests/publish/tarball-repo/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/test/action-test/my_index/index/index.toml
+++ b/testsuite/tests/test/action-test/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/update/selective/my_index/index/index.toml
+++ b/testsuite/tests/update/selective/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/update/selective/my_index/updated/index/index.toml
+++ b/testsuite/tests/update/selective/my_index/updated/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/with/auto-gpr-with/basic/my_index/index.toml
+++ b/testsuite/tests/with/auto-gpr-with/basic/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/with/auto-gpr-with/gpr_in_subdir/my_index/index.toml
+++ b/testsuite/tests/with/auto-gpr-with/gpr_in_subdir/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/with/pin-dir/my_index/index/index.toml
+++ b/testsuite/tests/with/pin-dir/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/workflows/action-command/my_index/index/index.toml
+++ b/testsuite/tests/workflows/action-command/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"

--- a/testsuite/tests/workflows/edit/my_index/index.toml
+++ b/testsuite/tests/workflows/edit/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.4"
+version = "0.5"


### PR DESCRIPTION
The recent addition of more enum values to support other distributions is a breaking change. This commit bumps the index and alr versions.

This raises the question of whether we should by default silently ignore unknown enum values, as this is not a syntactic change. This way, supporting more configurations wouldn't require a new index branch.

Creating issue https://github.com/alire-project/alire/issues/650 to track this idea.