### PR TITLE
Implement `alr toolchain --disable-assistant`

### DIFF
--- a/src/alire/alire-toolchains.adb
+++ b/src/alire/alire-toolchains.adb
@@ -246,9 +246,7 @@ package body Alire.Toolchains is
 
       --  The user has already chosen, so disable the assistant
 
-      Config.Edit.Set (Config.Edit.Filepath (Level),
-                       Config.Keys.Toolchain_Assistant,
-                       "false");
+      Set_Automatic_Assistant (False, Level);
 
       --  Finally deploy selections
 
@@ -257,6 +255,18 @@ package body Alire.Toolchains is
       end loop;
 
    end Assistant;
+
+   -----------------------------
+   -- Set_Automatic_Assistant --
+   -----------------------------
+
+   procedure Set_Automatic_Assistant (Enabled : Boolean; Level : Config.Level)
+   is
+   begin
+      Config.Edit.Set (Config.Edit.Filepath (Level),
+                       Config.Keys.Toolchain_Assistant,
+                       (if Enabled then "true" else "false"));
+   end Set_Automatic_Assistant;
 
    ------------------------
    -- Tool_Is_Configured --

--- a/src/alire/alire-toolchains.ads
+++ b/src/alire/alire-toolchains.ads
@@ -30,6 +30,9 @@ package Alire.Toolchains is
    --  plain `gnat`. This way we need to to litter the callers with similar
    --  transformations, as we always want whatever gnat_XXX is used for "gnat".
 
+   procedure Set_Automatic_Assistant (Enabled : Boolean; Level : Config.Level);
+   --  Enable/Disable the automatic assistant on next run
+
    function Tool_Is_Configured (Crate : Crate_Name) return Boolean;
    --  Say if a tool is actually configured by the user
 

--- a/src/alr/alr-commands-toolchain.ads
+++ b/src/alr/alr-commands-toolchain.ads
@@ -57,6 +57,7 @@ package Alr.Commands.Toolchain is
 private
 
    type Command is new Commands.Command with record
+      Disable   : aliased Boolean := False;
       Install   : aliased Boolean := False;
       Local     : aliased Boolean := False;
       S_Select  : aliased Boolean := False;

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -40,8 +40,7 @@ def prepare_env(config_dir, env):
 
     # Disable selection of toolchain to preserve older behavior. Tests that
     # require a configured compiler will have to set it up explicitly.
-    run_alr("config", "--global", "--set", "toolchain.assistant", "false",
-            "-c", config_dir)
+    run_alr("toolchain", "--disable-assistant", "-c", config_dir)
     #  Pass config location explicitly since env is not yet applied
 
     # If distro detection is disabled via environment, configure so in alr


### PR DESCRIPTION
As mentioned in #792 to simplify non-interactive operation.