### PR TITLE
Use of git repositories as pin remotes

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -6,6 +6,16 @@ stay on top of `alr` new features.
 
 ## Release `1.1`
 
+### Git remotes for pinned releases
+
+PR [#715](https://github.com/alire-project/alire/pull/715)
+
+The pinning commands (`alr with --use`, `alr pin --use`) now also accept a git
+repository URL, which will be downloaded and used to override a dependency, as
+previously could be done only with local directories. The pinning feature works
+recursively, so unpublished crates can now have complete dependencies prior to
+submission to the community index (which relies only on indexed dependencies).
+
 ### Switch to help with publishing of multi-crate repositories
 
 PR [#635](https://github.com/alire-project/alire/pull/635).

--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -8,7 +8,11 @@ with Alire.Platform;
 with Alire.Properties;
 with Alire.Roots;
 
+with GNATCOLL.VFS;
+
 package body Alire.Directories is
+
+   package Adirs renames Ada.Directories;
 
    ------------------------
    -- Report_Deprecation --
@@ -218,6 +222,21 @@ package body Alire.Directories is
 
       return Found;
    end Find_Files_Under;
+
+   ------------------------
+   -- Find_Relative_Path --
+   ------------------------
+
+   function Find_Relative_Path (Parent : Any_Path;
+                                Child  : Any_Path)
+                                return Any_Path
+   is
+      use GNATCOLL.VFS;
+   begin
+      return +GNATCOLL.VFS.Relative_Path
+        (File => Create (+Adirs.Full_Name (Child)),
+         From => Create (+Adirs.Full_Name (Parent)));
+   end Find_Relative_Path;
 
    ----------------------
    -- Find_Single_File --

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -40,6 +40,13 @@ package Alire.Directories is
    --  Depth 0 means given folder only
    --  Returns all instances found
 
+   function Find_Relative_Path (Parent : Any_Path;
+                                Child  : Any_Path)
+                                return Any_Path;
+   --  Given two paths, find the minimal relative path from Parent up to Child.
+   --  May still return an absolute path if Child is not in the same drive
+   --  (Windows) as Parent.
+
    function Find_Single_File (Path      : String;
                               Extension : String)
                               return String;

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -32,6 +32,13 @@ package Alire.Directories is
                               return String;
    --  Return either the valid enclosing root folder, or ""
 
+   procedure Ensure_Deletable (Path : Any_Path);
+   --  In Windows, git checkouts are created with read-only file that do not
+   --  sit well with Ada.Directories.Delete_Tree.
+
+   procedure Force_Delete (Path : Any_Path);
+   --  Calls Ensure_Deletable and then Adirs.Delete_Tree
+
    function Find_Files_Under (Folder    : String;
                               Name      : String;
                               Max_Depth : Natural := Natural'Last)

--- a/src/alire/alire-externals-softlinks.adb
+++ b/src/alire/alire-externals-softlinks.adb
@@ -1,3 +1,4 @@
+with Alire.TOML_Keys;
 with Alire.URI;
 with Alire.Utils.TTY;
 
@@ -13,8 +14,10 @@ package body Alire.Externals.Softlinks is
       --  TOML Keys used locally
 
       Kind     : constant String := "kind";
+      Origin   : constant String := TOML_Keys.Origin; -- Must be the same key
       Path     : constant String := "path";
       Relative : constant String := "relative";
+      Remote   : constant String := "remote";
 
    end Keys;
 
@@ -25,9 +28,34 @@ package body Alire.Externals.Softlinks is
    function From_TOML (Table : TOML_Adapters.Key_Queue) return External is
       Path : constant String :=
                Table.Checked_Pop (Keys.Path, TOML_String).As_String;
+      Remote : constant Boolean :=
+                 Table.Checked_Pop (Keys.Remote, TOML_Boolean).As_Boolean;
    begin
-      return New_Softlink (Path);
+      if Remote then
+         declare
+            Origin : Origins.Origin;
+         begin
+            Origin.From_TOML (Table).Assert;
+            return New_Remote (Origin => Origin,
+                               Path   => URI.Local_Path (Path));
+         end;
+      else
+         return New_Softlink (Path);
+      end if;
    end From_TOML;
+
+   ----------------
+   -- New_Remote --
+   ----------------
+
+   function New_Remote (Origin : Origins.Origin;
+                        Path   : Relative_Path) return External
+   is (Externals.External with
+       Has_Remote  => True,
+       Remote      => (Used => True, Remote => Origin),
+       Relative    => True,
+       Path_Length => Path'Length,
+       Rel_Path    => Alire.VFS.To_Portable (Path));
 
    ------------------
    -- New_Softlink --
@@ -61,11 +89,15 @@ package body Alire.Externals.Softlinks is
          begin
             if Check_Absolute_Path (Path) then
                return (Externals.External with
+                       Has_Remote  => False,
+                       Remote      => <>,
                        Relative    => False,
                        Path_Length => Path'Length,
                        Abs_Path    => Path);
             else
                return (Externals.External with
+                       Has_Remote  => False,
+                       Remote      => <>,
                        Relative    => True,
                        Path_Length => Target'Length,
                        Rel_Path    => Alire.VFS.To_Portable (+Target));
@@ -84,8 +116,15 @@ package body Alire.Externals.Softlinks is
    begin
       Table.Set (Keys.Kind,
                  Create_String (Utils.To_Lower_Case (Softlink'Img)));
+      Table.Set (Keys.Remote,
+                 Create_Boolean (This.Has_Remote));
       Table.Set (Keys.Relative,
                  Create_Boolean (This.Relative));
+
+      if This.Has_Remote then
+         Table.Set (Keys.Origin,
+                    This.Remote.Remote.To_TOML);
+      end if;
 
       if This.Relative then
          Table.Set (Keys.Path,

--- a/src/alire/alire-externals-softlinks.adb
+++ b/src/alire/alire-externals-softlinks.adb
@@ -1,3 +1,4 @@
+with Alire.OS_Lib;
 with Alire.TOML_Keys;
 with Alire.URI;
 with Alire.Utils.TTY;
@@ -105,6 +106,31 @@ package body Alire.Externals.Softlinks is
          end;
       end;
    end New_Softlink;
+
+   --------------
+   -- Relocate --
+   --------------
+
+   function Relocate (This : External;
+                      From : Any_Path) return External
+   is
+   begin
+      if Check_Absolute_Path (This.Path) then
+         return This;
+      end if;
+
+      declare
+         use Alire.OS_Lib.Operators;
+         New_Path : constant Any_Path := From / This.Path;
+      begin
+         return (Externals.External with
+                 Has_Remote => This.Has_Remote,
+                 Remote     => This.Remote,
+                 Relative   => True,
+                 Path_Length => New_Path'Length,
+                 Rel_Path    => Alire.VFS.To_Portable (New_Path));
+      end;
+   end Relocate;
 
    -------------
    -- To_TOML --

--- a/src/alire/alire-externals-softlinks.adb
+++ b/src/alire/alire-externals-softlinks.adb
@@ -52,7 +52,7 @@ package body Alire.Externals.Softlinks is
                         Path   : Relative_Path) return External
    is (Externals.External with
        Has_Remote  => True,
-       Remote      => (Used => True, Remote => Origin),
+       Remote      => (Used => True, Origin => Origin),
        Relative    => True,
        Path_Length => Path'Length,
        Rel_Path    => Alire.VFS.To_Portable (Path));
@@ -123,7 +123,7 @@ package body Alire.Externals.Softlinks is
 
       if This.Has_Remote then
          Table.Set (Keys.Origin,
-                    This.Remote.Remote.To_TOML);
+                    This.Remote.Origin.To_TOML);
       end if;
 
       if This.Relative then

--- a/src/alire/alire-externals-softlinks.ads
+++ b/src/alire/alire-externals-softlinks.ads
@@ -23,12 +23,12 @@ package Alire.Externals.Softlinks is
 
    function New_Remote (Origin : Origins.Origin;
                         Path   : Relative_Path) return External;
-   --  Create a softlink with an associated remote source. Path is where it
+   --  Create a softlink with an associated Origin source. Path is where it
    --  has been/will be deployed. Path must be relative to the root using the
    --  softlink.
 
    function Deploy (This : External) return Outcome;
-   --  For a remote pin, redeploy sources if they're not at the expected
+   --  For a Origin pin, redeploy sources if they're not at the expected
    --  location. For a local pin, do nothing.
 
    overriding
@@ -39,7 +39,7 @@ package Alire.Externals.Softlinks is
    --  version.
 
    function Is_Remote (This : External) return Boolean;
-   --  Say if this is a softlink with a remote origin
+   --  Say if this is a softlink with a Origin origin
 
    function Is_Valid (This : External) return Boolean;
    --  Check that the pointed-to folder exists
@@ -65,6 +65,9 @@ package Alire.Externals.Softlinks is
 
    function Path (This : External) return Any_Path;
 
+   function Remote (This : External) return Origins.Origin
+     with Pre => This.Is_Remote;
+
    function From_TOML (Table : TOML_Adapters.Key_Queue) return External;
 
    overriding
@@ -74,7 +77,7 @@ private
 
    type Optional_Remote (Used : Boolean) is record
       case Used is
-         when True => Remote : Origins.Origin;
+         when True => Origin : Origins.Origin;
          when False => null;
       end case;
    end record;
@@ -97,7 +100,7 @@ private
    is (if This.Has_Remote
        then (if GNAT.OS_Lib.Is_Directory (This.Path)
              then Outcome_Success
-             else Origins.Deployers.New_Deployer (This.Remote.Remote)
+             else Origins.Deployers.New_Deployer (This.Remote.Origin)
                                    .Deploy (This.Path))
        else Outcome_Success);
 
@@ -140,5 +143,12 @@ private
    is (Utils.To_Vector (Ada.Directories.Full_Name (This.Path)));
    --  As the path may be relative, we make it absolute to avoid duplicates
    --  with absolute paths reported by a Release.Project_Paths.
+
+   ------------
+   -- Origin --
+   ------------
+
+   function Remote (This : External) return Origins.Origin
+   is (This.Remote.Origin);
 
 end Alire.Externals.Softlinks;

--- a/src/alire/alire-externals-softlinks.ads
+++ b/src/alire/alire-externals-softlinks.ads
@@ -65,6 +65,11 @@ package Alire.Externals.Softlinks is
 
    function Path (This : External) return Any_Path;
 
+   function Relocate (This : External;
+                      From : Any_Path) return External;
+   --  Return the same external, but adjust its path (when relative) when seen
+   --  with prefix From.
+
    function Remote (This : External) return Origins.Origin
      with Pre => This.Is_Remote;
 

--- a/src/alire/alire-externals-softlinks.ads
+++ b/src/alire/alire-externals-softlinks.ads
@@ -1,6 +1,7 @@
 with Ada.Directories;
 
 with Alire.Interfaces;
+with Alire.Origins;
 with Alire.TOML_Adapters;
 private with Alire.VFS;
 
@@ -16,7 +17,15 @@ package Alire.Externals.Softlinks is
      and Interfaces.Tomifiable
    with private;
 
-   function New_Softlink (From : URL) return External;
+   function New_Softlink (From : Any_Path) return External;
+   --  Create a softlink for a local dir. From must be absolute or relative to
+   --  Ada.Directories.Current.
+
+   function New_Remote (Origin : Origins.Origin;
+                        Path   : Relative_Path) return External;
+   --  Create a softlink with an associated remote source. Path is where it
+   --  has been/will be deployed. Path must be relative to the root using the
+   --  softlink.
 
    overriding
    function Detect (This        : External;
@@ -53,9 +62,17 @@ package Alire.Externals.Softlinks is
 
 private
 
-   type External (Relative : Boolean; Path_Length : Positive) is
+   type Optional_Remote (Used : Boolean) is record
+      case Used is
+         when True => Remote : Origins.Origin;
+         when False => null;
+      end case;
+   end record;
+
+   type External (Has_Remote, Relative : Boolean; Path_Length : Positive) is
      new Externals.External
      and Interfaces.Tomifiable with record
+      Remote : Optional_Remote (Has_Remote);
       case Relative is
          when True  => Rel_Path : Portable_Path (1 .. Path_Length);
          when False => Abs_Path : Absolute_Path (1 .. Path_Length);

--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -160,7 +160,7 @@ package body Alire.Features.Index is
             Trace.Debug ("Index was already set, deleting and re-adding...");
             Assert (Indexes (I).Delete);
             return Add (Origin => Alire.Index.Community_Repo &
-                          "@" & Alire.Index.Community_Branch,
+                          "#" & Alire.Index.Community_Branch,
                         Name   => Alire.Index.Community_Name,
                         Under  => Config.Edit.Indexes_Directory,
                         Before => (if Has_Element (Next (I))
@@ -173,7 +173,7 @@ package body Alire.Features.Index is
 
       Trace.Debug ("Index was not set, adding it...");
       return Add (Origin => Alire.Index.Community_Repo &
-                    "@" & Alire.Index.Community_Branch,
+                    "#" & Alire.Index.Community_Branch,
                   Name   => Alire.Index.Community_Name,
                   Under  => Config.Edit.Indexes_Directory);
    exception

--- a/src/alire/alire-index_on_disk.ads
+++ b/src/alire/alire-index_on_disk.ads
@@ -14,7 +14,7 @@ package Alire.Index_On_Disk is
    --  Actual index is stored in <config>/indexes/<name>/repo
 
    --  URLs given to New_Handler functions must be complete, commit optional:
-   --  E.g.: git+https://path/to/server/and/project[@commit]
+   --  E.g.: git+https://path/to/server/and/project[#commit]
    --  E.g.: file:///path/to/local/folder
 
    Checkout_Directory : constant String := "repo";

--- a/src/alire/alire-origins-tweaks.adb
+++ b/src/alire/alire-origins-tweaks.adb
@@ -38,7 +38,7 @@ package body Alire.Origins.Tweaks is
 
       function Fix_VCS return Origin is
          use Ada.Directories;
-         URL : constant String := This.URL; -- Doesn't include @commit
+         URL : constant String := This.URL; -- Doesn't include #commit
       begin
          --  Check for "xxx+file://" or return as-is:
          if URI.Scheme (URL) not in URI.File_Schemes then

--- a/src/alire/alire-origins.adb
+++ b/src/alire/alire-origins.adb
@@ -1,5 +1,4 @@
 with Alire.URI;
-with Alire.Utils.TTY;
 with Alire.VCSs.Git;
 
 package body Alire.Origins is

--- a/src/alire/alire-origins.ads
+++ b/src/alire/alire-origins.ads
@@ -1,6 +1,7 @@
 with Alire.Hashes;
 with Alire.Interfaces;
 with Alire.TOML_Adapters;
+with Alire.Utils.TTY;
 
 private with Ada.Containers.Indefinite_Vectors;
 private with Ada.Strings.Unbounded;
@@ -8,6 +9,8 @@ private with Ada.Strings.Unbounded;
 with TOML; use all type TOML.Any_Value_Kind;
 
 package Alire.Origins is
+
+   package TTY renames Alire.Utils.TTY;
 
    type Kinds is
      (External,       -- A do-nothing origin, with some custom description
@@ -51,6 +54,8 @@ package Alire.Origins is
    function URL_With_Commit (This : Origin) return Alire.URL
      with Pre => This.Kind in VCS_Kinds;
    --  Append commit as '#commit'
+   function TTY_URL_With_Commit (This : Origin) return String
+     with Pre => This.Kind in VCS_Kinds;
 
    function Path (This : Origin) return String
      with Pre => This.Kind = Filesystem;
@@ -235,6 +240,8 @@ private
      (+This.Data.Commit);
    function URL_With_Commit (This : Origin) return Alire.URL is
      (This.URL & "#" & This.Commit);
+   function TTY_URL_With_Commit (This : Origin) return String is
+     (TTY.URL (This.URL) & "#" & TTY.Emph (This.Commit));
 
    function Path (This : Origin) return String is (+This.Data.Path);
 

--- a/src/alire/alire-origins.ads
+++ b/src/alire/alire-origins.ads
@@ -50,7 +50,7 @@ package Alire.Origins is
      with Pre => This.Kind in VCS_Kinds;
    function URL_With_Commit (This : Origin) return Alire.URL
      with Pre => This.Kind in VCS_Kinds;
-   --  Append commit as '@commit'
+   --  Append commit as '#commit'
 
    function Path (This : Origin) return String
      with Pre => This.Kind = Filesystem;
@@ -234,7 +234,7 @@ private
    function Commit (This : Origin) return String is
      (+This.Data.Commit);
    function URL_With_Commit (This : Origin) return Alire.URL is
-     (This.URL & "@" & This.Commit);
+     (This.URL & "#" & This.Commit);
 
    function Path (This : Origin) return String is (+This.Data.Path);
 

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -497,12 +497,22 @@ package body Alire.Roots is
    function Crate_File (This : Root) return Absolute_Path is
      (Path (This) / Crate_File_Name);
 
+   function Cache_Dir (This : Root) return Absolute_Path
+   is (This.Working_Folder / "cache");
+
    ----------------------
    -- Dependencies_Dir --
    ----------------------
 
    function Dependencies_Dir (This : Root) return Absolute_Path is
-      (This.Working_Folder / "cache" / "dependencies");
+     (This.Cache_Dir / "dependencies");
+
+   --------------
+   -- Pins_Dir --
+   --------------
+
+   function Pins_Dir (This : Root) return Absolute_Path
+   is (This.Cache_Dir / "pins");
 
    --------------------
    -- Working_Folder --
@@ -790,11 +800,10 @@ package body Alire.Roots is
                             Directories.Find_Relative_Path
                               (Parent => Ada.Directories.Current_Directory,
                                Child  =>
-                                 This.Working_Folder
-                               / "cache" / "pinned"
-                               / (Linked_Name & "_"
-                                 & Linked_Vers
-                                 & Depl.Base.Short_Unique_Id));
+                                 This.Pins_Dir
+                                 / (Linked_Name & "_"
+                                    & Linked_Vers
+                                    & Depl.Base.Short_Unique_Id));
          begin
             --  Fail if we needed to detect a crate and none found
 

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -1,12 +1,12 @@
 with Ada.Calendar;
 with Ada.Directories;
 
-with Alire.Conditional;
 with Alire.Crate_Configuration;
 with Alire.Dependencies.Containers;
 with Alire.Directories;
 with Alire.Environment;
 with Alire.Manifest;
+with Alire.Origins.Deployers;
 with Alire.OS_Lib;
 with Alire.Roots.Optional;
 with Alire.Solutions.Diffs;
@@ -696,6 +696,56 @@ package body Alire.Roots is
          Trace.Detail ("Update completed");
       end;
    end Update_Dependencies;
+
+   ----------------------
+   -- Pinned_To_Remote --
+   ----------------------
+
+   function Pinned_To_Remote (This        : in out Root;
+                              Crate       : String;
+                              URL         : String;
+                              Commit      : String;
+                              Must_Depend : Boolean)
+                              return Remote_Pin_Result
+   is (raise Unimplemented);
+
+   ---------------------------
+   -- Prepare_Pinned_Remote --
+   ---------------------------
+
+   --  function Prepare_Pinned_Remote (This   : Root;
+   --                                  Origin : Origins.Origin)
+   --                                  return Absolute_Path
+   --  is
+   --     Temp : Directories.Temp_File;
+   --     Depl : constant Origins.Deployers.Deployer'Class :=
+   --              Origins.Deployers.New_Deployer (Origin);
+   --  begin
+   --     Depl.Deploy (Temp.Filename).Assert;
+   --
+   --     --  Identify containing release
+   --
+   --     declare
+   --        Found : constant Alire.Roots.Optional.Root :=
+   --                  Roots.Optional.Detect_Root (Temp.Filename);
+   --        Name  : constant String :=
+   --                  (if Found.Is_Valid
+   --                   then Found.Value.Release.Constant_Reference.Name_Str
+   --                   else "");
+   --        Base  : constant Any_Path :=
+   --                  This.Working_Folder / "cache" / "pinned";
+   --     begin
+   --        if Name /= "" then
+   --           Ada.Directories.Create_Path (Base);
+   --
+   --           Ada.Directories.Rename (Temp.Filename, Base / Name);
+   --
+   --           return Base / Name;
+   --        else
+   --           Raise_Checked_Error ("No alire manifest found at the remote");
+   --        end if;
+   --     end;
+   --  end Prepare_Pinned_Remote;
 
    ------------------------------------
    -- Update_And_Deploy_Dependencies --

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -181,6 +181,16 @@ package body Alire.Roots is
       Round     : Natural := 0;
    begin
 
+      --  Begin by retrieving any broken remote, so it is ready for actions
+
+      for Dep of This.Solution.Links loop
+         if This.Solution.State (Dep.Crate).Link.Is_Remote and then
+           This.Solution.State (Dep.Crate).Link.Is_Broken
+         then
+            This.Solution.State (Dep.Crate).Link.Deploy.Assert;
+         end if;
+      end loop;
+
       --  Prepare environment for any post-fetch actions. This must be done
       --  after the lockfile on disk is written, since the root will read
       --  dependencies from there.
@@ -567,6 +577,10 @@ package body Alire.Roots is
       elsif (for some Rel of This.Solution.Releases =>
                This.Solution.State (Rel.Name).Is_Solved and then
                not GNAT.OS_Lib.Is_Directory (This.Release_Base (Rel.Name)))
+        or else
+          (for some Dep of This.Solution.Links =>
+             This.Solution.State (Dep.Crate).Link.Is_Remote and then
+             This.Solution.State (Dep.Crate).Link.Is_Broken)
       then
          Trace.Info ("Detected missing dependencies, updating workspace...");
          --  Some dependency is missing; redeploy. Should we clean first ???

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -847,6 +847,12 @@ package body Alire.Roots is
                Ada.Directories.Rename (Temp.Filename, Linked_Path);
             end if;
 
+            --  Return the solution using the downloaded sources. For that,
+            --  we create a remote link, and use either the dependency we
+            --  were given (already in the manifest), or else the one found
+            --  at the remote. The version will be narrowed down during the
+            --  post-processing in `alr with`.
+
             declare
                New_Link : constant Externals.Softlinks.External :=
                             Externals.Softlinks.New_Remote
@@ -857,14 +863,14 @@ package body Alire.Roots is
                              then Conditional.New_Dependency
                                (+Linked_Name, Semver.Extended.Any)
                              else Dependency);
-               Old_Sol  : constant Solutions.Solution := This.Solution;
             begin
                return Remote_Pin_Result'
                  (Crate_Length => Linked_Name'Length,
                   Crate        => Linked_Name,
                   New_Dep      => New_Dep,
-                  Solution     => Old_Sol.Depending_On (New_Dep.Value)
-                                         .Linking (+Linked_Name, New_Link));
+                  Solution     => This.Solution
+                                      .Depending_On (New_Dep.Value)
+                                      .Linking (+Linked_Name, New_Link));
             end;
          end;
 

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -1,7 +1,8 @@
 private with AAA.Caches.Files;
 
-limited with Alire.Environment;
+with Alire.Conditional;
 with Alire.Containers;
+limited with Alire.Environment;
 private with Alire.Lockfiles;
 with Alire.Paths;
 with Alire.Properties;
@@ -165,6 +166,25 @@ package Alire.Roots is
 
    procedure Write_Manifest (This : Root);
    --  Generates the crate.toml manifest at the appropriate location for Root
+
+   type Remote_Pin_Result (Crate_Length : Natural) is record
+      Crate    : String (1 .. Crate_Length); -- May be empty for a "raw" remote
+      New_Dep  : Conditional.Dependencies;   -- Detected dep + old dep
+      Solution : Solutions.Solution;         -- With new pin
+   end record;
+
+   function Pinned_To_Remote (This        : in out Root;
+                              Crate       : String;
+                              URL         : String;
+                              Commit      : String;
+                              Must_Depend : Boolean)
+                              return Remote_Pin_Result;
+   --  Prepares a pin to a remote repo with specific commit. If crate is not
+   --  already a dependency, it will be added as top-level, unless Must_Depend,
+   --  in which case Checked_Error. If Commit = "", the default tip commit in
+   --  the remote will be used instead. If Crate = "", a valid root must be
+   --  found at the given commit. If Crate /= "" and Commit contains a root,
+   --  their crate name must match.
 
    --  Files and folders derived from the root path (this obsoletes Alr.Paths):
 

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -174,17 +174,18 @@ package Alire.Roots is
    end record;
 
    function Pinned_To_Remote (This        : in out Root;
-                              Crate       : String;
+                              Dependency  : Conditional.Dependencies;
                               URL         : String;
                               Commit      : String;
                               Must_Depend : Boolean)
-                              return Remote_Pin_Result;
-   --  Prepares a pin to a remote repo with specific commit. If crate is not
-   --  already a dependency, it will be added as top-level, unless Must_Depend,
-   --  in which case Checked_Error. If Commit = "", the default tip commit in
-   --  the remote will be used instead. If Crate = "", a valid root must be
-   --  found at the given commit. If Crate /= "" and Commit contains a root,
-   --  their crate name must match.
+                              return Remote_Pin_Result
+     with Pre => Dependency.Is_Empty or else Dependency.Is_Value;
+   --  Prepares a pin to a remote repo with specific commit. If
+   --  Dependency.Crate is not already a dependency, it will be added as
+   --  top-level, unless Must_Depend, in which case Checked_Error. If Commit
+   --  = "", the default tip commit in the remote will be used instead. If
+   --  Dependency.Is_Empty, a valid root must be found at the given commit.
+   --  If Crate /= "" and Commit contains a root, their crate name must match.
 
    --  Files and folders derived from the root path (this obsoletes Alr.Paths):
 

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -169,8 +169,8 @@ package Alire.Roots is
 
    type Remote_Pin_Result (Crate_Length : Natural) is record
       Crate    : String (1 .. Crate_Length); -- May be empty for a "raw" remote
-      New_Dep  : Conditional.Dependencies;   -- Detected dep + old dep
-      Solution : Solutions.Solution;         -- With new pin
+      New_Dep  : Conditional.Dependencies;   -- Requested one or else found one
+      Solution : Solutions.Solution;         -- Includes new remote pin
    end record;
 
    function Pinned_To_Remote (This        : in out Root;
@@ -183,7 +183,7 @@ package Alire.Roots is
    --  Prepares a pin to a remote repo with specific commit. If
    --  Dependency.Crate is not already a dependency, it will be added as
    --  top-level, unless Must_Depend, in which case Checked_Error. If Commit
-   --  = "", the default tip commit in the remote will be used instead. If
+   --  is "", the default tip commit in the remote will be used instead. If
    --  Dependency.Is_Empty, a valid root must be found at the given commit.
    --  If Crate /= "" and Commit contains a root, their crate name must match.
 

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -192,11 +192,17 @@ package Alire.Roots is
    function Working_Folder (This : Root) return Absolute_Path;
    --  The "alire" folder inside the root path
 
+   function Cache_Dir (This : Root) return Absolute_Path;
+   --  The "alire/cache" dir inside the root path, containing releases and pins
+
    function Crate_File (This : Root) return Absolute_Path;
    --  The "/path/to/alire.toml" file inside Working_Folder
 
    function Dependencies_Dir (This : Root) return Absolute_Path;
    --  The folder where dependencies are checked out for this root
+
+   function Pins_Dir (This : Root) return Absolute_Path;
+   --  The folder where remote pins are checked out for this root
 
    function Lock_File (This : Root) return Absolute_Path;
    --  The "/path/to/alire.lock" file inside Working_Folder

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -426,13 +426,11 @@ package body Alire.Solutions is
                              then TTY.URL (Dep.Link.Path)
                                   & (if Dep.Link.Is_Remote
                                      then " from "
-                                          & TTY.URL (Dep.Link.Remote.URL)
-                                          & "#"
-                                          & TTY.Emph (Dep.Link.Remote.Commit)
+                                         & Dep.Link.Remote.TTY_URL_With_Commit
                                      else "") -- no remote
                              else Utils.To_Lower_Case (Rel.Origin.Kind'Img))
                           & ")" -- origin completed
-                    else ""),   -- no details
+                     else ""),   -- no details
                   Level);
             end;
          end loop;

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -565,6 +565,9 @@ package body Alire.Solutions is
                Table
                  .Append (TTY.Name (Dep.Crate))
                  .Append (TTY.Version ("file:" & Dep.Link.Path))
+                 .Append (if Dep.Link.Is_Remote
+                          then Dep.Link.Remote.TTY_URL_With_Commit
+                          else "")
                  .New_Row;
             elsif Dep.Is_Pinned then
                Table

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -425,19 +425,30 @@ package body Alire.Solutions is
          Trace.Log ("Dependencies (solution):", Level);
 
          for Rel of This.Releases loop
-            Trace.Log ("   " & Rel.Milestone.TTY_Image
-                       & (if This.State (Rel.Name).Is_Pinned or else
-                             This.State (Rel.Name).Is_Linked
-                         then TTY.Emph (" (pinned)")
-                         else "")
-                       & (if Detailed
-                         then " (origin: "
-                             & (if This.State (Rel.Name).Is_Linked
-                                then TTY.URL (This.State (Rel.Name).Link.Path)
-                                else Utils.To_Lower_Case (Rel.Origin.Kind'Img))
-                             & ")"
-                         else ""),
-                       Level);
+            declare
+               Dep : Dependencies.States.State renames This.State (Rel.Name);
+            begin
+               Trace.Log
+                 ("   "
+                  & Rel.Milestone.TTY_Image
+                  & (if Dep.Is_Pinned or else Dep.Is_Linked
+                     then TTY.Emph (" (pinned)")
+                     else "")
+                  & (if Detailed
+                     then " (origin: "
+                          & (if Dep.Is_Linked
+                             then TTY.URL (Dep.Link.Path)
+                                  & (if Dep.Link.Is_Remote
+                                     then " from "
+                                          & TTY.URL (Dep.Link.Remote.URL)
+                                          & "#"
+                                          & TTY.Emph (Dep.Link.Remote.Commit)
+                                     else "") -- no remote
+                             else Utils.To_Lower_Case (Rel.Origin.Kind'Img))
+                          & ")" -- origin completed
+                    else ""),   -- no details
+                  Level);
+            end;
          end loop;
       end if;
 

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -6,7 +6,6 @@ with Alire.Dependencies.Containers;
 with Alire.Dependencies.Diffs;
 with Alire.Dependencies.Graphs;
 with Alire.Index;
-with Alire.OS_Lib;
 with Alire.Roots.Optional;
 with Alire.Root;
 with Alire.Solutions.Diffs;
@@ -298,17 +297,6 @@ package body Alire.Solutions is
                      Link  : Externals.Softlinks.External)
                      return Solution
    is
-      use Alire.OS_Lib.Operators;
-
-      ----------
-      -- Join --
-      ----------
-
-      function Join (Parent, Child : Any_Path) return Any_Path
-      is (if Check_Absolute_Path (Child)
-          then Child
-          else Parent / Child);
-
       Linked_Root : constant Roots.Optional.Root :=
                       Roots.Optional.Detect_Root (Link.Path);
    begin
@@ -334,11 +322,9 @@ package body Alire.Solutions is
                      --  relative paths when possible.
 
                      New_Link : constant Externals.Softlinks.External :=
-                                  Externals.Softlinks.New_Softlink
-                                    (Join
-                                       (Parent => Link.Path,
-                                        Child  => Linked_Solution.State
-                                                    (Dep.Crate).Link.Path));
+                                  Linked_Solution
+                                    .State (Dep.Crate)
+                                    .Link.Relocate (From => Link.Path);
                   begin
 
                      --  We may or not already depend on the transitively

--- a/src/alire/alire-uri.ads
+++ b/src/alire/alire-uri.ads
@@ -1,6 +1,6 @@
 with Alire.Errors;
+with Alire.Utils;
 
-private with Alire.Utils;
 private with URI;
 
 package Alire.URI with Preelaborate is
@@ -83,6 +83,12 @@ package Alire.URI with Preelaborate is
 
    function Path (This : URL) return String;
    --  The path as properly defined (without the authority, if any)
+
+   function Is_HTTP_Or_Git (This : URL) return Boolean
+   is (Scheme (This) in Git | Pure_Git | HTTP
+       or else Alire.Utils.Ends_With (This, ".git"));
+   --  Heuristic to detect a possible git remote. Implementation public so
+   --  there is no doubt to what it does.
 
 private
 

--- a/src/alire/alire-vcss-git.adb
+++ b/src/alire/alire-vcss-git.adb
@@ -240,6 +240,36 @@ package body Alire.VCSs.Git is
       end if;
    end Remote;
 
+   ------------------------
+   -- Remote_Head_Commit --
+   ------------------------
+
+   not overriding
+   function Remote_Head_Commit (This : VCS;
+                                From : URL) return String
+   is
+      pragma Unreferenced (This);
+      Output : constant Utils.String_Vector :=
+                 Run_Git_And_Capture (Empty_Vector & "ls-remote" & From);
+   begin
+      --  Sample output from git (space is tab):
+      --  95818710c1a2bea0cbfa617a67972fe984761227        HEAD
+      --  b0825ac9373ed587394cf5e7ecf51fd7caf9290a        refs/heads/feat/cache
+      --  95818710c1a2bea0cbfa617a67972fe984761227        refs/heads/master
+      --  a917c31c47a8bd0155c402f692b63bd77e53bae7        refs/pull/1/head
+      --  22cb794ed99dfe6cbb0541af558ada1d2ed8fdbe        refs/tags/v0.1
+      --  ae6fdd0711bb3ca2c1e2d1d18caf7a1b82a11f0a        refs/tags/v0.1^{}
+      --  7376b76f23ab4421fbec31eb616d767edbec7343        refs/tags/v0.2
+
+      for Line of Output loop
+         if Tail (Crunch (Line), ASCII.HT) = "HEAD" then
+            return Head (Line, ASCII.HT);
+         end if;
+      end loop;
+
+      return "";
+   end Remote_Head_Commit;
+
    ------------
    -- Status --
    ------------

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -30,6 +30,11 @@ package Alire.VCSs.Git is
    --  Specify a branch to check out after cloning
 
    not overriding
+   function Remote_Head_Commit (This : VCS;
+                                From : URL) return String;
+   --  Returns the commit reported as HEAD by ls-remote. If none, returns ""
+
+   not overriding
    function Revision_Commit (This   : VCS;
                              Repo   : Directory_Path;
                              Rev    : String)

--- a/src/alire/alire-vcss.adb
+++ b/src/alire/alire-vcss.adb
@@ -25,8 +25,8 @@ package body Alire.VCSs is
    ------------
 
    function Commit (Origin : URL) return String is
-     (if Utils.Contains (Origin, "@")
-      then Utils.Tail (Origin, '@')
+     (if Utils.Contains (Origin, "#")
+      then Utils.Tail (Origin, '#')
       else "");
 
    ----------
@@ -42,7 +42,7 @@ package body Alire.VCSs is
    ----------
 
    function Repo (Origin : URL) return String is
-     (Utils.Head (Repo_And_Commit (Origin), '@'));
+     (Utils.Head (Repo_And_Commit (Origin), '#'));
 
    ---------------------
    -- Repo_And_Commit --

--- a/src/alire/alire-vcss.ads
+++ b/src/alire/alire-vcss.ads
@@ -7,7 +7,7 @@ package Alire.VCSs is
    subtype Known_Kinds is Kinds range Kinds'First .. Kinds'Pred (VCS_Unknown);
 
    --  URL format:
-   --  vcs+http[s]://path/to/repo[@commit]
+   --  vcs+http[s]://path/to/repo[#commit]
 
    function Clone (This : VCS;
                    From : URL;
@@ -28,10 +28,10 @@ package Alire.VCSs is
    --  Without kind and commit
 
    function Repo_And_Commit (Origin : URL) return String;
-   --  Without Kind and with optional Commit
+   --  Without Kind and with optional Commit (separated by #)
 
    function Commit (Origin : URL) return String;
-   --  Empty string if no commit part
+   --  Empty string if no commit part (separated by #)
 
    ------------------------
    -- Classwide versions --

--- a/src/alr/alr-commands-clean.adb
+++ b/src/alr/alr-commands-clean.adb
@@ -1,5 +1,3 @@
-with Ada.Directories;
-
 with Alire.Utils;
 
 with Alr.Spawn;
@@ -39,7 +37,7 @@ package body Alr.Commands.Clean is
       if Cmd.Cache then
          if OS_Lib.Is_Folder (Cmd.Root.Cache_Dir) then
             Trace.Detail ("Deleting working copy cache...");
-            Ada.Directories.Delete_Tree (Cmd.Root.Cache_Dir);
+            Alire.Directories.Force_Delete (Cmd.Root.Cache_Dir);
          else
             Trace.Detail ("Cache folder not present");
             --  This is expected if the crate has no dependencies

--- a/src/alr/alr-commands-clean.adb
+++ b/src/alr/alr-commands-clean.adb
@@ -2,7 +2,6 @@ with Ada.Directories;
 
 with Alire.Utils;
 
-with Alr.Paths;
 with Alr.Spawn;
 with Alr.Platform;
 
@@ -38,9 +37,9 @@ package body Alr.Commands.Clean is
       end if;
 
       if Cmd.Cache then
-         if OS_Lib.Is_Folder (Paths.Alr_Working_Cache_Folder) then
+         if OS_Lib.Is_Folder (Cmd.Root.Cache_Dir) then
             Trace.Detail ("Deleting working copy cache...");
-            Ada.Directories.Delete_Tree (Paths.Alr_Working_Cache_Folder);
+            Ada.Directories.Delete_Tree (Cmd.Root.Cache_Dir);
          else
             Trace.Detail ("Cache folder not present");
             --  This is expected if the crate has no dependencies

--- a/src/alr/alr-commands-pin.adb
+++ b/src/alr/alr-commands-pin.adb
@@ -3,6 +3,7 @@ with Alire.Dependencies;
 with Alire.Releases;
 with Alire.Solutions.Diffs;
 with Alire.Pinning;
+with Alire.URI;
 with Alire.Utils.TTY;
 with Alire.Utils.User_Input;
 
@@ -179,10 +180,8 @@ package body Alr.Commands.Pin is
 
             --  Pin to remote commit
 
-            if Cmd.Commit.all /= "" or else
-              Alire.Utils.Starts_With (Cmd.URL.all, "git+") or else
-              Alire.Utils.Ends_With   (Cmd.URL.all, ".git") or else
-              Alire.Utils.Starts_With (Cmd.URL.all, "http")
+            if Cmd.Commit.all /= ""
+              or else Alire.URI.Is_HTTP_Or_Git (Cmd.URL.all)
             then
                New_Sol := Cmd.Root.Pinned_To_Remote
                  (Dependency  => Alire.Conditional.New_Dependency

--- a/src/alr/alr-commands-pin.adb
+++ b/src/alr/alr-commands-pin.adb
@@ -251,8 +251,8 @@ package body Alr.Commands.Pin is
       .New_Line
       .Append ("Specify a single crate to modify its pin.")
       .New_Line
-      .Append ("Use the --use <PATH> switch to "
-               & " force alr to use the PATH target"
+      .Append ("Use the --use <PATH|URL> switch to "
+               & " force alr to use the target"
                & " to fulfill a dependency locally"
                & " instead of looking for indexed releases.")
      );

--- a/src/alr/alr-commands-pin.adb
+++ b/src/alr/alr-commands-pin.adb
@@ -1,3 +1,5 @@
+with Alire.Conditional;
+with Alire.Dependencies;
 with Alire.Releases;
 with Alire.Solutions.Diffs;
 with Alire.Pinning;
@@ -183,10 +185,12 @@ package body Alr.Commands.Pin is
               Alire.Utils.Starts_With (Cmd.URL.all, "http")
             then
                New_Sol := Cmd.Root.Pinned_To_Remote
-                 (Crate       => Argument (1),
+                 (Dependency  => Alire.Conditional.New_Dependency
+                    (Alire.Dependencies.From_String (Argument (1))),
                   URL         => Cmd.URL.all,
                   Commit      => Cmd.Commit.all,
-                  Must_Depend => True).Solution;
+                  Must_Depend => True)
+                 .Solution;
             else
 
                --  Pin to dir

--- a/src/alr/alr-commands-pin.ads
+++ b/src/alr/alr-commands-pin.ads
@@ -23,7 +23,7 @@ package Alr.Commands.Pin is
    overriding
    function Usage_Custom_Parameters (Cmd : Command) return String
    is ("[[crate[=<version>]]"
-       & " | crate --use=<path>"
+       & " | crate --use=<path> [--commit=HASH]"
        & " | --all]");
 
 private

--- a/src/alr/alr-commands-pin.ads
+++ b/src/alr/alr-commands-pin.ads
@@ -29,6 +29,7 @@ package Alr.Commands.Pin is
 private
 
    type Command is new Commands.Command with record
+      Commit  : aliased GNAT.Strings.String_Access;
       Pin_All : aliased Boolean;
       Unpin   : aliased Boolean;
       URL     : aliased GNAT.Strings.String_Access;

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -13,6 +13,7 @@ with Alire.Releases;
 with Alire.Roots.Optional;
 with Alire.Solutions;
 with Alire.Solver;
+with Alire.URI;
 with Alire.Utils.User_Input;
 
 with Alr.Commands.User_Input;
@@ -120,19 +121,6 @@ package body Alr.Commands.Withing is
       --  If we made here there were no errors adding the dependency
       --  and storing the softlink. We can proceed to confirming the
       --  replacement.
-
-      Trace.Always ("SOL1");
-      Cmd.Root.Solution.Print (Cmd.Root.Release,
-                               Cmd.Root.Environment,
-                               True,
-                               Alire.Trace.Always);
-      Trace.Always ("SOL2");
-      New_Solution.Solution.Print (Cmd.Root.Release,
-                                   Cmd.Root.Environment,
-                                   True,
-                                   Alire.Trace.Always);
-
-      Trace.Always ("DEP " & New_Solution.New_Dep.Image_One_Line);
 
       Replace_Current (Cmd,
                        Old_Deps     => Old_Deps,
@@ -599,10 +587,8 @@ package body Alr.Commands.Withing is
          --  Must be Add, but it could be regular or softlink
 
          if Cmd.URL.all /= "" then
-            if Cmd.Commit.all /= "" or else
-              Alire.Utils.Starts_With (Cmd.URL.all, "git+") or else
-              Alire.Utils.Ends_With   (Cmd.URL.all, ".git") or else
-              Alire.Utils.Starts_With (Cmd.URL.all, "http")
+            if Cmd.Commit.all /= ""
+              or else Alire.URI.Is_HTTP_Or_Git (Cmd.URL.all)
             then
 
                --  Pin to remote repo

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -661,9 +661,9 @@ package body Alr.Commands.Withing is
                 & " simultaneously added and removed in a single invocation.")
        .New_Line
        .Append ("* Adding dependencies pinned to external sources:")
-       .Append ("When a single crate name is accompanied by an --use PATH"
+       .Append ("When a single crate name is accompanied by an --use PATH|URL"
                 & " argument, the crate is always fulfilled for any required"
-                & " version by the sources found at PATH.")
+                & " version by the sources found at the given target.")
        .New_Line
        .Append ("* Adding dependencies from a GPR file:")
        .Append ("The project file given with --from will be scanned looking"
@@ -722,7 +722,7 @@ package body Alr.Commands.Withing is
         (Config      => Config,
          Output      => Cmd.URL'Access,
          Long_Switch => Switch_URL & "=",
-         Argument    => "PATH",
+         Argument    => "PATH|URL",
          Help        => "Add a dependency pinned to some external source");
 
       Define_Switch (Config,

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -92,15 +92,20 @@ package body Alr.Commands.Withing is
    -- Add_Remote_Link --
    ---------------------
 
-   procedure Add_Remote_Link (Cmd   : in out Command;
-                              Crate : String)
+   procedure Add_Remote_Link (Cmd : in out Command;
+                              Dep : String)
    is
       use Alire;
       Old_Deps     : constant Conditional.Dependencies :=
                        Cmd.Root.Release.Dependencies;
+      New_Dep      : constant Alire.Conditional.Dependencies :=
+                       (if Dep = ""
+                        then Alire.Conditional.No_Dependencies
+                        else Alire.Conditional.New_Dependency
+                          (Alire.Dependencies.From_String (Dep)));
       New_Solution : constant Roots.Remote_Pin_Result :=
                        Cmd.Root.Pinned_To_Remote
-                         (Crate       => Crate,
+                         (Dependency  => New_Dep,
                           URL         => Cmd.URL.all,
                           Commit      => Cmd.Commit.all,
                           Must_Depend => False);
@@ -115,6 +120,19 @@ package body Alr.Commands.Withing is
       --  If we made here there were no errors adding the dependency
       --  and storing the softlink. We can proceed to confirming the
       --  replacement.
+
+      Trace.Always ("SOL1");
+      Cmd.Root.Solution.Print (Cmd.Root.Release,
+                               Cmd.Root.Environment,
+                               True,
+                               Alire.Trace.Always);
+      Trace.Always ("SOL2");
+      New_Solution.Solution.Print (Cmd.Root.Release,
+                                   Cmd.Root.Environment,
+                                   True,
+                                   Alire.Trace.Always);
+
+      Trace.Always ("DEP " & New_Solution.New_Dep.Image_One_Line);
 
       Replace_Current (Cmd,
                        Old_Deps     => Old_Deps,
@@ -590,9 +608,9 @@ package body Alr.Commands.Withing is
                --  Pin to remote repo
 
                Add_Remote_Link (Cmd,
-                                Crate => (if Num_Arguments = 1
-                                          then Argument (1)
-                                          else ""));
+                                Dep => (if Num_Arguments = 1
+                                        then Argument (1)
+                                        else ""));
 
             else
 

--- a/src/alr/alr-commands-withing.ads
+++ b/src/alr/alr-commands-withing.ads
@@ -26,12 +26,13 @@ package Alr.Commands.Withing is
 private
 
    type Command is new Commands.Command with record
-      Del   : aliased Boolean := False;
-      From  : aliased Boolean := False;
-      Graph : aliased Boolean := False;
-      Solve : aliased Boolean := False;
-      Tree  : aliased Boolean := False;
-      URL   : aliased GNAT.Strings.String_Access;
+      Commit   : aliased GNAT.Strings.String_Access;
+      Del      : aliased Boolean := False;
+      From     : aliased Boolean := False;
+      Graph    : aliased Boolean := False;
+      Solve    : aliased Boolean := False;
+      Tree     : aliased Boolean := False;
+      URL      : aliased GNAT.Strings.String_Access;
       Versions : aliased Boolean := False;
    end record;
 

--- a/src/alr/alr-commands-withing.ads
+++ b/src/alr/alr-commands-withing.ads
@@ -20,7 +20,7 @@ package Alr.Commands.Withing is
    overriding function Usage_Custom_Parameters (Cmd : Command) return String is
      ("[{ [--del] <crate>[versions]..."
       & " | --from <gpr_file>..."
-      & " | <crate>[versions] --use <path> } ]"
+      & " | <crate>[versions] --use <path> [--commit HASH} ]"
       & " | --solve | --tree | --versions");
 
 private

--- a/testsuite/tests/pin/remote/test.py
+++ b/testsuite/tests/pin/remote/test.py
@@ -9,10 +9,12 @@ from drivers.alr import run_alr, init_local_crate
 from drivers.helpers import init_git_repo
 from drivers.asserts import assert_eq
 
+s = os.sep
+
 
 def verify(head):
     # Check that the linked dir exists at the expected location
-    pin_path = f"alire/cache/pins/upstream_0.0.0_{head[:8]}"
+    pin_path = f"alire{s}cache{s}pins{s}upstream_0.0.0_{head[:8]}"
     assert os.path.isdir(pin_path)
 
     # Verify info reported by alr

--- a/testsuite/tests/pin/remote/test.py
+++ b/testsuite/tests/pin/remote/test.py
@@ -1,0 +1,64 @@
+"""
+Check pinning to a remote, cleanup and redeploy
+"""
+
+import os
+import shutil
+
+from drivers.alr import run_alr, init_local_crate
+from drivers.helpers import init_git_repo
+from drivers.asserts import assert_eq
+
+
+def verify(head):
+    # Check that the linked dir exists at the expected location
+    pin_path = f"alire/cache/pins/upstream_0.0.0_{head[:8]}"
+    assert os.path.isdir(pin_path)
+
+    # Verify info reported by alr
+    p = run_alr("pin")
+    assert_eq(f"upstream file:{pin_path} ../upstream.git#{head}\n", p.out)
+
+    # Verify building with pinned dependency
+    run_alr("build")
+
+    # Verify removal of cached download
+    run_alr("clean", "--cache")
+    assert not os.path.isdir(pin_path)
+
+    # Verify automatic redownload when needed
+    run_alr("build")
+
+    # Prepare for next test
+    run_alr("with", "--del", "upstream")  # Remove dependency
+    shutil.rmtree("alire")                # Total cleanup not relying on alr
+
+
+# Initialize a git repo that will act as the "online" remote
+init_local_crate(name="upstream", binary=False)
+head = init_git_repo(".")
+os.chdir("..")
+os.rename("upstream", "upstream.git")  # so it is recognized as git repo
+
+# Initialize a client crate that will use the remote
+init_local_crate()  # This leaves us inside the new crate
+
+# Add using with directly
+run_alr("with", "--use", "../upstream.git", "--commit", head)
+verify(head)
+
+# Add using with, without head commit
+run_alr("with", "--use", "../upstream.git")
+verify(head)
+
+# Pin afterwards, with commit
+run_alr("with", "upstream", force=True)  # force, as it is unsolvable
+run_alr("pin", "upstream", "--use", "../upstream.git", "--commit", head)
+verify(head)
+
+# Pin afterwards, without commit
+run_alr("with", "upstream", force=True)
+run_alr("pin", "upstream", "--use", "../upstream.git")
+verify(head)
+
+print('SUCCESS')

--- a/testsuite/tests/pin/remote/test.yaml
+++ b/testsuite/tests/pin/remote/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}

--- a/testsuite/tests/with/pin-transitive/test.py
+++ b/testsuite/tests/with/pin-transitive/test.py
@@ -29,8 +29,8 @@ s = os.sep
 
 # Verify created pins
 p = run_alr("pin")
-assert_eq("direct   file:.." + s + ".." + s + "direct  \n"
-          "indirect file:.." + s + ".." + s + "indirect\n",
+assert_eq("direct   file:.." + s + ".." + s + "direct   \n"
+          "indirect file:.." + s + ".." + s + "indirect \n",
           p.out)
 
 # Check pin removal
@@ -40,7 +40,7 @@ os.chdir("../nest/base")
 run_alr("update")
 
 p = run_alr("pin")
-assert_eq("direct file:.." + s + ".." + s + "direct\n",
+assert_eq("direct file:.." + s + ".." + s + "direct \n",
           p.out)
 
 


### PR DESCRIPTION
Where only a local path was previously accepted, now a git remote with optional commit can be used:

`alr with --use https://github.com/foo.git --commit <hash>`

If no commit is given, the current remote HEAD is used. The pin won't move to another commit automatically.

With this, it is a bit more convenient to play with unindexed crates. Also, one can have a repo with pinned remotes and it will still work when it itself is used as a pin, so it may be convenient for early prototyping.

Fixes #508.