### PR TITLE
alr-commands-init.adb: add config/ in .gitignore

### DIFF
--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -279,6 +279,7 @@ package body Alr.Commands.Init is
          Put_Line ("obj/");
          Put_Line ("lib/");
          Put_Line ("alire/");
+         Put_Line ("config/");
          TIO.Close (File);
       end Generate_Gitignore;
 


### PR DESCRIPTION
The crate configuration is always generated by alr and should not be checked-in.