### PR TITLE
alr-platforms-windows.adb: msys2 install command line changed

### DIFF
--- a/src/alr/os_windows/alr-platforms-windows.adb
+++ b/src/alr/os_windows/alr-platforms-windows.adb
@@ -106,7 +106,7 @@ package body Alr.Platforms.Windows is
       use Alire.Utils;
 
       Install_Prefix : constant String :=
-        "InstallPrefix=" & Install_Dir;
+        "InstallDir=" & Install_Dir;
 
       Result : Alire.Outcome;
    begin


### PR DESCRIPTION
https://github.com/msys2/msys2-installer/pull/20 changed the name of the argument for installation prefix of the msys2 installer.
All previous versions are impacted and won't be able to install msys2 at the correct location.