### PR TITLE
Complete/rename the set of feedback procedures with icon prefix

### DIFF
--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -125,12 +125,12 @@ package body Alire.Publish is
       case Git.Status (Path) is
          when No_Remote =>
             if For_Archiving then
-               Log_Success ("Local repository is clean (without remote).");
+               Put_Success ("Local repository is clean (without remote).");
             else
                Git_Error ("No remote configured", Path);
             end if;
          when Clean =>
-            Log_Success ("Local repository is clean.");
+            Put_Success ("Local repository is clean.");
          when Ahead =>
             Git_Error ("Your branch is ahead of remote" & ASCII.LF &
                          "Please push local commits to the remote branch.",
@@ -273,7 +273,7 @@ package body Alire.Publish is
          .Append ("--non-interactive")
          .Append ("build"));
 
-      Log_Success ("Build succeeded.");
+      Put_Success ("Build succeeded.");
    end Check_Build;
 
    -------------------------
@@ -340,7 +340,7 @@ package body Alire.Publish is
                            Deployer.Compute_Hash
                              (Context.Tmp_Deploy_Dir.Filename, Kind));
             begin
-               Log_Success ("Computed hash: " & String (Hash));
+               Put_Success ("Computed hash: " & String (Hash));
                Context.Origin.Add_Hash (Hash);
             end;
          end loop;
@@ -438,7 +438,7 @@ package body Alire.Publish is
          TOML.File_IO.Dump_To_File (TOML_Origin, Index_File);
          Close (Index_File);
 
-         Log_Success
+         Put_Success
            ("Your index manifest file has been generated at "
             & TTY.URL (Index_Manifest));
 
@@ -446,7 +446,7 @@ package body Alire.Publish is
          --  message otherwise (when lacking a github login).
 
          if Config.Defined (Config.Keys.User_Github_Login) then
-            Log_Info
+            Put_Info
               ("Please upload this file to "
                & TTY.URL
                  (Index.Community_Host & "/"
@@ -457,7 +457,7 @@ package body Alire.Publish is
                   & String (TOML_Index.Manifest_Path (Name)))
                & " to create a pull request against the community index.");
          else
-            Log_Info
+            Put_Info
               ("Please create a pull request against the community index at "
                & TTY.URL (Utils.Tail (Index.Community_Repo, '+'))
                & " including this file at "
@@ -581,7 +581,7 @@ package body Alire.Publish is
          Tar_Archive;
       end if;
 
-      Log_Success ("Source archive created successfully.");
+      Put_Success ("Source archive created successfully.");
 
       declare
 
@@ -680,10 +680,10 @@ package body Alire.Publish is
       --  User has an account
 
       if not Config.Defined (Config.Keys.User_Github_Login) then
-         Log_Info ("Publishing to the community index"
+         Put_Info ("Publishing to the community index"
                    & " requires a GitHub account.");
       else
-         Log_Success ("User has a GitHub account: " & TTY.Emph
+         Put_Success ("User has a GitHub account: " & TTY.Emph
                       (Utils.User_Input.Query_Config.User_GitHub_Login));
       end if;
 
@@ -711,7 +711,7 @@ package body Alire.Publish is
                & TTY.URL (Utils.Tail (Index.Community_Repo, '+'))
                & " and fork the repository.");
          else
-            Log_Success ("User has forked the community repository");
+            Put_Success ("User has forked the community repository");
          end if;
 
          --  The repo must contain the base branch, or otherwise GitHub
@@ -730,7 +730,7 @@ package body Alire.Publish is
                & TTY.URL (Index.Community_Host
                  & "/" & Login & "/" & Index.Community_Repo_Name));
          else
-            Log_Success ("User's fork contains base branch: "
+            Put_Success ("User's fork contains base branch: "
                          & TTY.Emph (Index.Community_Branch));
          end if;
       end;
@@ -762,7 +762,7 @@ package body Alire.Publish is
          --  internal use with network drives? So allow forcing it.
       end if;
 
-      Log_Success ("Origin is of supported kind: " & Context.Origin.Kind'Img);
+      Put_Success ("Origin is of supported kind: " & Context.Origin.Kind'Img);
 
       if Context.Origin.Kind in Origins.VCS_Kinds then
 
@@ -779,7 +779,7 @@ package body Alire.Publish is
                URI.Authority (URL) = Site or else
                Utils.Ends_With (URI.Authority (URL), "." & Site))
          then
-            Log_Success ("Origin is hosted on trusted site: "
+            Put_Success ("Origin is hosted on trusted site: "
                          & URI.Authority (URL));
          else
             Raise_Checked_Error ("Origin is hosted on unknown site: "
@@ -944,7 +944,7 @@ package body Alire.Publish is
                                              else "HEAD"));
          begin
             if Commit /= "" then
-               Log_Success ("Revision exists in local repository ("
+               Put_Success ("Revision exists in local repository ("
                             & TTY.Emph (Commit) & ").");
             else
                Raise_Checked_Error ("Revision not found in local repository: "

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -762,8 +762,8 @@ package body Alire.Roots is
             Head : constant String :=
                      VCSs.Git.Handler.Remote_Head_Commit (URL);
          begin
-            Trace.Info ("No commit provided; using default remote HEAD: "
-                        & TTY.Emph (Head));
+            Put_Info ("No commit provided; using default remote HEAD: "
+                      & TTY.Emph (Head));
             return This.Pinned_To_Remote (Dependency  => Dependency,
                                           URL         => URL,
                                           Commit      => Head,
@@ -873,9 +873,7 @@ package body Alire.Roots is
                                       .Linking (+Linked_Name, New_Link));
             end;
          end;
-
       end;
-
    end Pinned_To_Remote;
 
    ------------------------------------

--- a/src/alire/alire.adb
+++ b/src/alire/alire.adb
@@ -63,23 +63,41 @@ package body Alire is
       end if;
    end Log_Exception;
 
+   -----------------
+   -- Put_Failure --
+   -----------------
+
+   procedure Put_Failure (Text : String; Level : Trace.Levels := Info) is
+   begin
+      Trace.Log (Utils.TTY.Error ("✗ ") & Text, Level);
+   end Put_Failure;
+
    --------------
-   -- Log_Info --
+   -- Put_Info --
    --------------
 
-   procedure Log_Info (Text : String; Level : Trace.Levels := Info) is
+   procedure Put_Info (Text : String; Level : Trace.Levels := Info) is
    begin
       Trace.Log (Utils.TTY.Info (Text), Level);
-   end Log_Info;
+   end Put_Info;
 
    -----------------
-   -- Log_Success --
+   -- Put_Success --
    -----------------
 
-   procedure Log_Success (Text : String; Level : Trace.Levels := Info) is
+   procedure Put_Success (Text : String; Level : Trace.Levels := Info) is
    begin
       Trace.Log (Utils.TTY.Success (Text), Level);
-   end Log_Success;
+   end Put_Success;
+
+   -----------------
+   -- Put_Warning --
+   -----------------
+
+   procedure Put_Warning (Text : String; Level : Trace.Levels := Info) is
+   begin
+      Trace.Log (Utils.TTY.Warn ("⚠ ") & Text, Level);
+   end Put_Warning;
 
    ------------
    -- Assert --

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -248,11 +248,21 @@ package Alire with Preelaborate is
    procedure Log_Exception (E     : Ada.Exceptions.Exception_Occurrence;
                             Level : Simple_Logging.Levels := Debug);
 
-   procedure Log_Info (Text : String; Level : Trace.Levels := Info);
+   --  Feedback-oriented commands for one-line feedback with symbol prefix:
+
+   procedure Put_Info (Text : String; Level : Trace.Levels := Info);
    --  Prepend Text with a blue "🛈", or "Note: " & if no color/tty.
 
-   procedure Log_Success (Text : String; Level : Trace.Levels := Info);
+   procedure Put_Warning (Text : String; Level : Trace.Levels := Info);
+   --  Prepend Text with a yellow "⚠", or "Warning: " if no color/tty
+
+   procedure Put_Success (Text : String; Level : Trace.Levels := Info);
    --  Prepend Text with a green check mark, or "Success:" if no color/tty.
+
+   procedure Put_Failure (Text : String; Level : Trace.Levels := Info);
+   --  Prepend Text with a red "✗", or "Failed:" if no color/tty. Intended as
+   --  the opposite of Put_Success when it makes sense to continue, albeit
+   --  briefly, without emitting a final error with Raise_Checked_Error.
 
 private
 

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -9,7 +9,7 @@ with Simple_Logging;
 
 package Alire with Preelaborate is
 
-   Version : constant String := "1.1.0-dev";
+   Version : constant String := "1.1.0-dev+c122dc5d";
    --  1.1.0-dev: begin post-1.0 changes
    --  1.0.0:     no changes since rc3
    --  1.0.0-rc3: added help colors PR

--- a/src/alr/alr-commands-index.adb
+++ b/src/alr/alr-commands-index.adb
@@ -123,7 +123,7 @@ package body Alr.Commands.Index is
    procedure Check (Cmd : in out Command) is
    begin
       Cmd.Requires_Full_Index (Strict => True);
-      Alire.Log_Success ("No unknown values found in index contents.");
+      Alire.Put_Success ("No unknown values found in index contents.");
    end Check;
 
    ----------

--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -379,7 +379,7 @@ package body Alr.Commands.Init is
          Alire.Lockfiles.File_Name
            (+Name, String (Filesystem_String'(Directory.Full_Name))));
 
-      Alire.Log_Success (TTY.Emph (Lower_Name) & " initialized successfully.");
+      Alire.Put_Success (TTY.Emph (Lower_Name) & " initialized successfully.");
    end Generate;
 
    -------------


### PR DESCRIPTION
To clarify things a bit, `Log_*` are the general logging procedures and `Put_*` are intended to report events to the user at the regular Info level, but prefixed with an icon: success (✓), failure (✗), warning (⚠), info (ⓘ).