### PR TITLE
Non-interactive toolchain selection with `alr toolchain --select <release>`

### DIFF
--- a/src/alire/alire-toolchains.adb
+++ b/src/alire/alire-toolchains.adb
@@ -152,9 +152,7 @@ package body Alire.Toolchains is
 
          --  Store tool milestone after successful deployment
 
-         Config.Edit.Set (Path  => Config.Edit.Filepath (Level),
-                          Key   => Tool_Key (Release.Name),
-                          Value => Release.Milestone.Image);
+         Set_As_Default (Release, Level);
 
       end Install;
 
@@ -255,6 +253,18 @@ package body Alire.Toolchains is
       end loop;
 
    end Assistant;
+
+   --------------------
+   -- Set_As_Default --
+   --------------------
+
+   procedure Set_As_Default (Release : Releases.Release; Level : Config.Level)
+   is
+   begin
+      Config.Edit.Set (Path  => Config.Edit.Filepath (Level),
+                       Key   => Tool_Key (Release.Name),
+                       Value => Release.Milestone.Image);
+   end Set_As_Default;
 
    -----------------------------
    -- Set_Automatic_Assistant --

--- a/src/alire/alire-toolchains.ads
+++ b/src/alire/alire-toolchains.ads
@@ -3,6 +3,7 @@ with Ada.Containers.Indefinite_Ordered_Sets;
 with Alire.Config;
 with Alire.Dependencies;
 private with Alire.Milestones;
+with Alire.Releases;
 with Alire.TTY;
 with Alire.Utils;
 
@@ -32,6 +33,10 @@ package Alire.Toolchains is
 
    procedure Set_Automatic_Assistant (Enabled : Boolean; Level : Config.Level);
    --  Enable/Disable the automatic assistant on next run
+
+   procedure Set_As_Default (Release : Releases.Release; Level : Config.Level);
+   --  Mark the given release as the default to be used. Does not check that it
+   --  be already installed.
 
    function Tool_Is_Configured (Crate : Crate_Name) return Boolean;
    --  Say if a tool is actually configured by the user

--- a/src/alr/alr-commands-toolchain.ads
+++ b/src/alr/alr-commands-toolchain.ads
@@ -29,7 +29,8 @@ package Alr.Commands.Toolchain is
           & "select the default toolchain for this configuration. "
           & "Adding --local will instead make the selection apply "
           & "only to the workspace (overridding a possible "
-          & "configuration-wide selection).")
+          & "configuration-wide selection). Giving a release argument will "
+          & "skip the assistant and set the release as the default.")
        .New_Line
        .Append
          ("Specify --install/--uninstall and a crate name with optional "
@@ -52,7 +53,7 @@ package Alr.Commands.Toolchain is
    overriding
    function Usage_Custom_Parameters (Cmd : Command) return String
    is ("[-u|--uninstall] [-i|--install crate[version set]] |"
-       & " --select [--local]");
+       & " --select [--local] [release]");
 
 private
 

--- a/testsuite/tests/toolchain/select/test.py
+++ b/testsuite/tests/toolchain/select/test.py
@@ -2,10 +2,11 @@
 Check toolchain selection assistant
 """
 
-import subprocess
+import os
 import re
+import subprocess
 
-from drivers.alr import run_alr
+from drivers.alr import run_alr, init_local_crate
 from drivers.asserts import assert_eq, assert_match
 
 # Activate the default compiler
@@ -14,6 +15,24 @@ p = run_alr("toolchain", "--select")
 # Check that the newest native compiler is the Default now (vs Available)
 p = run_alr("toolchain")
 assert_match(".*gnat_native.*" + re.escape("2.0.0") + ".*Default.*",
+             p.out)
+
+# Select an older compiler as default
+run_alr("toolchain", "--select", "gnat_native=1")
+p = run_alr("toolchain")
+assert_match(".*gnat_native.*" + re.escape("1.0.0") + ".*Default.*",
+             p.out)
+
+# Test local selection by configuring locally inside a crate
+init_local_crate()
+run_alr("toolchain", "--select", "gnat_native=2", "--local")
+p = run_alr("toolchain")
+assert_match(".*gnat_native.*" + re.escape("2.0.0") + ".*Default.*",
+             p.out)
+# And check that outside the global selection is still in effect
+os.chdir("..")
+p = run_alr("toolchain")
+assert_match(".*gnat_native.*" + re.escape("1.0.0") + ".*Default.*",
              p.out)
 
 # I've (mosteo) been unable to connect stdin with an alr launched via #


### PR DESCRIPTION
As mentioned in #792.