### PR TITLE
Fixes for CE2021.

### DIFF
--- a/src/alire/alire-crate_configuration.adb
+++ b/src/alire/alire-crate_configuration.adb
@@ -5,6 +5,7 @@ with Ada.Characters.Handling;
 
 with Alire_Early_Elaboration;
 with Alire.Solutions;
+with Alire.Releases;
 with Alire.Roots;
 with Alire.Origins;
 

--- a/src/alire/alire-crate_configuration.ads
+++ b/src/alire/alire-crate_configuration.ads
@@ -1,6 +1,5 @@
 with TOML;
 
-with Alire.Releases;
 with Alire.Properties.Configurations;
 limited with Alire.Roots;
 

--- a/src/alire/alire-crates.ads
+++ b/src/alire/alire-crates.ads
@@ -2,7 +2,6 @@ with Alire.Conditional;
 with Alire.Containers;
 with Alire.Externals.Lists;
 with Alire.Policies;
-with Alire.Properties;
 with Alire.Releases;
 with Alire.TOML_Adapters;
 with Alire.Utils;

--- a/src/alire/alire-dependencies-states.adb
+++ b/src/alire/alire-dependencies-states.adb
@@ -1,5 +1,5 @@
-with Alire.Crates;
 with Alire.Manifest;
+with Alire.Milestones;
 with Alire.Origins;
 with Alire.Roots.Optional;
 

--- a/src/alire/alire-dependencies-states.ads
+++ b/src/alire/alire-dependencies-states.ads
@@ -2,7 +2,6 @@ private with AAA.Containers.Indefinite_Holders;
 
 private with Alire.Containers;
 with Alire.Externals.Softlinks;
-with Alire.Properties;
 with Alire.Releases;
 with Alire.TOML_Adapters;
 

--- a/src/alire/alire-dependencies.ads
+++ b/src/alire/alire-dependencies.ads
@@ -1,5 +1,4 @@
 with Alire.Interfaces;
-with Alire.Milestones;
 with Alire.Utils;
 
 with Semantic_Versioning.Basic;

--- a/src/alire/alire-environment-formatting.ads
+++ b/src/alire/alire-environment-formatting.ads
@@ -1,5 +1,3 @@
-with Alire.Releases;
-
 package Alire.Environment.Formatting is
 
    function Format (Release_Dir : Any_Path;

--- a/src/alire/alire-environment.adb
+++ b/src/alire/alire-environment.adb
@@ -9,6 +9,7 @@ with Alire.Properties.Environment; use Alire.Properties.Environment;
 with Alire.OS_Lib;
 with Alire.GPR;
 with Alire.Properties.Scenarios;
+with Alire.Releases;
 with Alire.Roots;
 with Alire.Solutions;
 with Alire.Utils;

--- a/src/alire/alire-environment.ads
+++ b/src/alire/alire-environment.ads
@@ -1,6 +1,5 @@
 with Ada.Strings.Unbounded;
 
-with Alire.Releases;
 with Alire.Properties;
 with Alire.Platforms;
 limited with Alire.Roots;

--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -2,7 +2,6 @@ with Ada.Directories;
 
 with Alire.Config.Edit;
 with Alire.Index;
-with Alire.Origins.Deployers;
 with Alire.OS_Lib;
 
 with GNAT.OS_Lib;

--- a/src/alire/alire-index.ads
+++ b/src/alire/alire-index.ads
@@ -1,13 +1,9 @@
 private with Alire_Early_Elaboration;
 pragma Unreferenced (Alire_Early_Elaboration);
 
-with Alire.Dependencies;
-with Alire.GPR;
-with Alire.Origins;
 with Alire.Crates.Containers;
 with Alire.Policies;
 with Alire.Properties;
-with Alire.Properties.Licenses;
 with Alire.Releases;
 with Alire.Utils;
 

--- a/src/alire/alire-lockfiles.ads
+++ b/src/alire/alire-lockfiles.ads
@@ -1,5 +1,4 @@
 with Alire.Interfaces;
-with Alire.Properties;
 with Alire.Solutions;
 with Alire.TOML_Adapters;
 

--- a/src/alire/alire-origins-tweaks.adb
+++ b/src/alire/alire-origins-tweaks.adb
@@ -1,8 +1,6 @@
 with Ada.Directories;
 
 with Alire.OS_Lib;
-with Alire.Utils;
-
 with Alire.URI;
 
 package body Alire.Origins.Tweaks is

--- a/src/alire/alire-properties-bool.ads
+++ b/src/alire/alire-properties-bool.ads
@@ -1,5 +1,4 @@
 with Alire.Conditional;
-with Alire.GPR;
 with Alire.TOML_Adapters;
 with Alire.TOML_Keys;
 with Alire.Utils;

--- a/src/alire/alire-properties-cases.ads
+++ b/src/alire/alire-properties-cases.ads
@@ -1,5 +1,3 @@
-with TOML;
-
 generic
    --  Encapsulated enumeration type
    type Enum is (<>);

--- a/src/alire/alire-publish.ads
+++ b/src/alire/alire-publish.ads
@@ -1,4 +1,3 @@
-with Alire.Origins;
 with Alire.Roots;
 with Alire.URI;
 

--- a/src/alire/alire-root.adb
+++ b/src/alire/alire-root.adb
@@ -1,5 +1,4 @@
 with Alire.Directories;
-with Alire.Releases;
 
 package body Alire.Root is
 

--- a/src/alire/alire-selftest.adb
+++ b/src/alire/alire-selftest.adb
@@ -2,8 +2,6 @@ with Alire.Config.Edit;
 with Alire.Utils;
 with Alire.VCSs.Git;
 
-with TOML; use TOML;
-
 package body Alire.Selftest is
 
    --  Tests are Check_* procedures that end normally or raise some exception.

--- a/src/alire/alire-solutions-diffs.adb
+++ b/src/alire/alire-solutions-diffs.adb
@@ -1,6 +1,7 @@
-with Alire.Containers;
 with Alire.Utils.Tables;
 with Alire.Utils.TTY;
+
+with Semantic_Versioning;
 
 package body Alire.Solutions.Diffs is
 

--- a/src/alire/alire-solutions-diffs.ads
+++ b/src/alire/alire-solutions-diffs.ads
@@ -1,5 +1,3 @@
-with Semantic_Versioning.Extended;
-
 package Alire.Solutions.Diffs is
 
    type Diff is tagged private;

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -13,6 +13,8 @@ with Alire.Utils.Tables;
 with Alire.Utils.Tools;
 with Alire.Utils.TTY;
 
+with Semantic_Versioning.Extended;
+
 package body Alire.Solutions is
 
    package Semver renames Semantic_Versioning;

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -10,7 +10,7 @@ with Alire.TOML_Adapters;
 
 limited with Alire.Solutions.Diffs;
 
-with Semantic_Versioning.Extended;
+with Semantic_Versioning;
 
 with TOML;
 

--- a/src/alire/alire-solver.adb
+++ b/src/alire/alire-solver.adb
@@ -5,7 +5,6 @@ with Alire.Conditional;
 with Alire.Containers;
 with Alire.Dependencies.States;
 with Alire.Milestones;
-with Alire.Origins.Deployers;
 with Alire.Utils.TTY;
 
 package body Alire.Solver is

--- a/src/alire/alire-solver.ads
+++ b/src/alire/alire-solver.ads
@@ -6,8 +6,6 @@ with Alire.Types;
 
 with Semantic_Versioning.Extended;
 
-with TOML;
-
 package Alire.Solver is
 
    --------------

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -1,8 +1,8 @@
 with Ada.Directories;
 
+with Alire.Crates;
 with Alire.Directories;
 with Alire.Errors;
-with Alire.GPR;
 with Alire.TOML_Adapters;
 
 with Alire.Hashes.SHA512_Impl; pragma Unreferenced (Alire.Hashes.SHA512_Impl);

--- a/src/alire/alire-toml_index.ads
+++ b/src/alire/alire-toml_index.ads
@@ -1,7 +1,4 @@
-private with TOML;
-
 with Alire.Index_On_Disk;
-with Alire.Crates;
 with Alire.Releases;
 
 with Semantic_Versioning;

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -154,9 +154,10 @@ package Alire.Utils with Preelaborate is
                           C : Ada.Containers.Count_Type := 1)
                           renames Append;
 
-   overriding
+   pragma Style_Checks (Off);  -- for GNAT CE 2021, wants 'overriding'
    procedure Append_Vector (V : in out String_Vector; V2 : String_Vector)
                             renames Append;
+   pragma Style_Checks (On);
 
    function Append_To_Last_Line (V : String_Vector;
                                  S : String)

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -154,6 +154,7 @@ package Alire.Utils with Preelaborate is
                           C : Ada.Containers.Count_Type := 1)
                           renames Append;
 
+   overriding
    procedure Append_Vector (V : in out String_Vector; V2 : String_Vector)
                             renames Append;
 

--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -4,12 +4,8 @@ with Ada.Directories;
 with Ada.Text_IO;
 
 with Alire.Config;
-with Alire.Dependencies;
 with Alire.Lockfiles;
-with Alire.Milestones;
 with Alire.Paths;
-with Alire.Releases;
-with Alire.Roots.Optional;
 with Alire.Solutions;
 with Alire.Utils.TTY;
 with Alire.Utils.User_Input.Query_Config;

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -7,7 +7,6 @@ with Alire.Conditional;
 with Alire.Dependencies.Diffs;
 with Alire.Index;
 with Alire.Manifest;
-with Alire.Milestones;
 with Alire.Releases;
 with Alire.Roots.Optional;
 with Alire.Solutions;

--- a/src/alr/os_macos/alr-platforms-macos.adb
+++ b/src/alr/os_macos/alr-platforms-macos.adb
@@ -1,4 +1,3 @@
-with Alire.Origins.Deployers;
 with Alire.Platform;
 
 with Alr.OS_Lib;

--- a/src/alr/os_macos/alr-platforms-macos.ads
+++ b/src/alr/os_macos/alr-platforms-macos.ads
@@ -1,5 +1,3 @@
-with Alire.Origins;
-
 package Alr.Platforms.MacOS is
 
    type OS_Variant is new Supported with null record;


### PR DESCRIPTION
Remove compilation warnings from GNAT CE 2021.