### PR TITLE
Deploy dependencies atomically and related cleanup subcommand

### DIFF
--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -375,12 +375,7 @@ package body Alire.Directories is
    -- TEMP FILES --
    ----------------
 
-   ----------------
-   -- Initialize --
-   ----------------
-
-   overriding
-   procedure Initialize (This : in out Temp_File) is
+   function Temp_Name (Length : Positive := 8) return String is
       subtype Valid_Character is Character range 'a' .. 'z';
       package Char_Random is new
         Ada.Numerics.Discrete_Random (Valid_Character);
@@ -388,10 +383,24 @@ package body Alire.Directories is
    begin
       Char_Random.Reset (Gen);
 
-      This.Name := +"alr-XXXX.tmp";
-      for I in 5 .. 8 loop
-         UStrings.Replace_Element (This.Name, I, Char_Random.Random (Gen));
-      end loop;
+      return Result : String (1 .. Length + 4) do
+         Result (1 .. 4) := "alr-";
+         Result (Length + 1 .. Result'Last) := ".tmp";
+         for I in 5 .. Length loop
+            Result (I) := Char_Random.Random (Gen);
+         end loop;
+      end return;
+   end Temp_Name;
+
+   ----------------
+   -- Initialize --
+   ----------------
+
+   overriding
+   procedure Initialize (This : in out Temp_File) is
+
+   begin
+      This.Name := +Temp_Name;
 
       --  Try to use our alire folder to hide temporaries; return an absolute
       --  path in any case to avoid problems with the user of the tmp file

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -98,6 +98,11 @@ package Alire.Directories is
    -- Temporary files --
    ---------------------
 
+   function Temp_Name (Length : Positive := 8) return String
+     with Pre => Length >= 5;
+   --  Return a filename such as "alr-sdrv.tmp". Length refers to the name
+   --  without .tmp. The alr- prefix is fixed.
+
    --  TEMP_FILE: obtain a temporary name with optional cleanup
 
    type Temp_File is tagged limited private;

--- a/src/alire/alire-paths.ads
+++ b/src/alire/alire-paths.ads
@@ -5,6 +5,8 @@ package Alire.Paths with Preelaborate is
    Crate_File_Name : constant String := "alire.toml";
    --  Name of the manifest file in a regular workspace
 
+   Cache_Folder_Inside_Working_Folder : constant Relative_Path := "cache";
+
    Temp_Folder_Inside_Working_Folder : constant Relative_Path := "tmp";
 
    function Working_Folder_Inside_Root return Relative_Path

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -721,7 +721,7 @@ package body Alire.Roots is
    ---------------
 
    function Cache_Dir (This : Root) return Absolute_Path
-   is (This.Working_Folder / "cache");
+   is (This.Working_Folder / Paths.Cache_Folder_Inside_Working_Folder);
 
    ----------------------
    -- Dependencies_Dir --

--- a/src/alr/alr-commands-clean.ads
+++ b/src/alr/alr-commands-clean.ads
@@ -20,12 +20,13 @@ package Alr.Commands.Clean is
 
    overriding
    function Usage_Custom_Parameters (Cmd : Command) return String
-   is ("");
+   is ("[--cache] [--temp]");
 
 private
 
    type Command is new Commands.Command with record
       Cache : aliased Boolean := False;
+      Temp  : aliased Boolean := False;
    end record;
 
 end Alr.Commands.Clean;

--- a/testsuite/tests/clean/temp-files/test.py
+++ b/testsuite/tests/clean/temp-files/test.py
@@ -1,0 +1,36 @@
+"""
+Verify that `alr clean --temp` works properly
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq, assert_match
+
+import e3
+import os
+
+os.mkdir("test")
+os.chdir("test")
+
+# We create a temp file above us, one at the current dir, and one below.
+# The one above us should not be cleaned. Also, a file not conforming to
+# "alr-????.tmp" should not be cleaned either.
+
+e3.os.fs.touch("../alr-0001.tmp")
+e3.os.fs.touch("alr-0002.tmp")
+os.mkdir("nested")
+e3.os.fs.touch("nested/alr-0003.tmp")
+e3.os.fs.touch("alien.tmp")
+
+p = run_alr("clean", "--temp")
+
+assert os.path.exists("../alr-0001.tmp"), "unexpected deletion"
+assert os.path.exists("alien.tmp"), "unexpected deletion"
+assert not os.path.exists("alr-0002.tmp"), "unexpected file"
+assert not os.path.exists("nested/alr-0003.tmp"), "unexpected file"
+
+# Finally verify that running again in a clean environment does nothing
+
+p = run_alr("clean", "--temp", quiet=False)
+assert_eq("No temporaries found.\n", p.out)
+
+print('SUCCESS')

--- a/testsuite/tests/clean/temp-files/test.yaml
+++ b/testsuite/tests/clean/temp-files/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
Since downloads were done directly to their destination directory, interrupting one with e.g. Ctrl-C would cause them to be considered downloaded on next run. This starts to hit more often when doing large downloads. With this PR, deployments are done to an adjacent temporary that is finally renamed into the proper destination.

Since finalization and automatic cleanup won't happen with forced interruptions, and such temporaries may start to pile up, a new `alr clean --temp` is added for more convenient garbage collection.