### PR TITLE
Port to `ada_toml` for TOML 1.0

### DIFF
--- a/src/alire/alire-conditional_trees.adb
+++ b/src/alire/alire-conditional_trees.adb
@@ -493,7 +493,7 @@ package body Alire.Conditional_Trees is
          begin
             case Current.Kind is
                when TOML_Table =>
-                  Table.Set (Key, TOML.Merge (Current, Val));
+                  Table.Set (Key, TOML_Adapters.Merge_Tables (Current, Val));
                when TOML_Array =>
                   case Val.Kind is
                      when TOML.Atom_Value_Kind | TOML.TOML_Table =>

--- a/src/alire/alire-dependencies-states-maps.adb
+++ b/src/alire/alire-dependencies-states-maps.adb
@@ -69,7 +69,7 @@ package body Alire.Dependencies.States.Maps is
       --  Stored as an array of individual states:
       --  [[state]]
    begin
-      return Arr : constant TOML_Value := Create_Array (TOML_Table) do
+      return Arr : constant TOML_Value := Create_Array do
          for Dep of This loop
             Arr.Append (Dep.To_TOML);
          end loop;

--- a/src/alire/alire-origins.adb
+++ b/src/alire/alire-origins.adb
@@ -706,11 +706,14 @@ package body Alire.Origins is
                        +(Prefixes (This.Kind).all & (+This.Data.Description)));
 
          when Binary_Archive =>
-            Table := TOML.Merge (Table,
-                                 This.Data.Bin_Archive.As_Data.To_TOML);
+            Table := TOML_Adapters.Merge_Tables
+              (Table,
+               This.Data.Bin_Archive.As_Data.To_TOML);
 
          when Source_Archive =>
-            Table := TOML.Merge (Table, This.Data.Src_Archive.To_TOML);
+            Table := TOML_Adapters.Merge_Tables
+              (Table,
+               This.Data.Src_Archive.To_TOML);
 
          when System =>
             Table.Set (Keys.URL,

--- a/src/alire/alire-properties-configurations.adb
+++ b/src/alire/alire-properties-configurations.adb
@@ -43,14 +43,11 @@ package body Alire.Properties.Configurations is
       Res : Unbounded_String;
       First : Boolean := True;
    begin
-      if Str_Array.Kind /= TOML_Array
-        and then
-         Str_Array.Item_Kind /= TOML_String
-      then
-         raise Program_Error with "Invalid TOML kind for enum values";
-      end if;
-
       for Index in 1 .. Str_Array.Length loop
+         if Str_Array.Item (Index).Kind /= TOML_String then
+            raise Program_Error with "Invalid TOML kind for enum values";
+         end if;
+
          declare
             Val : constant String := Str_Array.Item (Index).As_String;
             Val_Str : constant Unbounded_String := +(if Wrap_With_Quotes
@@ -137,12 +134,8 @@ package body Alire.Properties.Configurations is
             return Image (Val.As_Integer);
 
          when TOML_Array =>
-            if Val.Item_Kind /= TOML_String then
-               Raise_Checked_Error ("Unexpected kind '" & Val.Item_Kind'Img &
-                                      "' in array conversion to String");
-            else
-               return To_String (Val);
-            end if;
+            --  Type of elements is checked inside following call
+            return To_String (Val);
          when others =>
             Raise_Checked_Error ("Unexpected kind '" & Val.Kind'Img &
                                    "' in conversion to String");
@@ -700,10 +693,9 @@ package body Alire.Properties.Configurations is
                when Enum =>
                   if From.Pop ("values", Type_Def.Values) then
                      if Type_Def.Values.Kind /= TOML_Array
-                       or else
-                        not Type_Def.Values.Item_Kind_Set
-                       or else
-                         Type_Def.Values.Item_Kind /= TOML_String
+                       or else Type_Def.Values.Length = 0
+                       or else (for some I in 1 .. Type_Def.Values.Length =>
+                                  Type_Def.Values.Item (I).Kind /= TOML_String)
                      then
                         From.Checked_Error
                           ("'values' must be a not empty array of strings");

--- a/src/alire/alire-properties-scenarios.adb
+++ b/src/alire/alire-properties-scenarios.adb
@@ -49,7 +49,7 @@ package body Alire.Properties.Scenarios is
                         Table.Checked_Error
                           ("At least two values required in scenario");
                      end if;
-                     if Val.Item_Kind = TOML_String then
+                     if Val.Item (1).Kind = TOML_String then
                         declare
                            use GPR;
                            Values : GPR.Value_Vector;
@@ -143,8 +143,7 @@ package body Alire.Properties.Scenarios is
       case V.Var.Element.Kind is
          when Enumeration =>
             declare
-               Arr : constant TOML.TOML_Value :=
-                 TOML.Create_Array (TOML.TOML_String);
+               Arr : constant TOML.TOML_Value := TOML.Create_Array;
             begin
                for Val of V.Var.Element.Values loop
                   Arr.Append (+Val);

--- a/src/alire/alire-properties-scenarios.adb
+++ b/src/alire/alire-properties-scenarios.adb
@@ -49,21 +49,22 @@ package body Alire.Properties.Scenarios is
                         Table.Checked_Error
                           ("At least two values required in scenario");
                      end if;
-                     if Val.Item (1).Kind = TOML_String then
-                        declare
-                           use GPR;
-                           Values : GPR.Value_Vector;
-                        begin
-                           for I in 1 .. Val.Length loop
-                              Values := Values or Val.Item (I).As_String;
-                           end loop;
-                           Props := Props and New_Property
-                             (GPR.Enum_Variable (Key, Values));
-                        end;
-                     else
-                        Table.Checked_Error
-                          ("scenario values must be a string array");
-                     end if;
+
+                     declare
+                        use GPR;
+                        Values : GPR.Value_Vector;
+                     begin
+                        for I in 1 .. Val.Length loop
+                           if Val.Item (I).Kind /= TOML_String then
+                              Table.Checked_Error
+                                ("scenario values must be a string array");
+                           end if;
+
+                           Values := Values or Val.Item (I).As_String;
+                        end loop;
+                        Props := Props and New_Property
+                          (GPR.Enum_Variable (Key, Values));
+                     end;
                   end if;
                end;
             end loop;

--- a/src/alire/alire-toml_adapters.adb
+++ b/src/alire/alire-toml_adapters.adb
@@ -135,6 +135,30 @@ package body Alire.TOML_Adapters is
                      Context : String) return Key_Queue is
      (From (Value, Context));
 
+   ------------------
+   -- Merge_Tables --
+   ------------------
+
+   function Merge_Tables (L, R : TOML.TOML_Value) return TOML.TOML_Value
+   is
+      use TOML;
+      function Merge_Internal (Key  : Unbounded_UTF8_String;
+                      L, R : TOML_Value)
+                      return TOML_Value
+      is
+         pragma Unreferenced (Key);
+      begin
+         if L.Kind = TOML_Table and then R.Kind = L.Kind then
+            return TOML.Merge (L, R, Merge_Internal'Access);
+         else
+            Raise_Checked_Error
+              ("Ill-shaped TOML information cannot be merged");
+         end if;
+      end Merge_Internal;
+   begin
+      return TOML.Merge (L, R, Merge_Entries => Merge_Internal'Access);
+   end Merge_Tables;
+
    ---------
    -- Pop --
    ---------
@@ -374,7 +398,7 @@ package body Alire.TOML_Adapters is
          return V;
       else
          declare
-            Arr : constant TOML_Value := Create_Array (V.Kind);
+            Arr : constant TOML_Value := Create_Array;
          begin
             Arr.Append (V);
             return Arr;

--- a/src/alire/alire-toml_adapters.ads
+++ b/src/alire/alire-toml_adapters.ads
@@ -154,6 +154,10 @@ package Alire.TOML_Adapters with Preelaborate is
        Pre => Val.Kind = TOML.TOML_Array;
    --  Take a TOML value and turn it into a vector of strings
 
+   function Merge_Tables (L, R : TOML.TOML_Value) return TOML.TOML_Value with
+     Pre => L.Kind in TOML.TOML_Table and then R.Kind in TOML.TOML_Table,
+     Post => Merge_Tables'Result.Kind in TOML.TOML_Table;
+
    generic
       type Enum is (<>);
    function Tomify_Enum (E : Enum) return TOML.TOML_Value;


### PR DESCRIPTION
Minor changes to use the new `ada_toml` `Merge` function.

Also, in TOML 1.0 arrays can be heterogeneous, and that also required a few tweaks here and there.