### PR TITLE
New config option to disable community index

### DIFF
--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -85,6 +85,11 @@ private
 
    Builtins : constant array (Natural range <>) of Builtin_Entry :=
      (
+      (+Keys.Catalog_Autoconfig,
+       Cfg_Bool,
+       +("When unset (default) or true, the community index will be added " &
+          "automatically when required if no other index is configured.")),
+
       (+Keys.User_Name,
        Cfg_String,
        +("User full name. Used for the authors and " &

--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -85,7 +85,7 @@ private
 
    Builtins : constant array (Natural range <>) of Builtin_Entry :=
      (
-      (+Keys.Catalog_Autoconfig,
+      (+Keys.Index_Auto_Community,
        Cfg_Bool,
        +("When unset (default) or true, the community index will be added " &
           "automatically when required if no other index is configured.")),

--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -25,14 +25,14 @@ package Alire.Config with Preelaborate is
 
       Editor_Cmd  : constant Config_Key := "editor.cmd";
 
-      Catalog_Autoconfig : constant Config_Key := "catalog.autoconfig";
-      --  When unset (default) or true, add the community index if no other
-      --  index is already configured.
-
       Distribution_Disable_Detection : constant Config_Key :=
                                          "distribution.disable_detection";
       --  When set to True, distro will be reported as unknown, and in turn no
       --  native package manager will be used.
+
+      Index_Auto_Community : constant Config_Key := "index.auto_community";
+      --  When unset (default) or true, add the community index if no other
+      --  index is already configured.
 
       Solver_Autonarrow : constant Config_Key := "solver.autonarrow";
       --  When true, `alr with` will substitute "any" dependencies by the

--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -25,6 +25,10 @@ package Alire.Config with Preelaborate is
 
       Editor_Cmd  : constant Config_Key := "editor.cmd";
 
+      Catalog_Autoconfig : constant Config_Key := "catalog.autoconfig";
+      --  When unset (default) or true, add the community index if no other
+      --  index is already configured.
+
       Distribution_Disable_Detection : constant Config_Key :=
                                          "distribution.disable_detection";
       --  When set to True, distro will be reported as unknown, and in turn no

--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -3,6 +3,7 @@ with Ada.Directories;
 with Alire.Config.Edit;
 with Alire.Index;
 with Alire.OS_Lib;
+with Alire.Warnings;
 
 with GNAT.OS_Lib;
 
@@ -151,6 +152,14 @@ package body Alire.Features.Index is
                   Find_All (Config.Edit.Indexes_Directory, Result);
       use Sets;
    begin
+      if not Config.DB.Get (Config.Keys.Catalog_Autoconfig, Default => True)
+      then
+         Warnings.Warn_Once
+           ("Not configuring the community index, disabled via "
+            & Config.Keys.Catalog_Autoconfig);
+         return Outcome_Success;
+      end if;
+
       Trace.Debug ("Resetting community index...");
       for I in Indexes.Iterate loop
          Assert (Result);

--- a/src/alire/alire-features-index.adb
+++ b/src/alire/alire-features-index.adb
@@ -152,11 +152,11 @@ package body Alire.Features.Index is
                   Find_All (Config.Edit.Indexes_Directory, Result);
       use Sets;
    begin
-      if not Config.DB.Get (Config.Keys.Catalog_Autoconfig, Default => True)
+      if not Config.DB.Get (Config.Keys.Index_Auto_Community, Default => True)
       then
          Warnings.Warn_Once
            ("Not configuring the community index, disabled via "
-            & Config.Keys.Catalog_Autoconfig);
+            & Config.Keys.Index_Auto_Community);
          return Outcome_Success;
       end if;
 

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -37,16 +37,22 @@ def prepare_env(config_dir, env):
     config_dir = os.path.abspath(config_dir)
     mkdir(config_dir)
     env['ALR_CONFIG'] = config_dir
+    #  We pass config location explicitly in the following calls since env is
+    #  not yet applied.
+
+    # Disable autoconfig of the community index, to prevent unintended use of
+    # it in tests, besides the overload of fetching it
+    run_alr("-c", config_dir, "config", "--global",
+            "--set", "catalog.autoconfig", "false")
 
     # Disable selection of toolchain to preserve older behavior. Tests that
     # require a configured compiler will have to set it up explicitly.
     run_alr("-c", config_dir, "toolchain", "--disable-assistant")
-    #  Pass config location explicitly since env is not yet applied
 
     # If distro detection is disabled via environment, configure so in alr
     if "ALIRE_DISABLE_DISTRO" in env:
         if env["ALIRE_DISABLE_DISTRO"] == "true":
-            run_alr("config", "--global",
+            run_alr("-c", config_dir, "config", "--global",
                     "--set", "distribution.disable_detection", "true")
 
 

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -43,7 +43,7 @@ def prepare_env(config_dir, env):
     # Disable autoconfig of the community index, to prevent unintended use of
     # it in tests, besides the overload of fetching it
     run_alr("-c", config_dir, "config", "--global",
-            "--set", "catalog.autoconfig", "false")
+            "--set", "index.auto_community", "false")
 
     # Disable selection of toolchain to preserve older behavior. Tests that
     # require a configured compiler will have to set it up explicitly.

--- a/testsuite/tests/config/community-disable/test.py
+++ b/testsuite/tests/config/community-disable/test.py
@@ -13,7 +13,9 @@ from drivers.asserts import assert_match
 # Since no index is configured, looking for crates will attempt to add the
 # community index
 p = run_alr("search", "hello", quiet=False)
-assert "Not configuring the community index, disabled via catalog.autoconfig" \
+assert \
+    "Not configuring the community index, " + \
+    "disabled via index.auto_community" \
     in p.out, "unexpected output: " + p.out
 
 

--- a/testsuite/tests/config/community-disable/test.py
+++ b/testsuite/tests/config/community-disable/test.py
@@ -1,0 +1,20 @@
+"""
+Verify that catalog.autoconfig works as intended (no autoadd community index)
+"""
+
+from glob import glob
+import os
+import re
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+
+
+# Since no index is configured, looking for crates will attempt to add the
+# community index
+p = run_alr("search", "hello", quiet=False)
+assert "Not configuring the community index, disabled via catalog.autoconfig" \
+    in p.out, "unexpected output: " + p.out
+
+
+print('SUCCESS')

--- a/testsuite/tests/config/community-disable/test.yaml
+++ b/testsuite/tests/config/community-disable/test.yaml
@@ -1,0 +1,2 @@
+driver: python-script
+# No index defined, on purpose

--- a/testsuite/tests/misc/gprbuild-switches/test.yaml
+++ b/testsuite/tests/misc/gprbuild-switches/test.yaml
@@ -1,1 +1,3 @@
 driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
This way we can ensure that no test in our testsuite is inadvertently using the
community index, as indeed it was happening.