### PR TITLE
Highlight switches in help long description

### DIFF
--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -9,7 +9,7 @@ with Simple_Logging;
 
 package Alire with Preelaborate is
 
-   Version : constant String := "1.1.0-dev";
+   Version : constant String := "1.1.0-dev+ba275f94";
    --  1.1.0-dev: begin post-1.0 changes
    --  1.0.0:     no changes since rc3
    --  1.0.0-rc3: added help colors PR

--- a/src/alr/alr-commands-help.adb
+++ b/src/alr/alr-commands-help.adb
@@ -47,7 +47,7 @@ package body Alr.Commands.Help is
       procedure Format (Text : Alire.Utils.String_Vector) is
       begin
          for Line of Text loop
-            AAA.Text_IO.Put_Paragraph (Line,
+            AAA.Text_IO.Put_Paragraph (Highlight_Switches (Line),
                                        Line_Prefix => "   ");
          end loop;
       end Format;
@@ -150,5 +150,48 @@ package body Alr.Commands.Help is
 
       Display_Help (Argument (1));
    end Execute;
+
+   ------------------------
+   -- Highlight_Switches --
+   ------------------------
+
+   function Highlight_Switches (Line : String) return String is
+
+      ---------------
+      -- Highlight --
+      ---------------
+      --  Avoid highlighting non-alphanumeric characters
+      function Highlight (Word : String) return String is
+         subtype Valid_Chars is Character with
+           Dynamic_Predicate => Valid_Chars in '0' .. '9' | 'a' .. 'z';
+         I : Natural := Word'Last; -- last char to highlight
+      begin
+         while I >= Word'First and then Word (I) not in Valid_Chars loop
+            I := I - 1;
+         end loop;
+
+         return TTY.Emph (Word (Word'First .. I)) & Word (I + 1 .. Word'Last);
+      end Highlight;
+
+      use Alire.Utils;
+      use String_Vectors;
+      Words : String_Vector := Split (Line, Separator => ' ');
+      I, J  : String_Vectors.Cursor;
+   begin
+      I := Words.First;
+      while Has_Element (I) loop
+         declare
+            Word : constant String := Element (I);
+         begin
+            J := Next (I);
+            if Starts_With (Word, "--") and then Word'Length > 2 then
+               Words.Insert (Before => J, New_Item => Highlight (Word));
+               Words.Delete (I);
+            end if;
+            I := J;
+         end;
+      end loop;
+      return Words.Flatten;
+   end Highlight_Switches;
 
 end Alr.Commands.Help;

--- a/src/alr/alr-commands-help.ads
+++ b/src/alr/alr-commands-help.ads
@@ -38,6 +38,9 @@ package Alr.Commands.Help is
    function Usage_Custom_Parameters (Cmd : Command) return String
    is ("[command|topic]");
 
+   function Highlight_Switches (Line : String) return String;
+   --  Visit every word and apply Emph to words starting with --
+
 private
 
    type Command is new Commands.Command with null record;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -425,7 +425,7 @@ package body Alr.Commands is
       Put_Line (TTY.Bold ("DESCRIPTION"));
 
       for Line of Dispatch_Table (Cmd).Long_Description loop
-         AAA.Text_IO.Put_Paragraph (Line,
+         AAA.Text_IO.Put_Paragraph (Help.Highlight_Switches (Line),
                                     Line_Prefix => "   ");
          --  GNATCOLL.Paragraph_Filling seems buggy at the moment, otherwise
          --  it would be the logical choice.
@@ -901,7 +901,8 @@ package body Alr.Commands is
          Ada.Text_IO.Put_Line
            ("Use ""alr help <command>"" for specific command help");
          OS_Lib.Bailout (1);
-      when Constraint_Error | Error_No_Command =>
+      when E : Constraint_Error | Error_No_Command =>
+         Alire.Log_Exception (E);
          if Raw_Arguments (1) (String'(Raw_Arguments (1))'First) = '-' then
             Log ("Unrecognized global option: " & Raw_Arguments (1), Error);
          else


### PR DESCRIPTION
E.g. in `alr search -h`, so they're easier to locate in the long description.