### PR TITLE
Workround for issue #729

### DIFF
--- a/src/alire/alire-conditional_trees.adb
+++ b/src/alire/alire-conditional_trees.adb
@@ -22,7 +22,7 @@ package body Alire.Conditional_Trees is
    function To_YAML (This : Tree) return String
    is (if This.Is_Empty
        then ""
-       else This.Constant_Reference.To_YAML);
+       else This.Element.To_YAML);
 
    overriding
    function To_YAML (V : Leaf_Node) return String is
@@ -99,7 +99,7 @@ package body Alire.Conditional_Trees is
    function Image_One_Line (This : Tree) return String is
      (if This.Is_Empty
       then "(empty)"
-      else This.Constant_Reference.Image);
+      else This.Element.Image);
 
    ----------------------------
    -- All_But_First_Children --
@@ -615,7 +615,7 @@ package body Alire.Conditional_Trees is
 
       return Forward_Iterator'
         (Children =>
-           Vector_Node (Container.Constant_Reference.Element.all).Values);
+           Vector_Node (Container.Element).Values);
    end Iterate;
 
    ---------------------

--- a/src/alire/alire-conditional_trees.ads
+++ b/src/alire/alire-conditional_trees.ads
@@ -444,7 +444,7 @@ private
       else This.Root.Leaf_Count);
 
    function Root (This : Tree) return Node'Class is
-     (This.Constant_Reference);
+     (This.Element);
 
    procedure Tree_TOML_Add (Table : TOML.TOML_Value;
                             Key   : String;

--- a/src/alire/alire-dependencies-states.adb
+++ b/src/alire/alire-dependencies-states.adb
@@ -15,9 +15,9 @@ package body Alire.Dependencies.States is
         or else
           (not L.Is_Empty and then not R.Is_Empty
            and then
-           L.Constant_Reference.Milestone = R.Constant_Reference.Milestone
+           L.Element.Milestone = R.Element.Milestone
            and then
-           L.Constant_Reference.Origin = R.Constant_Reference.Origin);
+           L.Element.Origin = R.Element.Origin);
    end "=";
 
    ----------------------


### PR DESCRIPTION
This came up on compiling alire (v1.0.0) on macOS Big Sur with FSF GCC 11.1.0. [A conversation on c.l.a](https://groups.google.com/g/comp.lang.ada/c/7dw7Oqi8lIk/m/5NUBhFN8DQAJ) indicates that the same issue will likely come up with GNAT CE 2021.

Updated rules in 3.10.2 and 6.4.1(6) caused the use of
Constant_Reference, which takes the Container as an aliased parameter,
to trip over its use on a container passed as an un-aliased parameter.