### PR TITLE
Revamped `alr version` output

### DIFF
--- a/src/alire/alire-toolchains.ads
+++ b/src/alire/alire-toolchains.ads
@@ -4,7 +4,7 @@ with AAA.Strings;
 
 with Alire.Config;
 with Alire.Dependencies;
-private with Alire.Milestones;
+with Alire.Milestones;
 with Alire.Releases;
 with Alire.Utils;
 with Alire.Utils.TTY;
@@ -37,6 +37,8 @@ package Alire.Toolchains is
    procedure Set_Automatic_Assistant (Enabled : Boolean; Level : Config.Level);
    --  Enable/Disable the automatic assistant on next run
 
+   function Assistant_Enabled return Boolean;
+
    procedure Set_As_Default (Release : Releases.Release; Level : Config.Level);
    --  Mark the given release as the default to be used. Does not check that it
    --  be already installed.
@@ -47,6 +49,10 @@ package Alire.Toolchains is
    function Tool_Dependency (Crate : Crate_Name) return Dependencies.Dependency
      with Pre => Tool_Is_Configured (Crate);
    --  Return the configured compiler as an exact compiler=version dependency
+
+   function Tool_Key (Crate : Crate_Name) return Config.Config_Key;
+
+   function Tool_Milestone (Crate : Crate_Name) return Milestones.Milestone;
 
    function Tool_Release (Crate : Crate_Name) return Releases.Release;
    --  Will raise Checked_Error for unconfigured, or configured but without the
@@ -81,6 +87,13 @@ package Alire.Toolchains is
               & "interactions.");
 
 private
+
+   -----------------------
+   -- Assistant_Enabled --
+   -----------------------
+
+   function Assistant_Enabled return Boolean
+   is (Config.Get (Config.Keys.Toolchain_Assistant, Default => True));
 
    --------------
    -- Tool_Key --

--- a/src/alr/alr-bootstrap.adb
+++ b/src/alr/alr-bootstrap.adb
@@ -1,12 +1,6 @@
-with Ada.Calendar;
-
 with Alire.Directories;
-with Alire_Early_Elaboration;
-with Alire.Index;
-with Alire.Root;
 
 with Alr.OS_Lib;
-with Alr.Utils;
 
 with GNAT.Ctrl_C;
 
@@ -24,22 +18,6 @@ package body Alr.Bootstrap is
 
       OS_Lib.Bailout (1);
    end Interrupted;
-
-   -----------------
-   -- Status_Line --
-   -----------------
-
-   function Status_Line return String is
-      use Ada.Calendar;
-      type Milliseconds is delta 0.001 range 0.0 .. 24.0 * 60.0 * 60.0;
-      Elapsed : constant Duration :=
-        Ada.Calendar.Clock - Alire_Early_Elaboration.Start;
-   begin
-      return
-        "(" & Utils.To_Lower_Case (Alire.Root.Current.Status'Img) & ") (" &
-        Utils.Trim (Alire.Index.Release_Count'Img) & " releases indexed)" &
-        (" (loaded in" & Milliseconds'Image (Milliseconds (Elapsed)) & "s)");
-   end Status_Line;
 
 begin
    GNAT.Ctrl_C.Install_Handler (Interrupted'Access);

--- a/src/alr/alr-bootstrap.ads
+++ b/src/alr/alr-bootstrap.ads
@@ -1,6 +1,5 @@
 package Alr.Bootstrap with Elaborate_Body is
 
-   function Status_Line return String;
-   --  One-liner reporting most interesting information
+   --  Body contains the handler for Ctrl-C
 
 end Alr.Bootstrap;

--- a/src/alr/alr-commands-version.adb
+++ b/src/alr/alr-commands-version.adb
@@ -1,10 +1,11 @@
+with Alire.Config.Edit;
+with Alire.Features.Index;
 with Alire.Index;
 with Alire.Properties;
 with Alire.Roots.Optional;
+with Alire.Utils.Tables;
 
 with Alr.Bootstrap;
-with Alr.Files;
-with Alr.OS_Lib;
 with Alr.Paths;
 
 with GNAT.Compiler_Version;
@@ -24,59 +25,75 @@ package body Alr.Commands.Version is
    procedure Execute (Cmd  : in out Command;
                       Args :        AAA.Strings.Vector)
    is
-      use Ada.Text_IO;
       use all type Alire.Roots.Optional.States;
+      Table : Alire.Utils.Tables.Table;
+      Not_Applicable : constant String := "(N/A)";
+      Index_Outcome : Alire.Outcome;
+      Indexes : constant Alire.Features.Index.Index_On_Disk_Set :=
+                  Alire.Features.Index.Find_All
+                    (Alire.Config.Edit.Indexes_Directory, Index_Outcome);
+      Root : constant Alire.Roots.Optional.Root :=
+               Alire.Roots.Optional.Search_Root (Alire.Directories.Current);
    begin
       if Args.Count /= 0 then
          Reportaise_Wrong_Arguments (Cmd.Name & " doesn't take arguments");
       end if;
 
-      Trace.Always ("Alr version: " & Alire.Version.Current);
-      Trace.Always ("Alire Library version: " & Alire.Version.Current);
-      Trace.Always ("alr status is " & Bootstrap.Status_Line);
-      Trace.Always ("config folder is " & Paths.Alr_Config_Folder);
-      Trace.Always ("source folder is " & Paths.Alr_Source_Folder);
+      Table.Append ("APPLICATION").Append ("").New_Row;
+      Table.Append ("alr version:").Append (Alire.Version.Current).New_Row;
+      Table.Append ("libalire version:")
+        .Append (Alire.Version.Current).New_Row;
+      Table.Append ("compilation date:")
+        .Append (GNAT.Source_Info.Compilation_ISO_Date & " "
+                 & GNAT.Source_Info.Compilation_Time).New_Row;
+      Table.Append ("compiler version:").Append (GNAT_Version.Version).New_Row;
 
-      Trace.Always
-        ("interaction flags are:"
-         & " force:" & Alire.Force'Img
-         & " not-interactive:" & CLIC.User_Input.Not_Interactive'Img);
-
-      case Cmd.Optional_Root.Status is
-         when Outside =>
-            Trace.Always ("alr root is empty");
-         when Broken =>
-            Trace.Always ("alr root has invalid metadata: "
-                          & TTY.Error (Cmd.Optional_Root.Message));
-         when Valid =>
-            Trace.Always ("alr root is " & Cmd.Root.Release.Milestone.Image);
-      end case;
-
-      declare
-         Guard : Folder_Guard (Enter_Working_Folder) with Unreferenced;
-      begin
-         Trace.Always ("alr root detection has settled on path: " &
-                         OS_Lib.Current_Folder);
-         Trace.Always ("alr is finding" & Files.Locate_Any_GPR_File'Img &
-                         " GPR project files");
-         Trace.Always
-           ("alr session state is [" & Cmd.Optional_Root.Status'Img & "]");
-      end;
-
-      Log ("alr compiled on [" &
-             GNAT.Source_Info.Compilation_ISO_Date & " " &
-             GNAT.Source_Info.Compilation_Time & "] with GNAT version [" &
-             GNAT_Version.Version & "]",
-           Always);
-
-      Trace.Always ("platform fingerprint: " & Version.Fingerprint);
-      Put ("platform properties:");
-      for Prop of Platform.Properties loop
-         Put (" " & Prop.Image);
+      Table.Append ("").New_Row;
+      Table.Append ("CONFIGURATION").New_Row;
+      Table.Append ("config folder:").Append (Paths.Alr_Config_Folder).New_Row;
+      Table.Append ("force flag:").Append (Alire.Force'Image).New_Row;
+      Table.Append ("non-interactive flag:")
+        .Append (CLIC.User_Input.Not_Interactive'Image).New_Row;
+      Table.Append ("community index branch:")
+        .Append (Alire.Index.Community_Branch).New_Row;
+      Table.Append ("indexes folder:")
+        .Append (Alire.Config.Edit.Indexes_Directory).New_Row;
+      Table.Append ("indexes metadata:")
+        .Append (if Index_Outcome.Success
+                 then "OK"
+                 else "ERROR: " & Index_Outcome.Message).New_Row;
+      for Index of Indexes loop
+         Table.Append ("index #" & Utils.Trim (Index.Priority'Image) & ":")
+           .Append ("(" & Index.Name & ") " & Index.Origin).New_Row;
       end loop;
-      New_Line;
-      Trace.Always ("community index required branch: "
-                    & Alire.Index.Community_Branch);
+
+      Table.Append ("").New_Row;
+      Table.Append ("WORKSPACE").New_Row;
+
+      Table.Append ("root status:")
+        .Append (Root.Status'Image).New_Row;
+      Table.Append ("root release:")
+        .Append (case Root.Status is
+                    when Valid  => Root.Value.Release.Milestone.Image,
+                    when others => Not_Applicable).New_Row;
+      Table.Append ("root error:")
+        .Append (case Root.Status is
+                    when Broken => Cmd.Optional_Root.Message,
+                    when others => Not_Applicable).New_Row;
+      Table.Append ("root folder:")
+        .Append (case Root.Status is
+                    when Outside => Not_Applicable,
+                    when others  => Root.Value.Path).New_Row;
+      Table.Append ("current folder:").Append (Alire.Directories.Current)
+        .New_Row;
+
+      Table.Append ("").New_Row;
+      Table.Append ("SYSTEM").New_Row;
+      for Prop of Platform.Properties loop
+         Table.Append (Prop.Key & ":").Append (Prop.Image).New_Row;
+      end loop;
+
+      Table.Print (Level => Always);
    end Execute;
 
    ----------------------

--- a/src/alr/alr-commands-version.adb
+++ b/src/alr/alr-commands-version.adb
@@ -71,13 +71,19 @@ package body Alr.Commands.Version is
         .Append (if Alire.Toolchains.Assistant_Enabled
                  then "enabled"
                  else "disabled").New_Row;
-      for Tool of Alire.Toolchains.Tools loop
-         Table
-           .Append (String (Alire.Toolchains.Tool_Key (Tool)) & ":")
-           .Append (if Alire.Toolchains.Tool_Is_Configured (Tool)
-                    then Alire.Toolchains.Tool_Milestone (Tool).Image
-                    else "not configured").New_Row;
-      end loop;
+      declare
+         I : Positive := 1;
+      begin
+         for Tool of Alire.Toolchains.Tools loop
+            Table
+              .Append ("tool #" & Utils.Trim (I'Image)
+                       & " " & Tool.As_String & ":")
+              .Append (if Alire.Toolchains.Tool_Is_Configured (Tool)
+                       then Alire.Toolchains.Tool_Milestone (Tool).Image
+                       else "not configured").New_Row;
+            I := I + 1;
+         end loop;
+      end;
 
       Table.Append ("").New_Row;
       Table.Append ("WORKSPACE").New_Row;
@@ -88,7 +94,7 @@ package body Alr.Commands.Version is
         .Append (case Root.Status is
                     when Valid  => Root.Value.Release.Milestone.Image,
                     when others => "N/A").New_Row;
-      Table.Append ("root error:")
+      Table.Append ("root load error:")
         .Append (case Root.Status is
                     when Broken  => Cmd.Optional_Root.Message,
                     when Valid   => "none",

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -256,7 +256,7 @@ package body Alr.Commands is
       --  user for its preference at this time.
 
       if Cmd not in Commands.Toolchain.Command'Class and then
-        Conf.Get (Conf.Keys.Toolchain_Assistant, Default => True)
+        Alire.Toolchains.Assistant_Enabled
       then
          Cmd.Requires_Full_Index;
          Alire.Toolchains.Assistant (Conf.Global);

--- a/src/alr/alr-main.adb
+++ b/src/alr/alr-main.adb
@@ -2,7 +2,6 @@ with Alire;
 with Alire_Early_Elaboration; pragma Elaborate_All (Alire_Early_Elaboration);
 with Alire.Root;
 
-with Alr.Bootstrap;
 with Alr.Commands;
 with Alr.Last_Chance_Handler;
 with Alr.Platform.Init;
@@ -22,6 +21,8 @@ begin
    --  type to shared specification. All of this should be done on Issue #335.
 
    Alire.Root.Set_Platform_Properties (Alr.Platform.Properties);
+
+   Trace.Debug ("alr platform configured");
 
    Commands.Execute;
 exception

--- a/src/alr/alr-main.adb
+++ b/src/alr/alr-main.adb
@@ -23,8 +23,6 @@ begin
 
    Alire.Root.Set_Platform_Properties (Alr.Platform.Properties);
 
-   Trace.Detail ("alr build is " & Bootstrap.Status_Line);
-
    Commands.Execute;
 exception
    when E : others =>

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -23,7 +23,7 @@ class CalledProcessError(Exception):
 
 def distro_is_known():
     p = run_alr('version')
-    return not re.match('.*platform properties:.*DISTRO_UNKNOWN.*',
+    return not re.match('.*distribution:.*DISTRO_UNKNOWN.*',
                         p.out, flags=re.S)
 
 

--- a/testsuite/tests/misc/force-switch/test.py
+++ b/testsuite/tests/misc/force-switch/test.py
@@ -7,11 +7,10 @@ from drivers.asserts import assert_match
 
 import re
 
-assert_match('.*interaction flags are:.*force:TRUE.*',
-             run_alr('version', '--force').out,
-             flags=re.S)
+assert_match('.*force flag:[\s]+TRUE.*',
+             run_alr('version', '--force').out)
 
-assert_match('.*interaction flags are:.*force:TRUE.*',
+assert_match('.*force flag:[\s]+TRUE',
              run_alr('version', '-f').out,
              flags=re.S)
 

--- a/testsuite/tests/toolchain/directories/test.py
+++ b/testsuite/tests/toolchain/directories/test.py
@@ -11,9 +11,10 @@ from drivers.helpers import contents
 
 # Identify config location
 p = run_alr("version")
-config_dir = re.search("config folder is ([^\n.]*)", p.out).group(1)
+config_dir = re.search("config folder:([^\n]*)", p.out).group(1).strip()
 config_dir = config_dir.replace("\\", "/")
 cache_dir = os.path.join(config_dir, "cache")
+
 # The 'contents` function we use to compare these strings normalizes all paths
 # to forward slashes, so we do the same with the config_dir
 

--- a/testsuite/tests/version/inside-outside/test.py
+++ b/testsuite/tests/version/inside-outside/test.py
@@ -1,0 +1,24 @@
+"""
+Verify that `alr version` works without error without, with and with broken
+manifest
+"""
+
+from drivers.alr import run_alr, init_local_crate, alr_manifest
+from drivers.asserts import assert_eq, assert_match
+
+# Run in several situations with minimal double-check
+
+p = run_alr("version")
+assert_match(".*root status:.*OUTSIDE", p.out)
+
+init_local_crate()
+p = run_alr("version")
+assert_match(".*root status:.*VALID", p.out)
+
+# break the manifest
+with open(alr_manifest(), "a") as manifest:
+    manifest.write("not valid TOML methinks...")
+p = run_alr("version")
+assert_match(".*root status:.*BROKEN", p.out)
+
+print('SUCCESS')

--- a/testsuite/tests/version/inside-outside/test.yaml
+++ b/testsuite/tests/version/inside-outside/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
Fixes #833
Fixes #607 (but for the `alr --version` flag, which I guess will be simpler to do with aliases)

Example of the new output:
```console
$ alr version
APPLICATION                                                                                   
alr version:            1.1.0-rc3                                                             
libalire version:       1.1.0-rc3                                                             
compilation date:       2021-09-16 12:15:56                                                   
compiler version:       Community 2021 (20210519-103)                                         
                       
CONFIGURATION          
config folder:          /home/jano/.config/alire                                              
force flag:             FALSE                                                                 
non-interactive flag:   FALSE                                                                 
community index branch: devel-1.1                                                             
indexes folder:         /home/jano/.config/alire/indexes                                      
indexes metadata:       OK                                                                    
index #1:               (community) git+https://github.com/alire-project/alire-index#devel-1.1
toolchain assistant:    disabled                                                              
tool #1 gnat:           gnat_external=2021.0.0                                                
tool #2 gprbuild:       not configured                                                        
                       
WORKSPACE              
root status:            VALID                                                                 
root release:           alr=1.1.0-dev                                                         
root load error:        none                                                                  
root folder:            /home/jano/prog/alire                                                 
current folder:         /home/jano/prog/alire/testsuite                                       
                       
SYSTEM                 
distribution:           UBUNTU                                                                
os:                     LINUX                                                                 
target:                 NATIVE                                                                
toolchain:              USER                                                                  
word-size:              BITS_64
```