### PR TITLE
Bump version for 1.1.2 maintenance release

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,7 +1,7 @@
 name = "alr"
 description = "Command-line tool from the Alire project"
 
-version = "1.1.0-dev"
+version = "1.1.2"
 
 authors = ["Alejandro R. Mosteo", "Fabien Chouteau", "Pierre-Marie de Rodat"]
 maintainers = ["alejandro@mosteo.com", "chouteau@adacore.com"]
@@ -19,12 +19,14 @@ aaa = "~0.2.3"
 ada_toml = "~0.1"
 ajunitgen = "^1.0.1"
 ansiada = "~0.1"
+clic = "~0.1.1"
 gnatcoll = "^21"
 minirest = "~0.2"
 optional = "~0.0.0"
 semantic_versioning = "^2"
 simple_logging = "^1.2"
 si_units = "~0.2"
+stopwatch = "~0.1"
 toml_slicer = "~0.1"
 uri_ada = "^1"
 spdx = "~0.2"
@@ -35,7 +37,7 @@ macos   = { OS = "macOS" }
 
 # Most dependencies require precise versions during the development cycle:
 [[pins]]
-ada_toml = { url = "https://github.com/pmderodat/ada-toml.git", commit = "ade3cc905cef405dbf53e16a54f6fb458482710f" }
+ada_toml = { url = "https://github.com/mosteo/ada-toml.git", commit = "ff7a848dff4c061e5fc6199665effb76a0e09f68" }
 ajunitgen = { url = "https://github.com/mosteo/ajunitgen.git", commit = "e5d01db5e7834d15c4066f0a8e33d780deae3cc9" }
 ansiada = { url = "https://github.com/mosteo/ansi-ada.git", commit = "acf9afca3afe1f8b8843c061f3cef860d7567307" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "f3bd1c51d12962879f52733e790b394f5bbfe05f" }
@@ -43,5 +45,6 @@ minirest = { url = "https://github.com/mosteo/minirest.git", commit = "4550aa356
 optional = { url = "https://github.com/mosteo/optional.git", commit = "0c7d20c0c8b48ccb6b25fb648d48382e598c25c3" }
 semantic_versioning = { url = "https://github.com/alire-project/semantic_versioning.git", commit = "fe4e72e40786589a66d53662639f894fcdb3419c" }
 simple_logging = { url = "https://github.com/alire-project/simple_logging.git", commit = "02a7de7568af6af7cedd1048901fae8e9477b1d9" }
+stopwatch = {url = "https://github.com/mosteo/stopwatch.git", commit = "b43f3e6e6fdc8ed5d36c30d1ce57738989a45977"}
 toml_slicer = { url = "https://github.com/mosteo/toml_slicer.git", commit = "1c0286bd724c6f257a36fc89412fcefd4f555228" }
 uri_ada = { url = "https://github.com/mosteo/uri-ada.git", commit = "b61eba59099b3ab39e59e228fe4529927f9e849e" }

--- a/src/alire/alire-version.ads
+++ b/src/alire/alire-version.ads
@@ -2,7 +2,8 @@ package Alire.Version with Preelaborate is
 
    --  Remember to update Alire.Index branch if needed too
 
-   Current : constant String := "1.1.1";
+   Current : constant String := "1.1.2";
+   --  1.1.2:     latest msys2 and ensure it's fully updated
    --  1.1.1:     fixes in #862 #866 #875 #876
    --  1.1.0:     toolchain compatibility checks
    --  1.1.0-rc3: toolchain with multiple switches, minor fixes


### PR DESCRIPTION
Also update to alire.toml to allow a successful self-build