### PR TITLE
Alr.Commands.Toolchain: tweak for multiple components and install dir

### DIFF
--- a/src/alire/alire-shared.adb
+++ b/src/alire/alire-shared.adb
@@ -97,7 +97,8 @@ package body Alire.Shared is
    -- Share --
    -----------
 
-   procedure Share (Release : Releases.Release)
+   procedure Share (Release  : Releases.Release;
+                    Location : Any_Path := Install_Path)
    is
       Already_Installed : Boolean := False;
 
@@ -155,8 +156,7 @@ package body Alire.Shared is
       end if;
 
       --  See if it can be skipped
-
-      if Available.Contains (Release) then
+      if Location = Install_Path and then Available.Contains (Release) then
          Trace.Detail ("Skipping installation of already available release: "
                        & Release.Milestone.TTY_Image);
          return;
@@ -165,7 +165,7 @@ package body Alire.Shared is
       --  Deploy at the install location
 
       Release.Deploy (Env             => Root.Platform_Properties,
-                      Parent_Folder   => Install_Path,
+                      Parent_Folder   => Location,
                       Was_There       => Already_Installed,
                       Perform_Actions => True,
                       Create_Manifest => True,

--- a/src/alire/alire-shared.ads
+++ b/src/alire/alire-shared.ads
@@ -19,8 +19,9 @@ package Alire.Shared is
    function Install_Path return Any_Path;
    --  Returns the base folder in which all shared releases live
 
-   procedure Share (Release : Releases.Release);
-   --  Deploy a release in the shared location for the configuration
+   procedure Share (Release  : Releases.Release;
+                    Location : Any_Path := Install_Path);
+   --  Deploy a release in the specified location
 
    procedure Remove
      (Release : Releases.Release;

--- a/src/alr/alr-commands-toolchain.adb
+++ b/src/alr/alr-commands-toolchain.adb
@@ -318,7 +318,9 @@ package body Alr.Commands.Toolchain is
             Install (Cmd, Elt, Set_As_Default => False);
          end loop;
 
-      else
+      elsif not Cmd.Disable then
+
+         --  When no command is specified, print the list
          Cmd.List;
       end if;
 

--- a/src/alr/alr-commands-toolchain.adb
+++ b/src/alr/alr-commands-toolchain.adb
@@ -40,7 +40,7 @@ package body Alr.Commands.Toolchain is
          Cmd.Install'Access,
          Switch      => "-i",
          Long_Switch => "--install",
-         Help        => "Install one or more toolchain component(s)");
+         Help        => "Install one or more toolchain component");
 
       Define_Switch
         (Config,
@@ -67,7 +67,7 @@ package body Alr.Commands.Toolchain is
          Cmd.Uninstall'Access,
          Switch      => "-u",
          Long_Switch => "--uninstall",
-         Help        => "Uninstall one or more toolchain component(s)");
+         Help        => "Uninstall one or more toolchain component");
    end Setup_Switches;
 
    -------------
@@ -255,11 +255,6 @@ package body Alr.Commands.Toolchain is
            ("The provided switches cannot be used simultaneously");
       end if;
 
-      --  if Args.Count > 1 then
-      --     Reportaise_Wrong_Arguments
-      --     ("One crate with optional version expected: crate[version set]");
-      --  end if;
-
       if (Cmd.Install or Cmd.Uninstall) and then Args.Is_Empty then
          Reportaise_Wrong_Arguments ("No release specified");
       end if;
@@ -271,11 +266,6 @@ package body Alr.Commands.Toolchain is
            ("Specify the action to perform with the crate");
       end if;
 
-      --  if Cmd.S_Select and then Args.Count > 1 then
-      --     Reportaise_Wrong_Arguments
-      --       ("Toolchain installation accepts at most one argument");
-      --  end if;
-
       if Cmd.Local and then not (Cmd.S_Select or else Cmd.Disable) then
          Reportaise_Wrong_Arguments
            ("--local requires --select or --disable-assistant");
@@ -283,12 +273,8 @@ package body Alr.Commands.Toolchain is
 
       if Cmd.Install_Dir.all /= "" and then not Cmd.Install then
          Reportaise_Wrong_Arguments
-           ("--install-dir only compatible --install action");
+           ("--install-dir is only compatible with --install action");
       end if;
-      --  if Cmd.Disable and then Args.Count /= 0 then
-      --     Reportaise_Wrong_Arguments
-      --       ("Disabling the assistant does not admit any extra arguments");
-      --  end if;
 
       --  Dispatch to subcommands
 
@@ -318,7 +304,7 @@ package body Alr.Commands.Toolchain is
                                         else Alire.Config.Global);
          else
             for Elt of Args loop
-               Install (Cmd, Args (1), Set_As_Default => True);
+               Install (Cmd, Elt, Set_As_Default => True);
             end loop;
          end if;
 

--- a/src/alr/alr-commands-toolchain.adb
+++ b/src/alr/alr-commands-toolchain.adb
@@ -1,3 +1,6 @@
+
+with GNAT.Strings; use GNAT.Strings;
+
 with AAA.Table_IO;
 
 with Alire.Config.Edit;
@@ -37,7 +40,13 @@ package body Alr.Commands.Toolchain is
          Cmd.Install'Access,
          Switch      => "-i",
          Long_Switch => "--install",
-         Help        => "Install a toolchain component");
+         Help        => "Install one or more toolchain component(s)");
+
+      Define_Switch
+        (Config,
+         Cmd.Install_Dir'Access,
+         Long_Switch => "--install-dir=",
+         Help        => "Toolchain component(s) installation directory");
 
       Define_Switch
         (Config,
@@ -58,7 +67,7 @@ package body Alr.Commands.Toolchain is
          Cmd.Uninstall'Access,
          Switch      => "-u",
          Long_Switch => "--uninstall",
-         Help        => "Uninstall a toolchain component");
+         Help        => "Uninstall one or more toolchain component(s)");
    end Setup_Switches;
 
    -------------
@@ -102,7 +111,11 @@ package body Alr.Commands.Toolchain is
 
          --  And perform the actual installation
 
-         Shared.Share (Rel);
+         if Cmd.Install_Dir.all /= "" then
+            Shared.Share (Rel, Cmd.Install_Dir.all);
+         else
+            Shared.Share (Rel);
+         end if;
 
          if Set_As_Default then
             Alire.Toolchains.Set_As_Default
@@ -236,44 +249,60 @@ package body Alr.Commands.Toolchain is
       --  Validation
 
       if Alire.Utils.Count_True
-        ((Cmd.Disable, Cmd.Install, Cmd.S_Select, Cmd.Uninstall)) > 1
+        ((Cmd.Install, Cmd.S_Select, Cmd.Uninstall)) > 1
       then
          Reportaise_Wrong_Arguments
            ("The provided switches cannot be used simultaneously");
       end if;
 
-      if Args.Count > 1 then
-         Reportaise_Wrong_Arguments
-           ("One crate with optional version expected: crate[version set]");
-      end if;
+      --  if Args.Count > 1 then
+      --     Reportaise_Wrong_Arguments
+      --     ("One crate with optional version expected: crate[version set]");
+      --  end if;
 
-      if (Cmd.Install or Cmd.Uninstall) and then Args.Count /= 1 then
+      if (Cmd.Install or Cmd.Uninstall) and then Args.Is_Empty then
          Reportaise_Wrong_Arguments ("No release specified");
       end if;
 
-      if Args.Count = 1 and then
+      if not Args.Is_Empty and then
         not (Cmd.Install or Cmd.Uninstall or Cmd.S_Select)
       then
          Reportaise_Wrong_Arguments
            ("Specify the action to perform with the crate");
       end if;
 
-      if Cmd.S_Select and then Args.Count > 1 then
-         Reportaise_Wrong_Arguments
-           ("Toolchain installation accepts at most one argument");
-      end if;
+      --  if Cmd.S_Select and then Args.Count > 1 then
+      --     Reportaise_Wrong_Arguments
+      --       ("Toolchain installation accepts at most one argument");
+      --  end if;
 
       if Cmd.Local and then not (Cmd.S_Select or else Cmd.Disable) then
          Reportaise_Wrong_Arguments
            ("--local requires --select or --disable-assistant");
       end if;
 
-      if Cmd.Disable and then Args.Count /= 0 then
+      if Cmd.Install_Dir.all /= "" and then not Cmd.Install then
          Reportaise_Wrong_Arguments
-           ("Disabling the assistant does not admit any extra arguments");
+           ("--install-dir only compatible --install action");
       end if;
+      --  if Cmd.Disable and then Args.Count /= 0 then
+      --     Reportaise_Wrong_Arguments
+      --       ("Disabling the assistant does not admit any extra arguments");
+      --  end if;
 
       --  Dispatch to subcommands
+
+      if Cmd.Disable then
+         Alire.Toolchains.Set_Automatic_Assistant (False,
+                                                   (if Cmd.Local
+                                                    then Alire.Config.Local
+                                                    else Alire.Config.Global));
+         Alire.Put_Info
+           ("Assistant disabled in "
+            & TTY.Emph (if Cmd.Local then "local" else "global")
+            & " configuration.");
+
+      end if;
 
       if Cmd.S_Select then
 
@@ -288,28 +317,23 @@ package body Alr.Commands.Toolchain is
                                         then Alire.Config.Local
                                         else Alire.Config.Global);
          else
-            Install (Cmd, Args (1), Set_As_Default => True);
+            for Elt of Args loop
+               Install (Cmd, Args (1), Set_As_Default => True);
+            end loop;
          end if;
 
       elsif Cmd.Uninstall then
-         Uninstall (Cmd, Args (1));
+         for Elt of Args loop
+            Uninstall (Cmd, Elt);
+         end loop;
 
       elsif Cmd.Install then
-         Install (Cmd, Args (1), Set_As_Default => False);
-
-      elsif Cmd.Disable then
-         Alire.Toolchains.Set_Automatic_Assistant (False,
-                                                   (if Cmd.Local
-                                                    then Alire.Config.Local
-                                                    else Alire.Config.Global));
-         Alire.Put_Info
-           ("Assistant disabled in "
-            & TTY.Emph (if Cmd.Local then "local" else "global")
-            & " configuration.");
+         for Elt of Args loop
+            Install (Cmd, Elt, Set_As_Default => False);
+         end loop;
 
       else
          Cmd.List;
-
       end if;
 
    exception

--- a/src/alr/alr-commands-toolchain.ads
+++ b/src/alr/alr-commands-toolchain.ads
@@ -1,5 +1,7 @@
 with AAA.Strings;
 
+private with GNAT.Strings;
+
 package Alr.Commands.Toolchain is
 
    --  Installation of binary toolchain crates into the ${ALR_CONFIG}/cache
@@ -32,12 +34,13 @@ package Alr.Commands.Toolchain is
           & "select the default toolchain for this configuration. "
           & "Adding --local will instead make the selection apply "
           & "only to the workspace (overridding a possible "
-          & "configuration-wide selection). Giving a release argument will "
-          & "skip the assistant and set the release as the default.")
+          & "configuration-wide selection). Giving one or more release"
+          & " argument will skip the assistant and set the release(s) as the"
+          & " default.")
        .New_Line
        .Append
-         ("Specify --install/--uninstall and a crate name with optional "
-          & "version set to make available or remove a tool.")
+         ("Specify --install/--uninstall and one or more crate name(s) with"
+          & " optional version(s) set to make available or remove a tool.")
        .New_Line
        .Append
          ("Run `" & TTY.Terminal ("alr help toolchains") & "` for further "
@@ -56,16 +59,17 @@ package Alr.Commands.Toolchain is
    overriding
    function Usage_Custom_Parameters (Cmd : Command) return String
    is ("[-u|--uninstall] [-i|--install crate[version set]] |"
-       & " --select [--local] [release]");
+       & " --select [--local] [releases] [--disable-assistant]");
 
 private
 
    type Command is new Commands.Command with record
-      Disable   : aliased Boolean := False;
-      Install   : aliased Boolean := False;
-      Local     : aliased Boolean := False;
-      S_Select  : aliased Boolean := False;
-      Uninstall : aliased Boolean := False;
+      Disable     : aliased Boolean := False;
+      Install     : aliased Boolean := False;
+      Install_Dir : aliased GNAT.Strings.String_Access := null;
+      Local       : aliased Boolean := False;
+      S_Select    : aliased Boolean := False;
+      Uninstall   : aliased Boolean := False;
    end record;
 
 end Alr.Commands.Toolchain;

--- a/src/alr/alr-commands-toolchain.ads
+++ b/src/alr/alr-commands-toolchain.ads
@@ -35,12 +35,12 @@ package Alr.Commands.Toolchain is
           & "Adding --local will instead make the selection apply "
           & "only to the workspace (overridding a possible "
           & "configuration-wide selection). Giving one or more release"
-          & " argument will skip the assistant and set the release(s) as the"
+          & " argument will skip the assistant and set the release as the"
           & " default.")
        .New_Line
        .Append
-         ("Specify --install/--uninstall and one or more crate name(s) with"
-          & " optional version(s) set to make available or remove a tool.")
+         ("Specify --install/--uninstall and one or more crate name with"
+          & " optional version set to make available or remove a tool.")
        .New_Line
        .Append
          ("Run `" & TTY.Terminal ("alr help toolchains") & "` for further "

--- a/src/alr/alr-commands-toolchain.ads
+++ b/src/alr/alr-commands-toolchain.ads
@@ -34,12 +34,12 @@ package Alr.Commands.Toolchain is
           & "select the default toolchain for this configuration. "
           & "Adding --local will instead make the selection apply "
           & "only to the workspace (overridding a possible "
-          & "configuration-wide selection). Giving one or more release"
+          & "configuration-wide selection). Giving one or more releases"
           & " argument will skip the assistant and set the release as the"
           & " default.")
        .New_Line
        .Append
-         ("Specify --install/--uninstall and one or more crate name with"
+         ("Specify --install/--uninstall and one or more crates name with"
           & " optional version set to make available or remove a tool.")
        .New_Line
        .Append

--- a/testsuite/fixtures/toolchain_index/gn/gnat_external/gnat_external-external.toml
+++ b/testsuite/fixtures/toolchain_index/gn/gnat_external/gnat_external-external.toml
@@ -7,6 +7,6 @@ maintainers-logins = ["mosteo"]
 [[external]]
 kind = "version-output"
 # We look for make instead that should be always installed.
-version-command = ["gnat", "--version"]
-version-regexp = "^GNAT ([\\d\\.]+).*|^GNAT Community ([\\d]{4}).*"
+version-command = ["make", "--version"]
+version-regexp = ".*Make ([\\d\\.]+).*"
 provides = "gnat"

--- a/testsuite/fixtures/toolchain_index/gn/gnat_external/gnat_external-external.toml
+++ b/testsuite/fixtures/toolchain_index/gn/gnat_external/gnat_external-external.toml
@@ -7,6 +7,6 @@ maintainers-logins = ["mosteo"]
 [[external]]
 kind = "version-output"
 # We look for make instead that should be always installed.
-version-command = ["make", "--version"]
-version-regexp = ".*Make ([\\d\\.]+).*"
+version-command = ["gnat", "--version"]
+version-regexp = "^GNAT ([\\d\\.]+).*|^GNAT Community ([\\d]{4}).*"
 provides = "gnat"

--- a/testsuite/fixtures/toolchain_index/gn/gnat_native/gnat_native-7777.0.0.toml
+++ b/testsuite/fixtures/toolchain_index/gn/gnat_native/gnat_native-7777.0.0.toml
@@ -1,9 +1,9 @@
 description = "Fake GNAT native crate"
 name = "gnat_native"
-version = "2.0.0"
+version = "7777.0.0"
 maintainers = ["alejandro@mosteo.com"]
 maintainers-logins = ["mylogin"]
-provides = ["gnat=2.0"]
+provides = ["gnat=7777.0"]
 
 # Test dynamic expression, but for all OSes
 [origin."case(os)"."..."]

--- a/testsuite/fixtures/toolchain_index/gn/gnat_native/gnat_native-8888.0.0.toml
+++ b/testsuite/fixtures/toolchain_index/gn/gnat_native/gnat_native-8888.0.0.toml
@@ -1,9 +1,9 @@
 description = "Fake GNAT native crate"
 name = "gnat_native"
-version = "1.0.0"
+version = "8888.0.0"
 maintainers = ["alejandro@mosteo.com"]
 maintainers-logins = ["mylogin"]
-provides = ["gnat=1.0"]
+provides = ["gnat=8888.0"]
 
 # Test dynamic expression, but for all OSes
 [origin."case(os)"."..."]

--- a/testsuite/tests/solver/compiler-installed/test.py
+++ b/testsuite/tests/solver/compiler-installed/test.py
@@ -20,8 +20,9 @@ assert_match(".*\n"  # Headers
              p.out)
 
 # Capture version
-version = re.search("[0-9.]+", p.out, re.MULTILINE).group()
+version = re.search("gnat_external ([0-9.]+)", p.out, re.MULTILINE).group(1)
 
+print(version)
 # When no compiler is selected, since the external one is available, it should
 # be used before offering to download a new compiler.
 
@@ -50,7 +51,7 @@ match_solution("gnat=1.0.0 (gnat_cross_2) (installed)", escape=True)
 
 run_alr("toolchain", "--install", "gnat_native")
 run_alr("update")
-match_solution("gnat=2.0.0 (gnat_native) (installed)", escape=True)
+match_solution("gnat=8888.0.0 (gnat_native) (installed)", escape=True)
 
 # If we remove the version exclusion, the external compiler will still be
 # preferred as there is no selected compiler yet.
@@ -61,7 +62,7 @@ match_solution(f"gnat={version} (gnat_external) (installed)", escape=True)
 
 # But, if the user selects a compiler as preferred, it will be used first
 
-run_alr("config", "--set", "toolchain.use.gnat", "gnat_cross_2=1.0.0")
+run_alr("config", "--set", "toolchain.use.gnat", "gnat_cross_2=7777.0.0")
 run_alr("update")
 match_solution("gnat=1.0.0 (gnat_cross_2) (installed)", escape=True)
 

--- a/testsuite/tests/solver/compiler-mixing/test.py
+++ b/testsuite/tests/solver/compiler-mixing/test.py
@@ -17,8 +17,7 @@ assert_match(".*\n"  # Headers
              p.out)
 
 # Capture version
-version = re.search("[0-9.]+", p.out, re.MULTILINE).group()
-
+version = re.search("gnat_external ([0-9.]+)", p.out, re.MULTILINE).group(1)
 # Prepare a couple of dependencies, one depending on gnat, and another one
 # depending on gnat_native.
 
@@ -45,8 +44,8 @@ match_solution(f"gnat={version} (gnat_external) (installed)",
 # If we add a precise dependency on e.g. the installed native compiler, this
 # should override the external compiler
 alr_with("gnat_native")
-match_solution("gnat=2.0.0 (gnat_native) (installed)", escape=True)
-match_solution("gnat_native=2.0.0 (installed)", escape=True)
+match_solution("gnat=8888.0.0 (gnat_native) (installed)", escape=True)
+match_solution("gnat_native=8888.0.0 (installed)", escape=True)
 
 # Let us swap the generic dependency with a targeted dependency, starting from
 # scratch
@@ -57,8 +56,8 @@ run_alr("with", "--use=../dep_targeted")
 alr_with("gnat")
 
 # In this case the only possible solution is with the targeted compiler
-match_solution("gnat=" + e("2.0.0 (gnat_native) (installed)") + ".*" +
-               "gnat_native=" + e("2.0.0 (installed)") + ".*")
+match_solution("gnat=" + e("8888.0.0 (gnat_native) (installed)") + ".*" +
+               "gnat_native=" + e("8888.0.0 (installed)") + ".*")
 
 # Second, we check a root targeted gnat with both dependencies
 
@@ -69,8 +68,8 @@ alr_with("gnat_native")
 
 # In this case the only possible solution is with the targeted compiler. The
 # Generic dependency also appears, coming from the dep_generic crate
-match_solution("gnat=" + e("2.0.0 (gnat_native) (installed)") + ".*" +
-               "gnat_native=" + e("2.0.0 (installed)") + ".*")
+match_solution("gnat=" + e("8888.0.0 (gnat_native) (installed)") + ".*" +
+               "gnat_native=" + e("8888.0.0 (installed)") + ".*")
 
 # Last combination is targeted x targeted
 os.chdir("..")
@@ -80,7 +79,7 @@ alr_with("gnat_native")
 
 # In this case the only possible solution is with the targeted compiler. The
 # generic dependency no longer exists, as nobody requested a generic gnat.
-match_solution("gnat_native=" + e("2.0.0 (installed)") + ".*")
+match_solution("gnat_native=" + e("8888.0.0 (installed)") + ".*")
 p = run_alr("with", "--solve")
 assert "gnat=" not in p.out, "Unexpected output"
 

--- a/testsuite/tests/solver/compiler-priorities/test.py
+++ b/testsuite/tests/solver/compiler-priorities/test.py
@@ -27,7 +27,7 @@ assert_match(".*\n"  # Headers
              p.out)
 
 # Capture version
-version = re.search("[0-9.]+", p.out, re.MULTILINE).group()
+version = re.search("gnat_external ([0-9.]+)", p.out, re.MULTILINE).group(1)
 
 # When no compiler is selected, only the gnat_external one should be used
 # unless a targeted compiler dependency is used
@@ -42,13 +42,13 @@ match_solution(f"gnat={version} (gnat_external) (installed)", escape=True)
 # Check that adding a second dependency on native packaged compiler is honored.
 # Both dependencies should appear in the solution.
 alr_with("gnat_native")
-match_solution("gnat=2.0.0 (gnat_native) (installed)", escape=True)
-match_solution("gnat_native=2.0.0 (installed)", escape=True)
+match_solution("gnat=8888.0.0 (gnat_native) (installed)", escape=True)
+match_solution("gnat_native=8888.0.0 (installed)", escape=True)
 
 # The previous dependency also should have caused the installation of the
 # native compiler as an available compiler, which we will check:
 p = run_alr("toolchain")
-assert_match(".*gnat_native.*2.0.0.*Available.*",
+assert_match(".*gnat_native.*8888.0.0.*Available.*",
              p.out)
 
 # Move to a new crate
@@ -69,16 +69,16 @@ assert_match(".*gnat_cross_1.*9999.*Available.*",
 alr_with("gnat")
 match_solution(f"gnat={version} (gnat_external) (installed)", escape=True)
 
-# Depend on any gnat but the externally available. Since we have gnat_native=2
+# Depend on any gnat but the externally available. Since we have gnat_native=8888
 # and gnat_cross_1=9999, normal version comparison would select the cross
 # compiler, but native compilers take precedence. So the solution should
 # match v2.
 alr_with("gnat", delete=True, manual=False)
 alr_with(f"gnat/={version}")
-match_solution("gnat=2.0.0 (gnat_native)", escape=True)
+match_solution("gnat=8888.0.0 (gnat_native)", escape=True)
 
 # If we uninstall the native compiler, the cross compiler will be preferred now
-run_alr("toolchain", "--uninstall", "gnat_native=2")
+run_alr("toolchain", "--uninstall", "gnat_native=8888")
 
 run_alr("update")
 match_solution("gnat=9999.0.0 (gnat_cross_1)", escape=True)
@@ -86,10 +86,10 @@ match_solution("gnat=9999.0.0 (gnat_cross_1)", escape=True)
 # Let's reinstall the newest native compiler and verify the previous situation
 run_alr("toolchain", "--install", "gnat_native")
 p = run_alr("toolchain")
-assert_match(".*gnat_native.*2.0.0.*Available.*",
+assert_match(".*gnat_native.*8888.0.0.*Available.*",
              p.out)
 run_alr("update")
-match_solution("gnat=2.0.0 (gnat_native)", escape=True)
+match_solution("gnat=8888.0.0 (gnat_native)", escape=True)
 
 # We can force the use of the cross-compiler by selecting it as default:
 run_alr("config", "--global",

--- a/testsuite/tests/solver/compiler-selected/test.py
+++ b/testsuite/tests/solver/compiler-selected/test.py
@@ -18,7 +18,7 @@ init_local_crate("xxx")
 alr_with("gnat*")
 
 # Will appear in the solution as generic fulfilled by the preferred compiler
-match_solution("gnat=2.0.0 (gnat_native) (installed)", escape=True)
+match_solution("gnat=8888.0.0 (gnat_native) (installed)", escape=True)
 
 # Selecting another default will cause a corresponding change in the solution
 run_alr("config", "--set", "toolchain.use.gnat", "gnat_cross_2=1")

--- a/testsuite/tests/toolchain/bad-switches/test.py
+++ b/testsuite/tests/toolchain/bad-switches/test.py
@@ -14,6 +14,12 @@ assert p.status != 0, "Call should have failed"
 p = run_alr("toolchain", "--select", "--uninstall", complain_on_error=False)
 assert p.status != 0, "Call should have failed"
 
+p = run_alr("toolchain", "--select", "--install-dir", complain_on_error=False)
+assert p.status != 0, "Call should have failed"
+
+p = run_alr("toolchain", "--uninstall", "--install-dir", complain_on_error=False)
+assert p.status != 0, "Call should have failed"
+
 # Bonus: test a proper invocation
 p = run_alr("toolchain")
 

--- a/testsuite/tests/toolchain/basic/test.py
+++ b/testsuite/tests/toolchain/basic/test.py
@@ -8,11 +8,11 @@ from drivers.alr import run_alr
 from drivers.asserts import assert_eq, assert_match
 
 # Install a precise version of gnat
-run_alr("toolchain", "--install", "gnat_native=1")
+run_alr("toolchain", "--install", "gnat_native=7777")
 
 # Verify that it appears as available
 p = run_alr("toolchain")
-assert_match(".*gnat_native.*" + re.escape("1.0.0") + ".*Available",
+assert_match(".*gnat_native.*" + re.escape("7777.0.0") + ".*Available",
              p.out)
 
 # Also that the external compiler is detected and always available
@@ -24,20 +24,20 @@ assert_match(".*Only regular releases deployed through Alire can be removed.*",
              p.out)
 
 # Verify that it can be uninstalled
-run_alr("toolchain", "--uninstall", "gnat_native=1")
+run_alr("toolchain", "--uninstall", "gnat_native=7777")
 p = run_alr("toolchain")
 assert "gnat_native" not in p.out, "Unexpected output"
 
 # Repeat install but without giving a version, and one should be autoidentified
 # as the newest available version
 p = run_alr("toolchain", "-i", "gnat_native", quiet=False)  # Test short switch
-assert_match(".*Requested crate resolved as gnat_native=2.0.0.*",
+assert_match(".*Requested crate resolved as gnat_native=8888.0.0.*",
              p.out)
 
 # Verify that we can explicitly install a second version for the same target
-run_alr("toolchain", "--install", "gnat_native=1")
+run_alr("toolchain", "--install", "gnat_native=7777")
 p = run_alr("toolchain")
-assert_match(".*gnat_native.*" + re.escape("1.0.0") + ".*Available",
+assert_match(".*gnat_native.*" + re.escape("7777.0.0") + ".*Available",
              p.out)
 
 # Verify that uninstalling without specifying version isn't allowed when there
@@ -48,8 +48,21 @@ assert_match(".*Requested crate has several installed releases.*",
              p.out)
 
 # Uninstall successfully by giving a version
-run_alr("toolchain", "--uninstall", "gnat_native=2")
+run_alr("toolchain", "--uninstall", "gnat_native=8888")
 # Now we can uninstall without specifying the version of the remaining release
 run_alr("toolchain", "--uninstall", "gnat_native")
+
+
+# Verify that two components can be installed at once
+run_alr("toolchain", "--install", "gnat_native", "gnat_cross_1")
+p = run_alr("toolchain")
+assert_match(".*gnat_native.*" + re.escape("8888.0.0") + ".*Available",
+             p.out)
+assert_match(".*gnat_cross_1.*" + re.escape("9999.0.0") + ".*Available",
+             p.out)
+
+# Uninstall both components
+run_alr("toolchain", "--uninstall", "gnat_native", "gnat_cross_1")
+
 
 print('SUCCESS')

--- a/testsuite/tests/toolchain/custom_install_dir/test.py
+++ b/testsuite/tests/toolchain/custom_install_dir/test.py
@@ -9,16 +9,16 @@ from drivers.alr import run_alr, init_local_crate, alr_with
 from drivers.asserts import assert_eq, assert_match, match_solution
 from drivers.helpers import contents
 
-install_dir = os.path.join (os.getcwd(), "custom_install")
-install_dir_2 = os.path.join (os.getcwd(), "custom_install_2")
+install_dir = os.path.join (os.getcwd(), "custom_install").replace("\\", "/")
+install_dir_2 = os.path.join (os.getcwd(), "custom_install").replace("\\", "/")
 
 
 unk_re = "[0-9]+\.[0-9]+\.[0-9]+_[0-9a-f]{8}"  # Unknown version + Unknown hash
 def config_path_re(crate):
     return re.escape(f"{install_dir}/{crate}_") + unk_re
 
-def check_content(crate):
-    paths = contents(install_dir, crate)
+def check_content(crate, dir):
+    paths = contents(dir, crate)
     try:
         assert len(paths) >= 1 and \
             re.search(config_path_re(crate), paths[0]), \
@@ -31,14 +31,14 @@ def check_content(crate):
 # First we test installation of one component
 run_alr("toolchain", "--install", "gnat_native", "--install-dir", install_dir)
 
-check_content("gnat_native")
+check_content("gnat_native", install_dir)
 
 
 # We now test installation of two components
 run_alr("toolchain", "--install", "gnat_native", "gnat_cross_1",
-        "--install-dir", install_dir)
+        "--install-dir", install_dir_2)
 
-check_content("gnat_native")
-check_content("gnat_cross_1")
+check_content("gnat_native", install_dir_2)
+check_content("gnat_cross_1", install_dir_2)
 
 print('SUCCESS')

--- a/testsuite/tests/toolchain/custom_install_dir/test.py
+++ b/testsuite/tests/toolchain/custom_install_dir/test.py
@@ -1,0 +1,44 @@
+"""
+Check folders when installing binary compiler crates at a custom location
+"""
+
+import os
+import re
+
+from drivers.alr import run_alr, init_local_crate, alr_with
+from drivers.asserts import assert_eq, assert_match, match_solution
+from drivers.helpers import contents
+
+install_dir = os.path.join (os.getcwd(), "custom_install")
+install_dir_2 = os.path.join (os.getcwd(), "custom_install_2")
+
+
+unk_re = "[0-9]+\.[0-9]+\.[0-9]+_[0-9a-f]{8}"  # Unknown version + Unknown hash
+def config_path_re(crate):
+    return re.escape(f"{install_dir}/{crate}_") + unk_re
+
+def check_content(crate):
+    paths = contents(install_dir, crate)
+    try:
+        assert len(paths) >= 1 and \
+            re.search(config_path_re(crate), paths[0]), \
+            "Unexpected contents: " + str(paths)
+    except:
+        print(f"erroneous regex was: {config_path_re(crate)}")
+        print(f"erroneous path was: {paths[0]}")
+        raise
+
+# First we test installation of one component
+run_alr("toolchain", "--install", "gnat_native", "--install-dir", install_dir)
+
+check_content("gnat_native")
+
+
+# We now test installation of two components
+run_alr("toolchain", "--install", "gnat_native", "gnat_cross_1",
+        "--install-dir", install_dir)
+
+check_content("gnat_native")
+check_content("gnat_cross_1")
+
+print('SUCCESS')

--- a/testsuite/tests/toolchain/custom_install_dir/test.yaml
+++ b/testsuite/tests/toolchain/custom_install_dir/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    toolchain_index:
+        in_fixtures: true

--- a/testsuite/tests/toolchain/select/test.py
+++ b/testsuite/tests/toolchain/select/test.py
@@ -9,30 +9,33 @@ import subprocess
 from drivers.alr import run_alr, init_local_crate
 from drivers.asserts import assert_eq, assert_match
 
+p = run_alr("index")
+print(p.out)
+
 # Activate the default compiler
 p = run_alr("toolchain", "--select")
 
 # Check that the newest native compiler is the Default now (vs Available)
 p = run_alr("toolchain")
-assert_match(".*gnat_native.*" + re.escape("2.0.0") + ".*Default.*",
+assert_match(".*gnat_native.*" + re.escape("8888.0.0") + ".*Default.*",
              p.out)
 
 # Select an older compiler as default
-run_alr("toolchain", "--select", "gnat_native=1")
+run_alr("toolchain", "--select", "gnat_native=7777")
 p = run_alr("toolchain")
-assert_match(".*gnat_native.*" + re.escape("1.0.0") + ".*Default.*",
+assert_match(".*gnat_native.*" + re.escape("7777.0.0") + ".*Default.*",
              p.out)
 
 # Test local selection by configuring locally inside a crate
 init_local_crate()
-run_alr("toolchain", "--select", "gnat_native=2", "--local")
+run_alr("toolchain", "--select", "gnat_native=8888", "--local")
 p = run_alr("toolchain")
-assert_match(".*gnat_native.*" + re.escape("2.0.0") + ".*Default.*",
+assert_match(".*gnat_native.*" + re.escape("8888.0.0") + ".*Default.*",
              p.out)
 # And check that outside the global selection is still in effect
 os.chdir("..")
 p = run_alr("toolchain")
-assert_match(".*gnat_native.*" + re.escape("1.0.0") + ".*Default.*",
+assert_match(".*gnat_native.*" + re.escape("7777.0.0") + ".*Default.*",
              p.out)
 
 # I've (mosteo) been unable to connect stdin with an alr launched via #


### PR DESCRIPTION
This patch adds support of multiple components and allows
--disable-assistant with all commands so that it is possible to
configure all the toolchain stuff in one command:
$ alr toolchain --select gnat_native gprbuild --disable-assistant

The patch also introduces a --install-dir switch to allow installation
in any directory. This can be useful for people willing to use the Alire
toolchain outside of an Alire workflow. It would be better if the root
dir of the archive (e.g. gprbuild_21.0.0_349f6f95) was skipped so that
all the tools would be available from <INSTALL_DIR>/bin/.