### PR TITLE
Separate dependency recursion from deployment

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -15,7 +15,7 @@ project-files = ["alr.gpr"]
 executables = ["alr"]
 
 [[depends-on]]
-aaa = "~0.2.1"
+aaa = "~0.2.3"
 ada_toml = "~0.1"
 ajunitgen = "^1.0.1"
 ansiada = "~0.1"
@@ -35,7 +35,6 @@ macos   = { OS = "macOS" }
 
 # Most dependencies require precise versions during the development cycle:
 [[pins]]
-aaa = { url = "https://github.com/mosteo/aaa.git", commit = "32ee4c80001ae388d8ae43b8a3aac94ccba30614" }
 ada_toml = { url = "https://github.com/pmderodat/ada-toml.git", commit = "ade3cc905cef405dbf53e16a54f6fb458482710f" }
 ajunitgen = { url = "https://github.com/mosteo/ajunitgen.git", commit = "e5d01db5e7834d15c4066f0a8e33d780deae3cc9" }
 ansiada = { url = "https://github.com/mosteo/ansi-ada.git", commit = "acf9afca3afe1f8b8843c061f3cef860d7567307" }

--- a/src/alire/alire-releases-containers.ads
+++ b/src/alire/alire-releases-containers.ads
@@ -10,6 +10,7 @@ package Alire.Releases.Containers is
 
    package Optional_Releases is new Optional.Values (Releases.Release,
                                                      Release_Image);
+   subtype Optional is Optional_Releases.Optional;
 
    package Release_Sets
    is new Ada.Containers.Indefinite_Ordered_Sets (Releases.Release,

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -64,18 +64,15 @@ package body Alire.Releases is
       P : Alire.Properties.Vector := Alire.Properties.No_Properties)
       return Alire.Dependencies.Containers.List
    is
-      function Enumerate is new Conditional.For_Dependencies.Enumerate
-        (Alire.Dependencies.Containers.List,
-         Alire.Dependencies.Containers.Append);
    begin
       if P.Is_Empty then
          --  Trying to evaluate a tree with empty dependencies will result
          --  in spurious warnings about missing environment properties (as we
          --  indeed didn't give any). Since we want to get flat dependencies
          --  that do not depend on any properties, this is indeed safe to do.
-         return Enumerate (R.Dependencies);
+         return Conditional.Enumerate (R.Dependencies);
       else
-         return Enumerate (R.Dependencies.Evaluate (P));
+         return Conditional.Enumerate (R.Dependencies.Evaluate (P));
       end if;
    end Flat_Dependencies;
 

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -302,7 +302,8 @@ package Alire.Solutions is
    --  Returns the proper releases in the solution (regular and detected
    --  externals). This also includes releases found at a linked folder.
 
-   function Required (This : Solution) return State_Map'Class;
+   function Required (This : Solution) return State_Map
+                      renames All_Dependencies;
    --  Returns all dependencies required to fulfill this solution,
    --  independently of their solving state.
 
@@ -396,6 +397,18 @@ package Alire.Solutions is
    --  replace "any" dependencies with the proper tilde or caret, depending on
    --  what was found in the solution. E.g., if the user provided lib=*, and it
    --  is solved as lib=2.0, replace lib=* with lib^2.0 in the result.
+
+   procedure Traverse
+     (This  : Solution;
+      Doing : access procedure
+        (This  : Solution;
+         State : Dependency_State);
+      Root  : Alire.Releases.Containers.Optional :=
+        Alire.Releases.Containers.Optional_Releases.Empty);
+   --  Visit every dependency in the solution, starting at leaves up to
+   --  the optional root release, calling Doing for each one. This allows
+   --  a safe-order traversal of a solution. This procedure is currently
+   --  sequential but it could be parallelized in the future.
 
 private
 


### PR DESCRIPTION
This PR provides a method of the `Solution` type that visits all dependencies in a safe order. This was done already to deploy dependencies and call their `post-fetch`, but now it is decoupled from this specific use. 

This will allow simpler invocation of other events to fix e.g. incremental compilation, `pre-build`, and #628.