### PR TITLE
alr-platforms-windows.adb: use a specific version of the msys2 auto install script

### DIFF
--- a/src/alr/os_windows/alr-platforms-windows.adb
+++ b/src/alr/os_windows/alr-platforms-windows.adb
@@ -25,7 +25,7 @@ package body Alr.Platforms.Windows is
 
    Msys2_Installer_Script     : constant String := "auto-install.js";
    Msys2_Installer_Script_URL : constant String :=
-     "https://raw.githubusercontent.com/msys2/msys2-installer/master/" &
+     "https://raw.githubusercontent.com/msys2/msys2-installer/a588bcc/" &
      Msys2_Installer_Script;
 
    -------------------


### PR DESCRIPTION
Use a fixed version instead of latest on master branch of msys2-installer.
Changes in the master branch can break our installation code.