### PR TITLE
Allow named references to identify the commit for a remote pin

### DIFF
--- a/src/alire/alire-origins.ads
+++ b/src/alire/alire-origins.ads
@@ -86,7 +86,10 @@ package Alire.Origins is
 
    --  Helper types
 
-   subtype Git_Commit is String (1 .. 40);
+   subtype Git_Commit is String (1 .. 40) with
+     Dynamic_Predicate =>
+       (for all Char of Git_Commit => Char in '0' .. '9' | 'a' .. 'f');
+
    subtype Hg_Commit  is String (1 .. 40);
 
    --  Constructors

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -755,18 +755,25 @@ package body Alire.Roots is
             & Requested_Crate);
       end if;
 
-      --  Identify the head commit, if not given:
+      --  Identify the head commit/reference
 
-      if Commit = "" then
+      if Commit = "" or else Commit not in Origins.Git_Commit then
          declare
-            Head : constant String :=
-                     VCSs.Git.Handler.Remote_Head_Commit (URL);
+            Ref_Commit : constant String :=
+                     VCSs.Git.Handler.Remote_Commit (URL, Ref => Commit);
          begin
-            Trace.Info ("No commit provided; using default remote HEAD: "
-                        & TTY.Emph (Head));
+            if Ref_Commit = "" then
+               Raise_Checked_Error ("Could not resolve reference to commit: "
+                                    & TTY.Emph (Commit));
+            else
+               Trace.Info ("Using commit " & TTY.Emph (Ref_Commit)
+                           & " for reference "
+                           & TTY.Emph (if Commit = "" then "HEAD"
+                                                      else Commit));
+            end if;
             return This.Pinned_To_Remote (Dependency  => Dependency,
                                           URL         => URL,
-                                          Commit      => Head,
+                                          Commit      => Ref_Commit,
                                           Must_Depend => Must_Depend);
          end;
       end if;

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -30,9 +30,11 @@ package Alire.VCSs.Git is
    --  Specify a branch to check out after cloning
 
    not overriding
-   function Remote_Head_Commit (This : VCS;
-                                From : URL) return String;
-   --  Returns the commit reported as HEAD by ls-remote. If none, returns ""
+   function Remote_Commit (This : VCS;
+                           From : URL;
+                           Ref  : String := "HEAD") return String;
+   --  Returns the commit matching Ref by ls-remote. If none, returns "". If
+   --  several match, Checked_Error.
 
    not overriding
    function Revision_Commit (This   : VCS;

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -9,7 +9,7 @@ with Simple_Logging;
 
 package Alire with Preelaborate is
 
-   Version : constant String := "1.1.0-dev";
+   Version : constant String := "1.1.0-dev+0f603c29";
    --  1.1.0-dev: begin post-1.0 changes
    --  1.0.0:     no changes since rc3
    --  1.0.0-rc3: added help colors PR

--- a/src/alr/alr-commands-pin.adb
+++ b/src/alr/alr-commands-pin.adb
@@ -250,10 +250,12 @@ package body Alr.Commands.Pin is
       .New_Line
       .Append ("Specify a single crate to modify its pin.")
       .New_Line
-      .Append ("Use the --use <PATH|URL> switch to "
-               & " force alr to use the target"
-               & " to fulfill a dependency locally"
-               & " instead of looking for indexed releases.")
+      .Append ("Use the --use <PATH|URL> switch to"
+               & " use the target to fulfill a dependency locally"
+               & " instead of looking for indexed releases."
+               & " An optional reference can be specified with --commit;"
+               & " the pin will be frozen at the commit currently matching"
+               & " the reference.")
      );
 
    --------------------
@@ -281,8 +283,8 @@ package body Alr.Commands.Pin is
         (Config      => Config,
          Output      => Cmd.Commit'Access,
          Long_Switch => "--commit=",
-         Argument    => "HASH",
-         Help        => "Commit to retrieve from repository");
+         Argument    => "REF",
+         Help        => "Reference to be retrieved from repository");
 
       Define_Switch
         (Config      => Config,

--- a/src/alr/alr-commands-pin.ads
+++ b/src/alr/alr-commands-pin.ads
@@ -23,7 +23,7 @@ package Alr.Commands.Pin is
    overriding
    function Usage_Custom_Parameters (Cmd : Command) return String
    is ("[[crate[=<version>]]"
-       & " | crate --use=<path> [--commit=HASH]"
+       & " | crate --use=<path> [--commit=REF]"
        & " | --all]");
 
 private

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -649,7 +649,10 @@ package body Alr.Commands.Withing is
        .Append ("* Adding dependencies pinned to external sources:")
        .Append ("When a single crate name is accompanied by an --use PATH|URL"
                 & " argument, the crate is always fulfilled for any required"
-                & " version by the sources found at the given target.")
+                & " version by the sources found at the given target."
+                & " An optional reference can be specified with --commit;"
+                & " the pin will be frozen at the commit currently matching"
+                & " the reference.")
        .New_Line
        .Append ("* Adding dependencies from a GPR file:")
        .Append ("The project file given with --from will be scanned looking"
@@ -701,7 +704,7 @@ package body Alr.Commands.Withing is
         (Config      => Config,
          Output      => Cmd.Commit'Access,
          Long_Switch => "--commit=",
-         Argument    => "HASH",
+         Argument    => "REF",
          Help        => "Commit to retrieve from repository");
 
       Define_Switch

--- a/src/alr/alr-commands-withing.ads
+++ b/src/alr/alr-commands-withing.ads
@@ -20,7 +20,7 @@ package Alr.Commands.Withing is
    overriding function Usage_Custom_Parameters (Cmd : Command) return String is
      ("[{ [--del] <crate>[versions]..."
       & " | --from <gpr_file>..."
-      & " | <crate>[versions] --use <path> [--commit HASH} ]"
+      & " | <crate>[versions] --use <path> [--commit REF} ]"
       & " | --solve | --tree | --versions");
 
 private


### PR DESCRIPTION
Anything that's reported by `git ls-remote` can be easily used to obtain the commit, so with minimal changes we can use tags, branches...