### PR TITLE
Move to stable index version, bump rc version

### DIFF
--- a/src/alire/alire-index.ads
+++ b/src/alire/alire-index.ads
@@ -43,7 +43,7 @@ package Alire.Index is
      and then Branch_String (Branch_String'Last) /= '-'
      and then (for some C of Branch_String => C = '-');
 
-   Community_Branch : constant String := "devel-0.5";
+   Community_Branch : constant String := "stable-1.0";
    --  The branch used for the community index
 
    Version : constant Semantic_Versioning.Version :=

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -9,7 +9,8 @@ with Simple_Logging;
 
 package Alire with Preelaborate is
 
-   Version : constant String := "0.1.0-rc1";
+   Version : constant String := "1.0.0-rc2";
+   --  1.0.0-rc2: move community index to stable-1.0 branch
    --  1.0.0-rc1: release candidate for 1.0
    --  0.8.1-dev: update to devel-0.5 index branch
    --  0.8.0-dev: post-0.7-beta changes

--- a/testsuite/fix-versions.sh
+++ b/testsuite/fix-versions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-oldversion=0.4
-newversion=0.5
+oldversion=0.5
+newversion=1.0
 
 find . -type f -name index.toml -exec sed -i "s/$oldversion/$newversion/" {} \;

--- a/testsuite/fixtures/basic_index/index.toml
+++ b/testsuite/fixtures/basic_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/fixtures/cases_index/index.toml
+++ b/testsuite/fixtures/cases_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/fixtures/checked_index/index.toml
+++ b/testsuite/fixtures/checked_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/fixtures/git_index/index.toml
+++ b/testsuite/fixtures/git_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/fixtures/native_index/index.toml
+++ b/testsuite/fixtures/native_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/fixtures/run_index/index.toml
+++ b/testsuite/fixtures/run_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/fixtures/solver_index/index.toml
+++ b/testsuite/fixtures/solver_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/skels/local-index/my_index/index/index.toml
+++ b/testsuite/skels/local-index/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/get/backup-user-manifest/my_index/index/index.toml
+++ b/testsuite/tests/get/backup-user-manifest/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/get/build/my_index/index/index.toml
+++ b/testsuite/tests/get/build/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/get/external-tool-dependency/my_index/index.toml
+++ b/testsuite/tests/get/external-tool-dependency/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/get/indirect-link/my_index/index/index.toml
+++ b/testsuite/tests/get/indirect-link/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/bad-action-command/my_index/index/index.toml
+++ b/testsuite/tests/index/bad-action-command/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/bad-index-metadata/my_index/index/index.toml
+++ b/testsuite/tests/index/bad-index-metadata/my_index/index/index.toml
@@ -1,2 +1,2 @@
-version = "0.5"
+version = "1.0"
 badkey = "sneaking around"

--- a/testsuite/tests/index/bad-license-too-long/my_index/index/index.toml
+++ b/testsuite/tests/index/bad-license-too-long/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/bad-license/my_index/index/index.toml
+++ b/testsuite/tests/index/bad-license/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/bad-tag/my_index/index/index.toml
+++ b/testsuite/tests/index/bad-tag/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/check-enums/my_index/index/index.toml
+++ b/testsuite/tests/index/check-enums/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/empty-tag/my_index/index/index.toml
+++ b/testsuite/tests/index/empty-tag/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/environment/my_index/index/index.toml
+++ b/testsuite/tests/index/environment/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/external-available/my_index/index.toml
+++ b/testsuite/tests/index/external-available/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/external-from-output/my_index/index/index.toml
+++ b/testsuite/tests/index/external-from-output/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/external-hint/my_index/index.toml
+++ b/testsuite/tests/index/external-hint/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/external-msys2/my_index/index.toml
+++ b/testsuite/tests/index/external-msys2/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/external-unindexed/my_index/index/index.toml
+++ b/testsuite/tests/index/external-unindexed/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/long-description/my_index/index/index.toml
+++ b/testsuite/tests/index/long-description/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/long-tag/my_index/index/index.toml
+++ b/testsuite/tests/index/long-tag/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/maint-bad-email/my_index/index/index.toml
+++ b/testsuite/tests/index/maint-bad-email/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/maint-bad-login/my_index/index/index.toml
+++ b/testsuite/tests/index/maint-bad-login/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/mismatched-crate/my_index/index/index.toml
+++ b/testsuite/tests/index/mismatched-crate/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/mismatched-parent/my_index/index/index.toml
+++ b/testsuite/tests/index/mismatched-parent/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/origin-filesystem-bad-path/bad_index_1/index.toml
+++ b/testsuite/tests/index/origin-filesystem-bad-path/bad_index_1/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/origin-filesystem-bad-path/bad_index_2/index.toml
+++ b/testsuite/tests/index/origin-filesystem-bad-path/bad_index_2/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/origin-no-archive-name/my_index/index/index.toml
+++ b/testsuite/tests/index/origin-no-archive-name/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/origin-unknown-kind/my_index/index/index.toml
+++ b/testsuite/tests/index/origin-unknown-kind/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/too-long-short-description/my_index/index/index.toml
+++ b/testsuite/tests/index/too-long-short-description/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/index/unexpected-contents/my_index/index/index.toml
+++ b/testsuite/tests/index/unexpected-contents/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/pin/all/my_index/index/index.toml
+++ b/testsuite/tests/pin/all/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/pin/change-type/my_index/index.toml
+++ b/testsuite/tests/pin/change-type/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/pin/downgrade/my_index/index/index.toml
+++ b/testsuite/tests/pin/downgrade/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/pin/pin-dir-with-regular/my_index/index.toml
+++ b/testsuite/tests/pin/pin-dir-with-regular/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/pin/pin-dir/my_index/index.toml
+++ b/testsuite/tests/pin/pin-dir/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/pin/post-update/my_index/index/index.toml
+++ b/testsuite/tests/pin/post-update/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/pin/unneeded-held/my_index/index/index.toml
+++ b/testsuite/tests/pin/unneeded-held/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/printenv/double-set/my_index/index/index.toml
+++ b/testsuite/tests/printenv/double-set/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/printenv/env-during-fetch/my_index/index/index.toml
+++ b/testsuite/tests/printenv/env-during-fetch/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/printenv/linked-paths/my_index/index/index.toml
+++ b/testsuite/tests/printenv/linked-paths/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/publish/check-build/my_index/index/index.toml
+++ b/testsuite/tests/publish/check-build/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/publish/check-properties/my_index/index/index.toml
+++ b/testsuite/tests/publish/check-properties/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/publish/tarball-plaindir/my_index/index/index.toml
+++ b/testsuite/tests/publish/tarball-plaindir/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/publish/tarball-repo/my_index/index/index.toml
+++ b/testsuite/tests/publish/tarball-repo/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/test/action-test/my_index/index/index.toml
+++ b/testsuite/tests/test/action-test/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/update/selective/my_index/index/index.toml
+++ b/testsuite/tests/update/selective/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/update/selective/my_index/updated/index/index.toml
+++ b/testsuite/tests/update/selective/my_index/updated/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/with/auto-gpr-with/basic/my_index/index.toml
+++ b/testsuite/tests/with/auto-gpr-with/basic/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/with/auto-gpr-with/gpr_in_subdir/my_index/index.toml
+++ b/testsuite/tests/with/auto-gpr-with/gpr_in_subdir/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/with/narrow-pre1/my_index/index/index.toml
+++ b/testsuite/tests/with/narrow-pre1/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/with/pin-dir/my_index/index/index.toml
+++ b/testsuite/tests/with/pin-dir/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/workflows/action-command/my_index/index/index.toml
+++ b/testsuite/tests/workflows/action-command/my_index/index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"

--- a/testsuite/tests/workflows/edit/my_index/index.toml
+++ b/testsuite/tests/workflows/edit/my_index/index.toml
@@ -1,1 +1,1 @@
-version = "0.5"
+version = "1.0"


### PR DESCRIPTION
First snafu, I forgot that we were on a devel index version that becomes the new stable one.