### PR TITLE
Solver timeout to prevent runaway situations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,3 +45,6 @@
 [submodule "deps/si_units"]
 	path = deps/si_units
 	url = https://github.com/HeisenbugLtd/si_units.git
+[submodule "deps/stopwatch"]
+	path = deps/stopwatch
+	url = https://github.com/mosteo/stopwatch

--- a/alire.gpr
+++ b/alire.gpr
@@ -10,6 +10,7 @@ with "semantic_versioning";
 with "simple_logging";
 with "si_units";
 with "spdx";
+with "stopwatch";
 with "toml_slicer";
 with "uri";
 with "xml_ez_out";

--- a/alr_env.gpr
+++ b/alr_env.gpr
@@ -13,6 +13,7 @@ aggregate project Alr_Env is
                          "deps/semantic_versioning",
                          "deps/simple_logging",
                          "deps/si_units",
+                         "deps/stopwatch",
                          "deps/toml_slicer",
                          "deps/uri-ada",
                          "deps/xmlezout",

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -908,6 +908,34 @@ package body Alire.Solutions is
       end if;
    end Print_Pins;
 
+   ------------------
+   -- Print_States --
+   ------------------
+
+   procedure Print_States (This   : Solution;
+                           Indent : String := "   ";
+                           Level  : Trace.Levels := Trace.Info)
+   is
+      Table : Utils.Tables.Table;
+   begin
+      Table.Header (Indent & "RELEASE");
+      Table.Header ("DEPENDENCY");
+      Table.New_Row;
+
+      for State of This.Dependencies loop
+         if State.Has_Release then
+            Table.Append (Indent & State.Release.Milestone.TTY_Image);
+         else
+            Table.Append (Indent & TTY.Warn ("(none)"));
+         end if;
+
+         Table.Append (State.TTY_Image);
+         Table.New_Row;
+      end loop;
+
+      Table.Print (Level => Level);
+   end Print_States;
+
    ----------------
    -- Print_Tree --
    ----------------

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -354,6 +354,11 @@ package Alire.Solutions is
    procedure Print_Pins (This : Solution);
    --  Dump a table with pins in this solution
 
+   procedure Print_States (This   : Solution;
+                           Indent : String := "   ";
+                           Level  : Trace.Levels := Trace.Info);
+   --  List all dependencies in the solution with their current state
+
    procedure Print_Tree (This       : Solution;
                          Root       : Alire.Releases.Release;
                          Prefix     : String := "";

--- a/src/alire/alire-solver.ads
+++ b/src/alire/alire-solver.ads
@@ -114,11 +114,24 @@ package Alire.Solver is
       Detecting    : Detection_Policies    := Detect;
       Hinting      : Hinting_Policies      := Hint;
       Sharing      : Sharing_Policies      := Allow_Shared;
+
+      Timeout      : Duration              := 5.0;
+      --  Time until reporting problems finding a complete solution
+
+      Timeout_More : Duration              := 10.0;
+      --  Extra period if the user wants to keep looking
+
+      Interactive  : Boolean               := True;
+      --  If not interactive, the first timeout will be applied without asking
    end record;
 
    Default_Options : constant Query_Options := (others => <>);
    --  A reasonable combo that will return the first complete solution found,
    --  or otherwise consider a subset of incomplete solutions.
+
+   Default_Options_Not_Interactive : constant Query_Options :=
+                                       (Interactive => False,
+                                        others      => <>);
 
    Exhaustive_Options : constant Query_Options :=
                           (Completeness => All_Incomplete,

--- a/src/alire/alire-utils-tables.adb
+++ b/src/alire/alire-utils-tables.adb
@@ -1,4 +1,15 @@
+with Alire.Utils.TTY;
+
 package body Alire.Utils.Tables is
+
+   ------------
+   -- Header --
+   ------------
+
+   procedure Header (T : in out Table; Cell : String) is
+   begin
+      T.Append (TTY.Emph (To_Upper_Case (Cell)));
+   end Header;
 
    -----------
    -- Print --

--- a/src/alire/alire-utils-tables.ads
+++ b/src/alire/alire-utils-tables.ads
@@ -4,6 +4,8 @@ package Alire.Utils.Tables with Preelaborate is
 
    type Table is new AAA.Table_IO.Table with null record;
 
+   procedure Header (T : in out Table; Cell : String);
+
    procedure Print (T         : Table;
                     Level     : Trace.Levels            := Info;
                     Separator : String                  := " ";

--- a/src/alr/alr-commands-search.adb
+++ b/src/alr/alr-commands-search.adb
@@ -61,8 +61,9 @@ package body Alr.Commands.Search is
                          (R.Dependencies (Platform.Properties),
                           Platform.Properties,
                           Alire.Solutions.Empty_Valid_Solution,
-                          Options => (Age    => Query_Policy,
-                                      others => <>))
+                          Options => (Age         => Query_Policy,
+                                      Interactive => False,
+                                      others      => <>))
                        then " "
                        else Flag_Unsolv)));
             Tab.Append (TTY.Version (Semantic_Versioning.Image (R.Version)));


### PR DESCRIPTION
Implements a timeout during solving (defaults to 5 seconds). If running interactive, the current best solution is shown and the user is asked to continue searching for another 10 seconds or use the incomplete solution.

Not sure how to test this one in the test suite, as it would require adding configuration and slow-down code just for testing. 