### PR TITLE
Error scopes

### DIFF
--- a/src/alire/alire-conditional_trees-toml_load.adb
+++ b/src/alire/alire-conditional_trees-toml_load.adb
@@ -1,4 +1,5 @@
 with Alire.Conditional_Trees.Case_Nodes;
+with Alire.Errors;
 with Alire.TOML_Keys;
 
 package body Alire.Conditional_Trees.TOML_Load is
@@ -66,7 +67,7 @@ package body Alire.Conditional_Trees.TOML_Load is
                              ("invalid enumeration value: " & Item_Key);
                         else
                            Trace.Debug
-                             (Case_Table.Message
+                             (Errors.Stack
                                 ("unknown enumeration value: " & Item_Key));
                         end if;
                      end if;

--- a/src/alire/alire-dependencies-states.ads
+++ b/src/alire/alire-dependencies-states.ads
@@ -4,6 +4,7 @@ private with Alire.Containers;
 with Alire.Externals.Softlinks;
 with Alire.Properties;
 with Alire.Releases;
+with Alire.TOML_Adapters;
 
 package Alire.Dependencies.States is
 

--- a/src/alire/alire-dependencies.adb
+++ b/src/alire/alire-dependencies.adb
@@ -1,3 +1,5 @@
+with Alire.TOML_Adapters;
+
 package body Alire.Dependencies is
 
    ---------------

--- a/src/alire/alire-dependencies.ads
+++ b/src/alire/alire-dependencies.ads
@@ -1,6 +1,5 @@
 with Alire.Interfaces;
 with Alire.Milestones;
-with Alire.TOML_Adapters;
 with Alire.Utils;
 
 with Semantic_Versioning.Basic;

--- a/src/alire/alire-errors.adb
+++ b/src/alire/alire-errors.adb
@@ -195,6 +195,7 @@ package body Alire.Errors is
 
    overriding
    procedure Finalize (This : in out Scope) is
+      pragma Unreferenced (This);
    begin
       Close;
    end Finalize;

--- a/src/alire/alire-errors.ads
+++ b/src/alire/alire-errors.ads
@@ -77,8 +77,8 @@ package Alire.Errors with Preelaborate is
    -----------
 
    type Scope (<>) is limited private;
-   --  A type to create a stack of error information. When Errors.Get is used,
-   --  the whole error stack is returned. Manages closing automatically.
+   --  A type to create a stack of error information. When Errors.Set is used,
+   --  the whole error stack is stored. Manages scope closing automatically.
 
    function Open (Text : String) return Scope;
    --  Push a new message into the error stack
@@ -91,7 +91,7 @@ package Alire.Errors with Preelaborate is
    --  As for Open; don't use manually.
 
    function Stack (Text : String) return String;
-   --  Return current error stack, plus Text
+   --  Return current error stack, plus Text as the latest error
 
 private
 

--- a/src/alire/alire-errors.ads
+++ b/src/alire/alire-errors.ads
@@ -1,4 +1,5 @@
 with Ada.Exceptions;
+private with Ada.Finalization;
 
 package Alire.Errors with Preelaborate is
 
@@ -71,9 +72,39 @@ package Alire.Errors with Preelaborate is
    --  Convenience to concatenate two error messages: a new wrapping text and
    --  an existing error within a exception being wrapped.
 
+   -----------
+   -- Scope --
+   -----------
+
+   type Scope (<>) is limited private;
+   --  A type to create a stack of error information. When Errors.Get is used,
+   --  the whole error stack is returned. Manages closing automatically.
+
+   function Open (Text : String) return Scope;
+   --  Push a new message into the error stack
+
+   procedure Open (Text : String);
+   --  Manually open a scope; used to blend seamlessly the TOML_Adapters.
+   --  Should not be used otherwise.
+
+   procedure Close;
+   --  As for Open; don't use manually.
+
+   function Stack (Text : String) return String;
+   --  Return current error stack, plus Text
+
 private
 
    Id_Marker : constant String := "alire-stored-error:";
+
+   type Scope is new Ada.Finalization.Limited_Controlled with null record;
+
+   overriding
+   procedure Finalize (This : in out Scope);
+
+   -----------------
+   -- Is_Error_Id --
+   -----------------
 
    function Is_Error_Id (Str : String) return Boolean is
      (Str'Length > Id_Marker'Length and then

--- a/src/alire/alire-properties-cases.ads
+++ b/src/alire/alire-properties-cases.ads
@@ -1,5 +1,3 @@
-with Alire.TOML_Adapters;
-
 with TOML;
 
 generic

--- a/src/alire/alire-properties-licenses.adb
+++ b/src/alire/alire-properties-licenses.adb
@@ -97,7 +97,7 @@ package body Alire.Properties.Licenses is
    begin
       if Value.Kind = TOML_Array then
          Warnings.Warn_Once
-           (From.Message
+           (Errors.Stack
               ("Array of license in manifest is deprecated. " &
                  "License should be a single string containing a " &
                  "valid SPDX expression (https://spdx.org/licenses/)"));

--- a/src/alire/alire-properties-scenarios.adb
+++ b/src/alire/alire-properties-scenarios.adb
@@ -1,3 +1,5 @@
+with Alire.Errors;
+
 package body Alire.Properties.Scenarios is
 
    ---------------
@@ -127,7 +129,7 @@ package body Alire.Properties.Scenarios is
      (if +From.Unwrap.Keys (1)  = TOML_Keys.GPR_Set_Ext
       then From_TOML (From)
       else raise Checked_Error with
-        From.Message ("scenario expressions can only set externals"));
+        Errors.Stack ("scenario expressions can only set externals"));
 
    -------------
    -- To_TOML --

--- a/src/alire/alire-solver.ads
+++ b/src/alire/alire-solver.ads
@@ -2,7 +2,6 @@ with Alire.Dependencies;
 with Alire.Index;
 with Alire.Properties;
 with Alire.Solutions;
-with Alire.TOML_Adapters;
 with Alire.Types;
 
 with Semantic_Versioning.Extended;

--- a/src/alire/alire-toml_adapters.adb
+++ b/src/alire/alire-toml_adapters.adb
@@ -8,6 +8,7 @@ package body Alire.TOML_Adapters is
 
    overriding
    procedure Finalize (This : in out Key_Queue) is
+      pragma Unreferenced (This);
    begin
       --  Manually close this error scope
       Errors.Close;

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -3,6 +3,7 @@ with Ada.Directories;
 with Alire.Directories;
 with Alire.Errors;
 with Alire.GPR;
+with Alire.TOML_Adapters;
 
 with Alire.Hashes.SHA512_Impl; pragma Unreferenced (Alire.Hashes.SHA512_Impl);
 --  Hash implementation generics are not directly withed anywhere. Since they

--- a/src/alire/alire-toml_index.ads
+++ b/src/alire/alire-toml_index.ads
@@ -3,7 +3,6 @@ private with TOML;
 with Alire.Index_On_Disk;
 with Alire.Crates;
 with Alire.Releases;
-with Alire.TOML_Adapters;
 
 with Semantic_Versioning;
 

--- a/src/alire/alire.adb
+++ b/src/alire/alire.adb
@@ -156,18 +156,20 @@ package body Alire is
    begin
       if Report then
          if Log_Debug then
-            Err_Log ("Generating Outcome_Failure with message: " & Message);
+            Err_Log ("Generating Outcome_Failure with message: "
+                     & Errors.Stack (Message));
             Err_Log ("Generating Outcome_Failure with call stack:");
             Err_Log (Stack);
          end if;
 
-         Trace.Debug ("Generating Outcome_Failure with message: " & Message);
+         Trace.Debug ("Generating Outcome_Failure with message: "
+                      & Errors.Stack (Message));
          Trace.Debug ("Generating Outcome_Failure with call stack:");
          Trace.Debug (Stack);
       end if;
 
       return (Success => False,
-              Message => +Message);
+              Message => +Errors.Stack (Message));
    end Outcome_Failure;
 
    ----------------------------


### PR DESCRIPTION
This is a generalization of the idea behind `TOML_Adapters.Key_Queue.Descend` (nested information to display on error). The new type `Errors.Scope` allows to push a new message into the error stack; whenever an error is stored with `Errors.Set`, the complete error stack is stored for the later report. If a scope is left, the corresponding info is removed from the stack.

This will allow to provide more precise error information also outside of the context of TOML parsing. `TOML_Adapters.Key_Queue` has been reworked to rely on the error stack too. With this unified error mechanism, an exception does not result in the complete loss of the TOML information stack.