### PR TITLE
Don't err when unsetting a non-existing config key

### DIFF
--- a/src/alire/alire-shared.adb
+++ b/src/alire/alire-shared.adb
@@ -213,8 +213,12 @@ package body Alire.Shared is
          Put_Warning ("Removing it anyway; it will be also removed from the "
                       & "default toolchain.");
 
-         --  So remove it
-         Toolchains.Unconfigure (Release.Name);
+         --  So remove it at any level. We currently do not have a way to know
+         --  from which level we have to remove this configuration.
+         Toolchains.Unconfigure (Release.Name, Config.Global,
+                                 Fail_If_Unset => False);
+         Toolchains.Unconfigure (Release.Name, Config.Local,
+                                 Fail_If_Unset => False);
       end if;
 
       if not Confirm or else Query

--- a/src/alire/alire-toolchains.adb
+++ b/src/alire/alire-toolchains.adb
@@ -217,12 +217,8 @@ package body Alire.Toolchains is
 
             --  Clean up stored version
 
-            if not CLIC.Config.Edit.Unset
-              (Path  => Config.Edit.Filepath (Level),
-               Key   => Tool_Key (Crate))
-            then
-               Raise_Checked_Error ("Cannot unset config key");
-            end if;
+            Unconfigure (Crate, Level);
+
          else
 
             Put_Info
@@ -393,16 +389,27 @@ package body Alire.Toolchains is
    -- Unconfigure --
    -----------------
 
-   procedure Unconfigure (Crate : Crate_Name) is
+   procedure Unconfigure (Crate         : Crate_Name;
+                          Level         : Config.Level;
+                          Fail_If_Unset : Boolean := True) is
    begin
-      for Level in Config.Level loop
-         if not CLIC.Config.Edit.Unset
-           (Config.Edit.Filepath (Level),
-            Tool_Key (Crate))
-         then
-            Raise_Checked_Error ("Cannot unset config key");
-         end if;
-      end loop;
+      if CLIC.Config.Defined (Config.DB, Tool_Key (Crate)) and then
+        not CLIC.Config.Edit.Unset
+          (Config.Edit.Filepath (Level),
+           Tool_Key (Crate))
+      then
+         declare
+            Msg : constant String :=
+                    "Cannot unset config key " & Tool_Key (Crate)
+                  & " at config level " & Level'Image;
+         begin
+            if Fail_If_Unset then
+               Raise_Checked_Error (Msg);
+            else
+               Trace.Debug (Msg);
+            end if;
+         end;
+      end if;
    end Unconfigure;
 
 end Alire.Toolchains;

--- a/src/alire/alire-toolchains.ads
+++ b/src/alire/alire-toolchains.ads
@@ -61,8 +61,10 @@ package Alire.Toolchains is
    --  release being deployed (e.g. the user messed with files and deleted it
    --  manually).
 
-   procedure Unconfigure (Crate : Crate_Name);
-   --  Set the crate as not configured.
+   procedure Unconfigure (Crate         : Crate_Name;
+                          Level         : Config.Level;
+                          Fail_If_Unset : Boolean := True);
+   --  Set the crate as not configured. If not set and Fail_If_Unset, raise
 
    Description : constant AAA.Strings.Vector
      := AAA.Strings.Empty_Vector

--- a/src/alr/alr-commands-config.adb
+++ b/src/alr/alr-commands-config.adb
@@ -120,7 +120,7 @@ package body Alr.Commands.Config is
             Key : constant String := Args.Element (1);
          begin
             if not CLIC.Config.Is_Valid_Config_Key (Key) then
-               Reportaise_Wrong_Arguments ("Invalid configration key '" &
+               Reportaise_Wrong_Arguments ("Invalid configuration key '" &
                  Key & "'");
             end if;
 


### PR DESCRIPTION
Fixes #880.

I don't know how to test this as my attempts at passing input to the assistant menu in Python have failed (here: https://github.com/alire-project/alire/blob/df0366acdf4bf4a685be6cfaf0e438c1ac4ba44c/testsuite/tests/toolchain/select/test.py#L41)