### PR TITLE
Sort releases by version in the assistant

### DIFF
--- a/src/alire/alire-releases-containers.adb
+++ b/src/alire/alire-releases-containers.adb
@@ -1,3 +1,5 @@
+with AAA.Strings;
+
 with Alire.Errors;
 
 with Semantic_Versioning.Extended;
@@ -33,6 +35,21 @@ package body Alire.Releases.Containers is
 
       return Result;
    end Elements_Providing;
+
+   --------------
+   -- From_Set --
+   --------------
+
+   function From_Set (This : Release_Set)
+                      return Release_Set_By_Version.Set
+   is
+   begin
+      return Result : Release_Set_By_Version.Set do
+         for Rel of This loop
+            Result.Insert (Rel);
+         end loop;
+      end return;
+   end From_Set;
 
    ------------
    -- Insert --
@@ -125,6 +142,27 @@ package body Alire.Releases.Containers is
          New_Map.Include (Release.Name, Release);
       end return;
    end Including;
+
+   --------------
+   -- Is_Older --
+   --------------
+
+   function Is_Older (This, Than : Releases.Release) return Boolean
+   is (This.Version < Than.Version
+       or else
+         (This.Version = Than.Version
+          and then This.Version.Build < Than.Version.Build)
+       or else
+         (This.Version = Than.Version
+          and then This.Version.Build = Than.Version.Build
+          and then This.Provides (GNAT_Crate)
+          and then Than.Provides (GNAT_Crate)
+          and then not AAA.Strings.Has_Suffix (This.Name.As_String, "_native")
+          and then AAA.Strings.Has_Suffix (Than.Name.As_String, "_native"))
+       or else
+         (This.Version = Than.Version
+          and then This.Version.Build = Than.Version.Build
+          and then Than.Name < This.Name));
 
    ------------
    -- Remove --

--- a/src/alire/alire-releases-containers.ads
+++ b/src/alire/alire-releases-containers.ads
@@ -19,6 +19,16 @@ package Alire.Releases.Containers is
    type Release_Set is new Release_Sets.Set with null record;
    Empty_Release_Set : constant Release_Set;
 
+   function Is_Older (This, Than : Releases.Release) return Boolean;
+
+   package Release_Set_By_Version
+   is new Ada.Containers.Indefinite_Ordered_Sets (Releases.Release,
+                                                  Is_Older,
+                                                  Releases."=");
+
+   function From_Set (This : Release_Set)
+                      return Release_Set_By_Version.Set;
+
    function Image_One_Line (This : Release_Set) return String;
 
    function Satisfying (This : Release_Set;

--- a/src/alire/alire-toolchains.adb
+++ b/src/alire/alire-toolchains.adb
@@ -100,8 +100,10 @@ package body Alire.Toolchains is
          declare
             First : Boolean := True;
          begin
-            for Release of reverse Index.Releases_Satisfying (Any_Tool (Crate),
-                                                              Env)
+            for Release of reverse
+              Releases.Containers.From_Set -- This sorts by version
+                (Index.Releases_Satisfying (Any_Tool (Crate),
+                 Env))
             loop
                if Release.Origin.Is_Regular then
 
@@ -110,7 +112,7 @@ package body Alire.Toolchains is
                   --  already guarantees that the last compiler in the
                   --  collection will be a native one (if there is one).
 
-                  if First then
+                  if First and then Release.Name.As_String = "gnat_native" then
                      First := False;
                      Add_Choice (Release.Milestone.TTY_Image, Release,
                                  Prepend => True);


### PR DESCRIPTION
I guess it will make more sense as more versions become available to choose from.

Before:
```
  1. gnat_native=11.2.0-1
  2. None
  3. gnat_external=9.3.0 [Detected at /usr/bin/gnat]
  4. gnat_native=10.3.0-1
  5. gnat_arm_elf=11.2.0-1
  6. gnat_arm_elf=10.3.0-1
  7. gnat_riscv64_elf=11.2.0-1
  8. gnat_riscv64_elf=10.3.0-1
```
After:
```
  1. gnat_native=11.2.0-1
  2. None
  3. gnat_external=9.3.0 [Detected at /usr/bin/gnat]
  4. gnat_arm_elf=11.2.0-1
  5. gnat_riscv64_elf=11.2.0-1
  6. gnat_arm_elf=10.3.0-1
  7. gnat_native=10.3.0-1
  8. gnat_riscv64_elf=10.3.0-1
```