### PR TITLE
Subprocesses: Better error if unable to create tmp file

### DIFF
--- a/src/alire/alire-os_lib-subprocess.adb
+++ b/src/alire/alire-os_lib-subprocess.adb
@@ -275,6 +275,9 @@ package body Alire.OS_Lib.Subprocess is
 
    begin
       Create_Temp_Output_File (File, Name);
+      if Name = null then
+         Raise_Checked_Error ("Cannot create temporary file");
+      end if;
 
       Trace.Detail ("Spawning: " & Image (Command, Full_Args) &
                       " > " & Name.all);


### PR DESCRIPTION
Instead of erroring with generic unknown error we say that we couldn't create the temp file.