### PR TITLE
Use remote of local branch for publishing

### DIFF
--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -953,7 +953,10 @@ package body Alire.Publish is
 
             declare
                use Utils;
-               Raw_URL   : constant String := Git.Fetch_URL (Root_Path);
+               Raw_URL   : constant String :=
+                             Git.Fetch_URL
+                               (Root_Path,
+                                Origin => Git.Remote (Root_Path));
                --  The one reported by the repo, in its public form
 
                Fetch_URL : constant String :=

--- a/src/alire/alire-vcss-git.adb
+++ b/src/alire/alire-vcss-git.adb
@@ -67,12 +67,28 @@ package body Alire.VCSs.Git is
                    From : URL;
                    Into : Directory_Path)
                    return Outcome
+   is (This.Clone (From, Into, Branch => ""));
+
+   -----------
+   -- Clone --
+   -----------
+
+   not overriding
+   function Clone (This   : VCS;
+                   From   : URL;
+                   Into   : Directory_Path;
+                   Branch : String)
+                   return Outcome
    is
       pragma Unreferenced (This);
       Extra : constant String_Vector :=
-        Empty_Vector & (if Log_Level < Trace.Info
-                        then "-q"
-                        else "--progress");
+                Empty_Vector
+                & (if Log_Level < Trace.Info
+                   then "-q"
+                   else "--progress")
+                & (if Branch /= ""
+                   then Empty_Vector & "--branch" & Branch
+                   else Empty_Vector);
    begin
       Trace.Detail ("Checking out [git]: " & From);
 

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -22,6 +22,14 @@ package Alire.VCSs.Git is
                    return Outcome;
 
    not overriding
+   function Clone (This   : VCS;
+                   From   : URL;
+                   Into   : Directory_Path;
+                   Branch : String)
+                   return Outcome;
+   --  Specify a branch to check out after cloning
+
+   not overriding
    function Revision_Commit (This   : VCS;
                              Repo   : Directory_Path;
                              Rev    : String)


### PR DESCRIPTION
When a local clone had several remotes configured, `origin` was being used in all cases. Now, the remote of the checked-out branch is used as expected.