### PR TITLE
Building for macOS.

### DIFF
--- a/src/alr/os_macos/alr-platforms-macos.adb
+++ b/src/alr/os_macos/alr-platforms-macos.adb
@@ -1,4 +1,3 @@
-with Alire.Origins.Deployers;
 with Alire.Platform;
 
 with Alr.OS_Lib;

--- a/src/alr/os_macos/alr-platforms-macos.ads
+++ b/src/alr/os_macos/alr-platforms-macos.ads
@@ -1,5 +1,3 @@
-with Alire.Origins;
-
 package Alr.Platforms.MacOS is
 
    type OS_Variant is new Supported with null record;


### PR DESCRIPTION
 Fixes:
```
alr-platforms-macos.adb:1:19: warning: unit "Alire.Origins.Deployers" is not referenced
alr-platforms-macos.ads:1:11: warning: no entities of "Alire.Origins" are referenced
```