### PR TITLE
New property for detected host architecture

### DIFF
--- a/alr_env.gpr
+++ b/alr_env.gpr
@@ -7,18 +7,19 @@ aggregate project Alr_Env is
                          "deps/ada-toml",
                          "deps/ajunitgen",
                          "deps/ansi",
+                         "deps/clic",
                          "deps/gnatcoll-slim",
                          "deps/minirest",
                          "deps/optional",
                          "deps/semantic_versioning",
-                         "deps/simple_logging",
                          "deps/si_units",
+                         "deps/simple_logging",
+                         "deps/spdx",
                          "deps/stopwatch",
                          "deps/toml_slicer",
                          "deps/uri-ada",
-                         "deps/xmlezout",
-                         "deps/spdx",
-                         "deps/clic");
+                         "deps/xmlezout"
+                        );
 
    for Project_Files use ("alr.gpr");
 

--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -223,7 +223,7 @@ package body Alire.Directories is
    begin
       if Exists (Path) and then
         Kind (Path) = Directory and then
-        Platforms.Current.On_Windows
+        Platforms.Current.Operating_System in Platforms.Windows
       then
          Trace.Debug ("Forcing writability of dir " & Path);
          OS_Lib.Subprocess.Checked_Spawn

--- a/src/alire/alire-platforms-common.adb
+++ b/src/alire/alire-platforms-common.adb
@@ -1,0 +1,54 @@
+with AAA.Enum_Tools;
+
+with Alire.OS_Lib.Subprocess;
+
+package body Alire.Platforms.Common is
+
+   Arch_Detected : Boolean       := False;
+   Arch_Value    : Architectures := Architecture_Unknown;
+
+   ---------------------------
+   -- Machine_Hardware_Name --
+   ---------------------------
+
+   function Machine_Hardware_Name return Architectures is
+   begin
+      if Arch_Detected then
+         return Arch_Value;
+      end if;
+
+      Detect : declare
+         function Is_Known_Arch is new AAA.Enum_Tools.Is_Valid (Architectures);
+
+         Output : AAA.Strings.Vector;
+
+         --  uname is part of coreutils, so it should be available in
+         --  linuxes/msys2.
+
+         Code   : constant Integer :=
+                    OS_Lib.Subprocess.Unchecked_Spawn_And_Capture
+                      (Command             => "uname",
+                       Arguments           => AAA.Strings.To_Vector ("-m"),
+                       Output              => Output);
+
+         Name   : constant String := Output.Flatten;
+      begin
+         Arch_Detected := True;
+
+         if Code /= 0 then
+            Trace.Debug ("uname failed with code: "
+                         & AAA.Strings.Trim (Code'Image));
+         else
+            if Is_Known_Arch (Name) then
+               Trace.Debug ("uname known machine string is: " & Name);
+               Arch_Value := Architectures'Value (Name);
+            else
+               Trace.Debug ("uname unknown machine string is: " & Name);
+            end if;
+         end if;
+
+         return Arch_Value;
+      end Detect;
+   end Machine_Hardware_Name;
+
+end Alire.Platforms.Common;

--- a/src/alire/alire-platforms-common.adb
+++ b/src/alire/alire-platforms-common.adb
@@ -2,6 +2,8 @@ with AAA.Enum_Tools;
 
 with Alire.OS_Lib.Subprocess;
 
+with System;
+
 package body Alire.Platforms.Common is
 
    Arch_Detected : Boolean       := False;
@@ -16,6 +18,22 @@ package body Alire.Platforms.Common is
       if Arch_Detected then
          return Arch_Value;
       end if;
+
+      --  Custom detection for Windows without requiring msys2
+
+      if On_Windows then
+         Arch_Detected := True;
+         case Standard.System.Word_Size is
+            when 64 =>
+               Arch_Value := X86_64;
+            when others =>
+               Arch_Value := Architecture_Unknown;
+         end case;
+
+         return Arch_Value;
+      end if;
+
+      --  Detection in unix-like platforms
 
       Detect : declare
          function Is_Known_Arch is new AAA.Enum_Tools.Is_Valid (Architectures);

--- a/src/alire/alire-platforms-common.ads
+++ b/src/alire/alire-platforms-common.ads
@@ -1,5 +1,7 @@
 with Alire.OS_Lib;
 
+private with GNATCOLL.OS.Constants;
+
 private package Alire.Platforms.Common is
 
    --  Reusable code from both Linux/macOS or other several OSes. Intended for
@@ -9,6 +11,9 @@ private package Alire.Platforms.Common is
 
    function Machine_Hardware_Name return Architectures;
    --  As reported by uname, already turned into our architecture enum
+
+   function On_Windows return Boolean;
+   --  Says if we are on Windows
 
    ----------------------
    -- XDG_Cache_Folder --
@@ -29,5 +34,16 @@ private package Alire.Platforms.Common is
          ("XDG_CONFIG_HOME",
           Default => OS_Lib.Getenv ("HOME", Default => "/tmp") / ".config")
        / "alire");
+
+private
+
+   ----------------
+   -- On_Windows --
+   ----------------
+
+   pragma Warnings (Off, "condition is always"); -- Silence warning of OS check
+   function On_Windows return Boolean
+   is (GNATCOLL.OS.Constants.OS in GNATCOLL.OS.Windows);
+   pragma Warnings (On);
 
 end Alire.Platforms.Common;

--- a/src/alire/alire-platforms-common.ads
+++ b/src/alire/alire-platforms-common.ads
@@ -7,6 +7,9 @@ private package Alire.Platforms.Common is
 
    use OS_Lib.Operators; -- Bring in "/" for paths
 
+   function Machine_Hardware_Name return Architectures;
+   --  As reported by uname, already turned into our architecture enum
+
    ----------------------
    -- XDG_Cache_Folder --
    ----------------------

--- a/src/alire/alire-platforms-current.ads
+++ b/src/alire/alire-platforms-current.ads
@@ -4,8 +4,6 @@ private with Alire.Platforms.Common;
 with Alire.Properties;
 private with Alire.Properties.Platform;
 
-private with GNATCOLL.OS.Constants;
-
 private with System;
 
 package Alire.Platforms.Current is
@@ -62,10 +60,6 @@ package Alire.Platforms.Current is
 
    function Host_Architecture return Platforms.Architectures;
 
-   function On_Windows return Boolean;
-   --  Say if we are on Windows, until the OS detection is moved here from
-   --  Alr.Platform.
-
    function Target return Platforms.Targets;
 
    function Toolchain return Platforms.Toolchains;
@@ -93,15 +87,6 @@ private
 
    function Host_Architecture return Platforms.Architectures
    renames Common.Machine_Hardware_Name;
-
-   ----------------
-   -- On_Windows --
-   ----------------
-
-   pragma Warnings (Off, "condition is always"); -- Silence warning of OS check
-   function On_Windows return Boolean
-   is (GNATCOLL.OS.Constants.OS in GNATCOLL.OS.Windows);
-   pragma Warnings (On);
 
    ----------------
    -- Properties --

--- a/src/alire/alire-platforms-current.ads
+++ b/src/alire/alire-platforms-current.ads
@@ -1,6 +1,6 @@
 limited with Alire.Environment;
 private with Alire.OS_Lib.Subprocess;
-with Alire.Platforms;
+private with Alire.Platforms.Common;
 with Alire.Properties;
 private with Alire.Properties.Platform;
 
@@ -60,6 +60,8 @@ package Alire.Platforms.Current is
    function Distribution_Is_Known return Boolean is
      (Platforms."/=" (Distribution, Platforms.Distro_Unknown));
 
+   function Host_Architecture return Platforms.Architectures;
+
    function On_Windows return Boolean;
    --  Say if we are on Windows, until the OS detection is moved here from
    --  Alr.Platform.
@@ -85,6 +87,13 @@ private
        then Platforms.Distro_Unknown
        else Detected_Distribution);
 
+   -----------------------
+   -- Host_Architecture --
+   -----------------------
+
+   function Host_Architecture return Platforms.Architectures
+   renames Common.Machine_Hardware_Name;
+
    ----------------
    -- On_Windows --
    ----------------
@@ -103,10 +112,11 @@ private
 
    function Properties return Alire.Properties.Vector
    is (Platprop.Distribution_Is (Distribution) and
-         Platprop.System_Is (Operating_System) and
-         Platprop.Target_Is (Target) and
-         Platprop.Toolchain_Is (Toolchain) and
-         Platprop.Word_Size_Is (Word_Size));
+       Platprop.Host_Arch_Is (Host_Architecture) and
+       Platprop.System_Is (Operating_System) and
+       Platprop.Target_Is (Target) and
+       Platprop.Toolchain_Is (Toolchain) and
+       Platprop.Word_Size_Is (Word_Size));
 
    ------------
    -- Target --

--- a/src/alire/alire-platforms.ads
+++ b/src/alire/alire-platforms.ads
@@ -2,6 +2,15 @@ package Alire.Platforms with Preelaborate is
 
    --  Platform information necessary for some releases
 
+   type Architectures is (ARM,
+                          AARCH64,
+                          AARCH64_BE,
+                          I386,
+                          I686,
+                          X86_64,
+                          Architecture_Unknown);
+   --  See e.g. https://stackoverflow.com/a/45125525/761390
+
    type Operating_Systems is (Linux,
                               MacOS,
                               Windows,

--- a/src/alire/alire-properties-platform.ads
+++ b/src/alire/alire-properties-platform.ads
@@ -20,6 +20,16 @@ package Alire.Properties.Platform with Preelaborate is
                                         Distro_Key,
                                         Tomify);
 
+   function Host_Arch_Key (A : Platforms.Architectures) return String
+   is (TOML_Keys.Host_Arch);
+
+   function Tomify is new TOML_Adapters.Tomify_Enum (Platforms.Architectures);
+   package Host_Archs is new Values (Platforms.Architectures,
+                                     Platforms.Architectures'Image,
+                                     Platforms.Architectures'Image,
+                                     Host_Arch_Key,
+                                     Tomify);
+
    function OS_Key (OS : Platforms.Operating_Systems) return String
    is (TOML_Keys.OS);
 
@@ -72,6 +82,13 @@ package Alire.Properties.Platform with Preelaborate is
       Name      => "Distribution",
       TOML_Name => TOML_Keys.Distribution);
 
+   package Host_Arch_Cases is new Cases
+     (Enum      => Ps.Architectures,
+      Property  => PrPl.Host_Archs.Property,
+      Element   => PrPl.Host_Archs.Element,
+      Name      => "Architecture",
+      TOML_Name => TOML_Keys.Host_Arch);
+
    package OS_Cases is new Cases
      (Enum      => Ps.Operating_Systems,
       Property  => PrPl.Operating_Systems.Property,
@@ -92,6 +109,9 @@ package Alire.Properties.Platform with Preelaborate is
       Element   => PrPl.Word_Sizes.Element,
       Name      => "Word_Size",
       TOML_Name => TOML_Keys.Word_Size);
+
+   function Host_Arch_Is (A : Platforms.Architectures) return Vector
+   renames Host_Archs.New_Vector;
 
    function Distribution_Is (D : Platforms.Distributions) return Vector
    renames Distributions.New_Vector;

--- a/src/alire/alire-toml_keys.ads
+++ b/src/alire/alire-toml_keys.ads
@@ -28,6 +28,7 @@ package Alire.TOML_Keys with Preelaborate is
    GPR_Ext        : constant String := "gpr-externals";
    GPR_Set_Ext    : constant String := "gpr-set-externals";
    Hint           : constant String := "hint";
+   Host_Arch      : constant String := "host-arch";
    License        : constant String := "licenses";
    Long_Descr     : constant String := "long-description";
    Maintainer     : constant String := "maintainers";

--- a/src/alire/os_linux/alire-platforms-current__linux.adb
+++ b/src/alire/os_linux/alire-platforms-current__linux.adb
@@ -1,7 +1,5 @@
 with AAA.Strings; use AAA.Strings;
 
-with Alire.Platforms.Common;
-
 with GNAT.Regpat;
 
 package body Alire.Platforms.Current is

--- a/src/alire/os_macos/alire-platforms-current__macos.adb
+++ b/src/alire/os_macos/alire-platforms-current__macos.adb
@@ -1,5 +1,4 @@
 with Alire.OS_Lib;
-with Alire.Platforms.Common;
 
 package body Alire.Platforms.Current is
 

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -389,6 +389,7 @@ package body Alr.Commands is
          Trace.Debug ("End command line.");
       end Log_Command_Line;
 
+      use all type Alire.Platforms.Operating_Systems;
    begin
 
       Log_Command_Line;
@@ -402,7 +403,7 @@ package body Alr.Commands is
       --  Use CLIC.TTY selection/detection of TTY
       Trace.Is_TTY := CLIC.TTY.Is_TTY;
 
-      if not Alire.Platforms.Current.On_Windows
+      if Alire.Platforms.Current.Operating_System /= Alire.Platforms.Windows
         and then not No_Color
         and then not No_TTY
       then


### PR DESCRIPTION
This will allow indexing the proper binaries for different host architectures.

~~Since using this property will require changing the index version, for now I would just leave the PR unmerged and merge it for the next major release.~~

There are other backwards-incompatible changes merged, but that's no problem because the stable index is forward-compatible.

Fixes #849 