### PR TITLE
alire.ads: Bump version to 1.0-rc1

### DIFF
--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -9,7 +9,8 @@ with Simple_Logging;
 
 package Alire with Preelaborate is
 
-   Version : constant String := "0.8.1-dev";
+   Version : constant String := "0.1.0-rc1";
+   --  1.0.0-rc1: release candidate for 1.0
    --  0.8.1-dev: update to devel-0.5 index branch
    --  0.8.0-dev: post-0.7-beta changes
 


### PR DESCRIPTION
My idea is to tag a release with this `1.0-rc1` one, let it sleep for a week or so and then tag the `1.0` proper.