### PR TITLE
Incremental building of dependencies

### DIFF
--- a/src/alire/alire-os_lib-subprocess.adb
+++ b/src/alire/alire-os_lib-subprocess.adb
@@ -107,7 +107,7 @@ package body Alire.OS_Lib.Subprocess is
       if Exit_Code /= 0 then
          Raise_Checked_Error
            ("Command " & Image (Command, Arguments) &
-              " exited with code" & Exit_Code'Img);
+              " exited with code " & Utils.Trim (Exit_Code'Image));
       end if;
    end Checked_Spawn;
 

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -192,7 +192,7 @@ package body Alire.Releases is
                          This.Milestone.Image);
       else
          Was_There := False;
-         Put_Info ("Deploying release " & This.Milestone.TTY_Image & "...");
+         Put_Info ("Deploying " & This.Milestone.TTY_Image & "...");
          Alire.Origins.Deployers.Deploy (This, Folder).Assert;
 
          --  For deployers that do nothing, we ensure the folder exists so all

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -103,7 +103,21 @@ package body Alire.Roots is
                            (This.Environment, With_Path => True).Length);
             Current : Positive := 1;
          begin
-            if Release.Auto_GPR_With then
+            if not Release.Auto_GPR_With then
+
+               Put_Info (TTY.Bold ("Not") & " pre-building "
+                         & Utils.TTY.Name (Release.Name)
+                         & " (auto with disabled)",
+                         Trace.Detail);
+
+            elsif Release.Executables (This.Environment).Is_Empty then
+
+               Put_Info (TTY.Bold ("Not") & " pre-building "
+                         & Utils.TTY.Name (Release.Name)
+                         & " (no executables declared)",
+                         Trace.Detail);
+
+            else
 
                --  Build all the project files
                for Gpr_File of Release.Project_Files
@@ -124,10 +138,6 @@ package body Alire.Roots is
                   Current := Current + 1;
                end loop;
 
-            else
-               Put_Info (TTY.Bold ("Not") & " building "
-                         & Utils.TTY.Name (Release.Name)
-                         & " (auto with disabled)");
             end if;
 
          exception

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -1,15 +1,17 @@
 with Alire.Conditional;
 with Alire.Crate_Configuration;
 with Alire.Dependencies.Containers;
-with Alire.Dependencies.States;
 with Alire.Directories;
 with Alire.Environment;
+with Alire.Errors;
 with Alire.Manifest;
 with Alire.Origins;
 with Alire.OS_Lib;
+with Alire.Properties.Actions.Executor;
 with Alire.Roots.Optional;
 with Alire.Shared;
 with Alire.Solutions.Diffs;
+with Alire.Spawn;
 with Alire.User_Pins.Maps;
 with Alire.Utils.TTY;
 with Alire.Utils.User_Input;
@@ -25,6 +27,152 @@ package body Alire.Roots is
    package Semver renames Semantic_Versioning;
 
    use type UString;
+
+   -----------
+   -- Build --
+   -----------
+
+   function Build (This             : in out Root;
+                   Scenario         : GPR.Scenario;
+                   Export_Build_Env : Boolean)
+                   return Boolean
+   is
+      Build_Failed : exception;
+
+      --------------------------
+      -- Build_Single_Release --
+      --------------------------
+
+      procedure Build_Single_Release (This     : in out Root;
+                                      Solution : Solutions.Solution;
+                                      State    : Dependencies.States.State)
+      is
+         pragma Unreferenced (Solution);
+
+         --  Relocate to the release folder
+         CD : Directories.Guard
+           (if State.Has_Release and then State.Release.Origin.Is_Regular
+            then Directories.Enter (This.Release_Base (State.Crate))
+            else Directories.Stay) with Unreferenced;
+
+         ---------------------------
+         -- Run_Pre_Build_Actions --
+         ---------------------------
+
+         procedure Run_Pre_Build_Actions (Release : Releases.Release) is
+         begin
+            Alire.Properties.Actions.Executor.Execute_Actions
+              (Release,
+               Env     => This.Environment,
+               Moment  => Alire.Properties.Actions.Pre_Build);
+         exception
+            when E : others =>
+               Trace.Warning ("A pre-build action failed, " &
+                                "re-run with -vv -d for details");
+               Log_Exception (E);
+               raise Build_Failed;
+         end Run_Pre_Build_Actions;
+
+         ----------------------------
+         -- Run_Post_Build_Actions --
+         ----------------------------
+
+         procedure Run_Post_Build_Actions (Release : Releases.Release) is
+         begin
+            Alire.Properties.Actions.Executor.Execute_Actions
+              (Release,
+               Env     => This.Environment,
+               Moment  => Alire.Properties.Actions.Post_Build);
+         exception
+            when E : others =>
+               Trace.Warning ("A post-build action failed, " &
+                                "re-run with -vv -d for details");
+               Log_Exception (E);
+               raise Build_Failed;
+         end Run_Post_Build_Actions;
+
+         -------------------
+         -- Call_Gprbuild --
+         -------------------
+
+         procedure Call_Gprbuild (Release : Releases.Release) is
+            use Directories.Operators;
+            Count : constant Natural :=
+                      Natural
+                        (Release.Project_Files
+                           (This.Environment, With_Path => True).Length);
+            Current : Positive := 1;
+         begin
+            if Release.Auto_GPR_With then
+
+               --  Build all the project files
+               for Gpr_File of Release.Project_Files
+                 (This.Environment, With_Path => True)
+               loop
+                  Put_Info ("Building "
+                            & Utils.TTY.Name (Release.Name) & "/"
+                            & TTY.URL (Gpr_File)
+                            & (if Count > 1
+                              then " (" & Utils.Trim (Current'Image)
+                              & "/" & Utils.Trim (Count'Image) & ")"
+                              else "")
+                            & "...");
+
+                  Spawn.Gprbuild (This.Release_Base (Release.Name) / Gpr_File,
+                                  Extra_Args => Scenario.As_Command_Line);
+
+                  Current := Current + 1;
+               end loop;
+
+            else
+               Put_Info (TTY.Bold ("Not") & " building "
+                         & Utils.TTY.Name (Release.Name)
+                         & " (auto with disabled)");
+            end if;
+
+         exception
+            when E : Alire.Checked_Error =>
+               Trace.Error (Errors.Get (E, Clear => False));
+               Log_Exception (E);
+               raise Build_Failed;
+            when E : others =>
+               Log_Exception (E);
+               raise Build_Failed;
+         end Call_Gprbuild;
+
+      begin
+
+         if not State.Has_Release then
+            Put_Info (State.As_Dependency.TTY_Image & ": no build needed.");
+            return;
+         end if;
+
+         declare
+            Release : constant Releases.Release := State.Release;
+         begin
+
+            Run_Pre_Build_Actions (Release);
+
+            Call_Gprbuild (Release);
+
+            Run_Post_Build_Actions (Release);
+
+         end;
+
+      end Build_Single_Release;
+
+   begin
+      if Export_Build_Env then
+         This.Export_Build_Environment;
+      end if;
+
+      This.Traverse (Build_Single_Release'Access);
+
+      return True;
+   exception
+      when Build_Failed =>
+         return False;
+   end Build;
 
    -------------------
    -- Build_Context --
@@ -1105,5 +1253,34 @@ package body Alire.Roots is
 
       This.Sync_Pins_From_Manifest (Exhaustive => False);
    end Reload_Manifest;
+
+   --------------
+   -- Traverse --
+   --------------
+
+   procedure Traverse
+     (This  : in out Root;
+      Doing : access procedure
+        (This     : in out Root;
+         Solution : Solutions.Solution;
+         State    : Dependencies.States.State))
+   is
+
+      -------------------
+      -- Traverse_Wrap --
+      -------------------
+
+      procedure Traverse_Wrap (Solution : Solutions.Solution;
+                               State    : Dependencies.States.State)
+      is
+      begin
+         Doing (This, Solution, State);
+      end Traverse_Wrap;
+
+   begin
+      This.Solution.Traverse
+        (Traverse_Wrap'Access,
+         Root => Releases.Containers.Optional_Releases.Unit (Release (This)));
+   end Traverse;
 
 end Alire.Roots;

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -102,15 +102,19 @@ package body Alire.Roots is
                         (Release.Project_Files
                            (This.Environment, With_Path => True).Length);
             Current : Positive := 1;
+            Is_Root : constant Boolean :=
+                        Release.Name = This.Release.Constant_Reference.Name;
          begin
-            if not Release.Auto_GPR_With then
+            if not Is_Root and then not Release.Auto_GPR_With then
 
                Put_Info (TTY.Bold ("Not") & " pre-building "
                          & Utils.TTY.Name (Release.Name)
                          & " (auto with disabled)",
                          Trace.Detail);
 
-            elsif Release.Executables (This.Environment).Is_Empty then
+            elsif not Is_Root and then
+              Release.Executables (This.Environment).Is_Empty
+            then
 
                Put_Info (TTY.Bold ("Not") & " pre-building "
                          & Utils.TTY.Name (Release.Name)

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -210,8 +210,10 @@ package Alire.Roots is
                    Scenario         : GPR.Scenario;
                    Export_Build_Env : Boolean)
                    return Boolean;
-   --  Recursively build all dependencies and finally the root release. Return
-   --  True on successful build.
+   --  Recursively build all dependencies that declare executables, and finally
+   --  the root release. Also executes all pre-build/post-build actions for
+   --  all releases in the solution (even those not built). Returns True on
+   --  successful build.
 
    --  Files and folders derived from the root path (this obsoletes Alr.Paths):
 

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -3,6 +3,8 @@ with Ada.Directories;
 private with Ada.Finalization;
 
 with Alire.Containers;
+with Alire.Dependencies.States;
+with Alire.GPR;
 limited with Alire.Environment;
 private with Alire.Lockfiles;
 with Alire.Paths;
@@ -195,6 +197,21 @@ package Alire.Roots is
    --  modification procedures, or somehow outside alire after This was
    --  created, we need to reload the manifest. The solution remains
    --  untouched (use Update to recompute a fresh solution).
+
+   procedure Traverse
+     (This  : in out Root;
+      Doing : access procedure
+        (This     : in out Root;
+         Solution : Solutions.Solution;
+         State    : Dependencies.States.State));
+   --  Recursively visit all dependencies in a safe order, ending with the root
+
+   function Build (This             : in out Root;
+                   Scenario         : GPR.Scenario;
+                   Export_Build_Env : Boolean)
+                   return Boolean;
+   --  Recursively build all dependencies and finally the root release. Return
+   --  True on successful build.
 
    --  Files and folders derived from the root path (this obsoletes Alr.Paths):
 

--- a/src/alire/alire-solver.adb
+++ b/src/alire/alire-solver.adb
@@ -12,7 +12,6 @@ with Alire.Releases.Containers;
 with Alire.Shared;
 with Alire.Root;
 with Alire.Toolchains;
-with Alire.Utils;
 with Alire.Utils.TTY;
 
 with CLIC.User_Input;

--- a/src/alire/alire-spawn.adb
+++ b/src/alire/alire-spawn.adb
@@ -1,8 +1,7 @@
+with Alire_Early_Elaboration;
 with Alire.OS_Lib.Subprocess;
 
-with Alr.Commands;
-
-package body Alr.Spawn is
+package body Alire.Spawn is
 
    -------------
    -- Command --
@@ -14,7 +13,7 @@ package body Alr.Spawn is
    is
       Unused_Output : Alire.Utils.String_Vector;
    begin
-      if Commands.Is_Quiet then
+      if Alire_Early_Elaboration.Switch_Q then
          Unused_Output :=
            Alire.OS_Lib.Subprocess.Checked_Spawn_And_Capture
              (Cmd, Args, Understands_Verbose, Err_To_Out => True);
@@ -51,4 +50,4 @@ package body Alr.Spawn is
                Understands_Verbose => True);
    end Gprbuild;
 
-end Alr.Spawn;
+end Alire.Spawn;

--- a/src/alire/alire-spawn.ads
+++ b/src/alire/alire-spawn.ads
@@ -1,6 +1,6 @@
 with Alire.Utils;
 
-package Alr.Spawn is
+package Alire.Spawn is
 
    --  Encapsulates all external spawns
    --  Any of those may raise Command_Failed or GNAT.OS_Lib exceptions
@@ -20,4 +20,4 @@ package Alr.Spawn is
    --  Out-of-tree build takes place in
    --    $crate / Alire.Paths.Build_Folder ($crate/alire/build).
 
-end Alr.Spawn;
+end Alire.Spawn;

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -1,3 +1,5 @@
+with Stopwatch;
+
 package body Alr.Commands.Build is
 
    -------------
@@ -33,16 +35,21 @@ package body Alr.Commands.Build is
 
       Cmd.Requires_Valid_Session;
 
-      if Cmd.Root.Build (Scenario, Export_Build_Env) then
+      declare
+         Timer : Stopwatch.Instance;
+      begin
+         if Cmd.Root.Build (Scenario, Export_Build_Env) then
 
-         Trace.Detail ("Compilation finished successfully");
-         Trace.Detail ("Use alr run --list to check available executables");
+            Trace.Info ("Build finished successfully in "
+                        & TTY.Bold (Timer.Image) & " seconds.");
+            Trace.Detail ("Use alr run --list to check available executables");
 
-         return True;
+            return True;
 
-      else
-         return False;
-      end if;
+         else
+            return False;
+         end if;
+      end;
 
    end Execute;
 

--- a/src/alr/alr-commands-clean.adb
+++ b/src/alr/alr-commands-clean.adb
@@ -2,11 +2,11 @@ with Ada.Directories;
 
 with Alire.Config.Edit;
 with Alire.Directories;
-with Alire.Paths;
-with Alire.Utils;
 with Alire.GPR;
+with Alire.Paths;
+with Alire.Spawn;
+with Alire.Utils;
 
-with Alr.Spawn;
 with Alr.Platform;
 
 package body Alr.Commands.Clean is
@@ -142,12 +142,12 @@ package body Alr.Commands.Clean is
            (Platform.Properties, With_Path => True)
          loop
 
-            Spawn.Command ("gprclean",
-                           Empty_Vector &
-                             "-r" &
-                             "-P" & Gpr_File &
-                             Scenario.As_Command_Line,
-                           Understands_Verbose => True);
+            Alire.Spawn.Command ("gprclean",
+                                 Empty_Vector &
+                                   "-r" &
+                                   "-P" & Gpr_File &
+                                   Scenario.As_Command_Line,
+                                 Understands_Verbose => True);
          end loop;
 
          return;

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -412,6 +412,9 @@ def add_action(type, command):
     :param str type: "pre-build", etc
     :param list command: array/list of strings that make up the command
     """
+    if not os.path.isfile(alr_manifest()):
+        raise RuntimeError("Manifest not found")
+
     with open(alr_manifest(), "a") as manifest:
         manifest.write("[[actions]]\n")
         manifest.write(f"type = '{type}'\n")

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -404,3 +404,15 @@ def alr_with(dep="", path="", url="", commit="", branch="",
                 args += ["--branch", f"{branch}"]
 
             return run_alr(*args, force=force)
+
+
+def add_action(type, command):
+    """
+    Add an action to the manifest in the current directory.
+    :param str type: "pre-build", etc
+    :param list command: array/list of strings that make up the command
+    """
+    with open(alr_manifest(), "a") as manifest:
+        manifest.write("[[actions]]\n")
+        manifest.write(f"type = '{type}'\n")
+        manifest.write(f"command = {command}\n")

--- a/testsuite/tests/build/incremental/test.py
+++ b/testsuite/tests/build/incremental/test.py
@@ -50,7 +50,7 @@ alr_with("root", path="..")
 
 p = run_alr("build", complain_on_error=False)
 assert p.status != 0, "Command should have failed"
-assert 'Command ["fake_alr_test_exec"] exited with code 1' in p.out, \
+assert 'Command ["fake_alr_test_exec"] exited with code' in p.out, \
     "Output does not contain expected error, but: " + p.out
 
 print('SUCCESS')

--- a/testsuite/tests/build/incremental/test.py
+++ b/testsuite/tests/build/incremental/test.py
@@ -1,0 +1,62 @@
+"""
+Test that a tool built by a dependency is available to a dependent crate
+"""
+
+from drivers.alr import run_alr, init_local_crate, alr_with, alr_manifest
+from drivers.alr import add_action
+from os import chdir
+from os.path import join
+from shutil import rmtree, which
+# from drivers.asserts import assert_eq, assert_match
+
+# We test with a locally pinned dependency, which should make no difference as
+# it is a regular release in the eyes of the build process
+
+init_local_crate("root")
+init_local_crate("depended", binary=True, enter=False)
+
+alr_with("depended", path="depended")
+
+# Add a pre-build action to the root crate that attempts to run bin/depended
+with open(alr_manifest(), "a") as manifest:
+    manifest.writelines(["[[actions]]\n",
+                         "type = 'pre-build'\n",
+                         "command = ['depended/bin/depended']\n"])
+
+run_alr("build")
+
+# Now, add the executable to the path in the depended crate, and an action that
+# uses only the executable name
+
+# First, ensure that a same-name executable isn't in the environment by some
+# bizarre chance
+assert which("depended") is None, "Unexpected 'depended' command in PATH"
+
+chdir("depended")
+with open(alr_manifest(), "a") as manifest:
+    manifest.writelines(["[environment]\n",
+                         "PATH.append = '${CRATE_ROOT}/bin'\n"])
+chdir("..")
+# Clean up a bit just in case
+rmtree("alire")
+rmtree("depended/alire")
+
+with open(alr_manifest(), "a") as manifest:
+    manifest.writelines(["[[actions]]\n",
+                         "type = 'pre-build'\n",
+                         "command = ['depended']\n"])
+
+# Finally verify that a non-existant executable is actually failing. We do this
+# using "root" as an intermediate crate, to ensure that "pre-build" is also
+# being run for all dependencies and not only the root one.
+
+add_action("pre-build", ["fake_alr_test_exec"])
+init_local_crate("root_test")
+alr_with("root", path="..")
+
+p = run_alr("build", complain_on_error=False)
+assert p.status != 0, "Command should have failed"
+assert 'Command ["fake_alr_test_exec"] exited with code 1' in p.out, \
+    "Output does not contain expected error"
+
+print('SUCCESS')

--- a/testsuite/tests/build/incremental/test.yaml
+++ b/testsuite/tests/build/incremental/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    basic_index:
+        in_fixtures: true


### PR DESCRIPTION
Fixes #628 

For context: we want to build dependencies in a safe order, so tools built by a dependency become available down the building chain.

@Fabien-Chouteau , this is istill work in progress, but I've hit a situation. When trying to build `shoot_n_loot` with this patch, it fails because it tries to build the project files in `samd51_hal`. My question would be if this is a problem with our current idea, or with some crate configuration.

Right now, the feature works by trying to build all project files in dependencies that have `auto_gpr_with` enabled.  Perhaps we could restrict it further to crates explicitly declaring executables?