### PR TITLE
pacman: Remove unneeded -e flag

### DIFF
--- a/src/alire/alire-origins-deployers-system-pacman.adb
+++ b/src/alire/alire-origins-deployers-system-pacman.adb
@@ -43,10 +43,10 @@ package body Alire.Origins.Deployers.System.Pacman is
                  Subprocess.Checked_Spawn_And_Capture
                    ("pacman",
                     Empty_Vector &
-                      "-Qqe" &
+                      "-Qq" &
                       This.Base.Package_Name,
                     Valid_Exit_Codes => (0, 1), -- Returned when not found
-                    Err_To_Out     => True);
+                    Err_To_Out       => True);
    begin
       if not Output.Is_Empty
         and then


### PR DESCRIPTION
The `-e` flag filters out packages installed indirectly (i.e., as dependencies), causing our detection of such a package to fail. `-Q` by design already only works on installed packages, so that's all we need.

Fixes https://github.com/alire-project/alire/issues/641