### PR TITLE
Check_Absolute_Path on Windows should also accept lowercase drive letters

### DIFF
--- a/src/alire/os_windows/alire-check_absolute_path.adb
+++ b/src/alire/os_windows/alire-check_absolute_path.adb
@@ -2,7 +2,7 @@ separate (Alire)
 function Check_Absolute_Path (Path : Any_Path) return Boolean is
 begin
    return (Path'Length >= 3
-           and then Path (Path'First) in 'A' .. 'Z'
+           and then Path (Path'First) in 'A' .. 'Z' | 'a' .. 'z'
            and then Path (Path'First + 1) = ':'
            and then Path (Path'First + 2) = GNAT.OS_Lib.Directory_Separator);
 end Check_Absolute_Path;


### PR DESCRIPTION
#739