### PR TITLE
Move version out of root package

### DIFF
--- a/src/alire/alire-version.ads
+++ b/src/alire/alire-version.ads
@@ -1,0 +1,14 @@
+package Alire.Version with Preelaborate is
+
+   Current : constant String := "1.1.0-rc2";
+   --  1.1.0-rc2: toolchain non-interactive, lockfile under alire
+   --  1.1.0-rc1: crate config, toolchains, manifest pins
+   --  1.1.0-dev: begin post-1.0 changes
+   --  1.0.0:     no changes since rc3
+   --  1.0.0-rc3: added help colors PR
+   --  1.0.0-rc2: move community index to stable-1.0 branch
+   --  1.0.0-rc1: release candidate for 1.0
+   --  0.8.1-dev: update to devel-0.5 index branch
+   --  0.8.0-dev: post-0.7-beta changes
+
+end Alire.Version;

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -10,15 +10,6 @@ with CLIC.TTY;
 
 package Alire with Preelaborate is
 
-   Version : constant String := "1.1.0-dev+local-toolchain";
-   --  1.1.0-dev: begin post-1.0 changes
-   --  1.0.0:     no changes since rc3
-   --  1.0.0-rc3: added help colors PR
-   --  1.0.0-rc2: move community index to stable-1.0 branch
-   --  1.0.0-rc1: release candidate for 1.0
-   --  0.8.1-dev: update to devel-0.5 index branch
-   --  0.8.0-dev: post-0.7-beta changes
-
    Checked_Error : exception;
    --  A Checked_Error is an explicitly diagnosed error condition, usually in
    --  relation with user inputs (e.g., parsing of TOML files or other inputs).

--- a/src/alr/alr-commands-version.adb
+++ b/src/alr/alr-commands-version.adb
@@ -31,8 +31,8 @@ package body Alr.Commands.Version is
          Reportaise_Wrong_Arguments (Cmd.Name & " doesn't take arguments");
       end if;
 
-      Trace.Always ("Alr version: " & Alr.Version);
-      Trace.Always ("Alire Library version: " & Alire.Version);
+      Trace.Always ("Alr version: " & Alire.Version.Current);
+      Trace.Always ("Alire Library version: " & Alire.Version.Current);
       Trace.Always ("alr status is " & Bootstrap.Status_Line);
       Trace.Always ("config folder is " & Paths.Alr_Config_Folder);
       Trace.Always ("source folder is " & Paths.Alr_Source_Folder);

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -1,9 +1,10 @@
 with AAA.Strings;
 
 with Alire.Directories;
+with Alire.GPR;
 with Alire.Roots.Optional;
 with Alire.Solver;
-with Alire.GPR;
+with Alire.Version;
 
 with CLIC.Subcommand;
 
@@ -128,7 +129,7 @@ private
 
    package Sub_Cmd is new CLIC.Subcommand.Instance
      (Main_Command_Name   => "alr",
-      Version             => Alr.Version,
+      Version             => Alire.Version.Current,
       Put                 => Ada.Text_IO.Put,
       Put_Line            => Ada.Text_IO.Put_Line,
       Put_Error           => Put_Error,

--- a/src/alr/alr.ads
+++ b/src/alr/alr.ads
@@ -5,8 +5,6 @@ with CLIC.TTY;
 
 package Alr with Preelaborate is
 
-   Version : constant String := Alire.Version;
-
    --  Nothing of note in this root package. Entities declared here are
    --  generally useful everywhere or in many packages: Exceptions for
    --  commands, tracing for all


### PR DESCRIPTION
While bumping the version for rc2...

This way changing it does not require recompiling absolutely everything.