### PR TITLE
[RFC] Installation and sharing of resources

### DIFF
--- a/src/alire/alire-paths.ads
+++ b/src/alire/alire-paths.ads
@@ -9,6 +9,9 @@ package Alire.Paths with Preelaborate is
 
    Deps_Folder_Inside_Cache_Folder : constant Relative_Path := "dependencies";
 
+   Prefix_Folder_Inside_Working_Folder : constant Relative_Path := "prefix";
+   --  The folder gprinstall uses as prefix
+
    Temp_Folder_Inside_Working_Folder : constant Relative_Path := "tmp";
 
    function Working_Folder_Inside_Root return Relative_Path

--- a/src/alire/alire-platforms-current.ads
+++ b/src/alire/alire-platforms-current.ads
@@ -1,5 +1,6 @@
 limited with Alire.Environment;
 private with Alire.OS_Lib.Subprocess;
+private with Alire.Paths;
 with Alire.Platforms;
 with Alire.Properties;
 private with Alire.Properties.Platform;
@@ -74,7 +75,12 @@ package Alire.Platforms.Current is
    --  Return the platform information wrapped in a vector of properties useful
    --  for dynamic expression resolution in indices/releases.
 
+   function Prefix_Folder return Absolute_Path;
+   --  Default installation location outside of sandboxes
+
 private
+
+   use OS_Lib.Operators;
 
    ------------------
    -- Distribution --
@@ -93,6 +99,13 @@ private
    function On_Windows return Boolean
    is (GNATCOLL.OS.Constants.OS in GNATCOLL.OS.Windows);
    pragma Warnings (On);
+
+   -------------------
+   -- Prefix_Folder --
+   -------------------
+
+   function Prefix_Folder return Absolute_Path
+   is (Config_Folder / Paths.Prefix_Folder_Inside_Working_Folder);
 
    ----------------
    -- Properties --

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -146,27 +146,6 @@ package body Alire.Roots is
 
             end if;
 
-            --  Gprinstall everything
-
-            if Is_Root then
-               Put_Info ("Installing projects...");
-
-               for Gpr_File of Release.Project_Files
-                 (This.Environment, With_Path => True)
-               loop
-                  Spawn.Command
-                    ("gprinstall",
-                     AAA.Strings.To_Vector ("-r")
-                     & "-f" -- force overwrite
-                     & "-m" -- minimal install (only needed sources)
-                     & "-p" -- create missing dirs
-                     & "-r" -- recursively install projects
-                     & String'("--prefix=" & (This.Prefix_Dir))
-                     & "-P" & Gpr_File
-                    );
-               end loop;
-            end if;
-
          exception
             when E : Alire.Checked_Error =>
                Trace.Error (Errors.Get (E, Clear => False));
@@ -239,6 +218,42 @@ package body Alire.Roots is
                       Origin => "root");
       end return;
    end Build_Context;
+
+   -------------
+   -- Install --
+   -------------
+
+   procedure Install (This      : in out Root;
+                     Prefix     : Absolute_Path;
+                     Cmd_Args   : AAA.Strings.Vector;
+                     Export_Env : Boolean)
+   is
+      use AAA.Strings;
+   begin
+
+      if Export_Env then
+         This.Export_Build_Environment;
+      end if;
+
+      --  Gprinstall everything
+
+      Put_Info ("Installing projects...");
+
+      for Gpr_File of Release (This).Project_Files
+        (This.Environment, With_Path => True)
+      loop
+         Spawn.Command
+           ("gprinstall",
+            AAA.Strings.To_Vector ("-r")
+            & "-m" -- minimal install (only needed sources)
+            & "-p" -- create missing dirs
+            & "-r" -- recursively install projects
+            & String'("--prefix=" & Prefix)
+            & "-P" & Gpr_File
+            & Cmd_Args
+           );
+      end loop;
+   end Install;
 
    ------------------
    -- Direct_Withs --

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -141,16 +141,6 @@ package body Alire.Roots is
                   Spawn.Gprbuild (This.Release_Base (Release.Name) / Gpr_File,
                                   Extra_Args => Cmd_Args);
 
-                  --  Also install it to our sandboxed prefix
-
-                  Spawn.Gprinstall
-                    (Project_File => This.Release_Base (Release.Name)
-                                     / Gpr_File,
-                     Prefix       => This.Prefix_Dir,
-                     Recursive    => False,
-                     Quiet        => True,
-                     Extra_Args   => AAA.Strings.Empty_Vector);
-
                   Current := Current + 1;
                end loop;
 
@@ -205,11 +195,6 @@ package body Alire.Roots is
       end if;
 
       This.Traverse (Build_Single_Release'Access);
-
-      --  Final installation of all projects in our sandbox
-      This.Install (Prefix     => This.Prefix_Dir,
-                    Cmd_Args   => AAA.Strings.Empty_Vector,
-                    Export_Env => False);
 
       return True;
    exception

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -217,6 +217,12 @@ package Alire.Roots is
    --  all releases in the solution (even those not built). Returns True on
    --  successful build.
 
+   procedure Install (This       : in out Root;
+                      Prefix     : Absolute_Path;
+                      Cmd_Args   : AAA.Strings.Vector;
+                      Export_Env : Boolean);
+   --  Call gprbuild -r on the root project files and --prefix=Prefix
+
    procedure Generate_Configuration (This : in out Root);
    --  Generate or re-generate the crate configuration files
 

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -234,6 +234,9 @@ package Alire.Roots is
    function Pins_Dir (This : Root) return Absolute_Path;
    --  The folder where remote pins are checked out for this root
 
+   function Prefix_Dir (This : Root) return Absolute_Path;
+   --  The folder gprinstall uses as prefix by default
+
    function Lock_File (This : Root) return Absolute_Path;
    --  The "/path/to/alire.lock" file inside Working_Folder
 

--- a/src/alire/alire-spawn.adb
+++ b/src/alire/alire-spawn.adb
@@ -52,4 +52,31 @@ package body Alire.Spawn is
                Understands_Verbose => True);
    end Gprbuild;
 
+   ----------------
+   -- Gprinstall --
+   ----------------
+
+   procedure Gprinstall
+     (Project_File : Absolute_File;
+      Prefix       : Absolute_Path;
+      Recursive    : Boolean;
+      Quiet        : Boolean;
+      Extra_Args   : AAA.Strings.Vector)
+   is
+      use AAA.Strings;
+   begin
+      Spawn.Command
+        ("gprinstall",
+         AAA.Strings.Empty_Vector
+         & (if Recursive then To_Vector ("-r") else Empty_Vector)
+         & (if Quiet     then To_Vector ("-q") else Empty_Vector)
+         & "-f"
+         & "-m" -- minimal install (only needed sources)
+         & "-p" -- create missing dirs
+         & String'("--prefix=" & Prefix)
+         & "-P" & Project_File
+         & Extra_Args
+        );
+   end Gprinstall;
+
 end Alire.Spawn;

--- a/src/alire/alire-spawn.ads
+++ b/src/alire/alire-spawn.ads
@@ -17,7 +17,14 @@ package Alire.Spawn is
       Extra_Args    : AAA.Strings.Vector);
    --  Launches gprbuild for the building of a crate.
    --  Extra args can be -Xblah detected from command-line.
-   --  Out-of-tree build takes place in
-   --    $crate / Alire.Paths.Build_Folder ($crate/alire/build).
+
+   procedure Gprinstall
+     (Project_File : Absolute_File;
+      Prefix       : Absolute_Path;
+      Recursive    : Boolean;
+      Quiet        : Boolean;
+      Extra_Args   : AAA.Strings.Vector);
+   --  Launches
+   --  gprinstall -f -m -p [-r] -P Project_File --prefix=Prefix -- Extra_Args
 
 end Alire.Spawn;

--- a/src/alr/alr-commands-install.adb
+++ b/src/alr/alr-commands-install.adb
@@ -1,0 +1,65 @@
+with Ada.Directories;
+
+with Stopwatch;
+
+package body Alr.Commands.Install is
+
+   package Adirs renames Ada.Directories;
+
+   -------------
+   -- Execute --
+   -------------
+
+   overriding
+   procedure Execute (Cmd  : in out Command;
+                      Args :        AAA.Strings.Vector)
+   is
+   begin
+      Cmd.Requires_Valid_Session;
+
+      declare
+         Timer : Stopwatch.Instance;
+      begin
+         Cmd.Root.Install
+           (Prefix     =>
+              (if Cmd.Prefix.all = ""
+               then Cmd.Root.Prefix_Dir
+               else Adirs.Full_Name (Cmd.Prefix.all)),
+            Cmd_Args   => Args,
+            Export_Env => True);
+
+         Trace.Info ("Install finished successfully in "
+                     & TTY.Bold (Timer.Image) & " seconds.");
+      end;
+   end Execute;
+
+   ----------------------
+   -- Long_Description --
+   ----------------------
+
+   overriding
+   function Long_Description (Cmd : Command)
+                              return AAA.Strings.Vector
+   is (AAA.Strings.Empty_Vector
+       .Append ("Invokes gprbuild to compile all targets in the current"
+         & " crate."));
+
+   --------------------
+   -- Setup_Switches --
+   --------------------
+
+   overriding
+   procedure Setup_Switches
+     (Cmd    : in out Command;
+      Config : in out CLIC.Subcommand.Switches_Configuration)
+   is
+      use CLIC.Subcommand;
+   begin
+      Define_Switch (Config,
+                     Cmd.Prefix'Access,
+                     "", "--prefix=",
+                     "Override installation prefix (default is "
+                     & TTY.URL ("${CRATE_ROOT}/alire/prefix)") & ")");
+   end Setup_Switches;
+
+end Alr.Commands.Install;

--- a/src/alr/alr-commands-install.adb
+++ b/src/alr/alr-commands-install.adb
@@ -1,5 +1,6 @@
 with Ada.Directories;
 
+--  with Alire.Dependencies;
 with Alire.Platforms.Current;
 
 with Stopwatch;
@@ -7,6 +8,8 @@ with Stopwatch;
 package body Alr.Commands.Install is
 
    package Adirs renames Ada.Directories;
+
+   --  procedure Install_One (Dep : Alire.Dependencies.Dependency) is null;
 
    -------------
    -- Execute --
@@ -17,24 +20,37 @@ package body Alr.Commands.Install is
                       Args :        AAA.Strings.Vector)
    is
    begin
-      Cmd.Requires_Valid_Session;
+      if Args.Is_Empty then
 
-      declare
-         Timer  : Stopwatch.Instance;
-         Prefix : constant Alire.Absolute_Path :=
-                    (if Cmd.Prefix.all = ""
-                     then Alire.Platforms.Current.Prefix_Folder
-                     else Adirs.Full_Name (Cmd.Prefix.all));
-      begin
-         Cmd.Root.Install
-           (Prefix     => Prefix,
-            Cmd_Args   => Args,
-            Export_Env => True);
+         Cmd.Requires_Valid_Session;
 
-         Trace.Info ("Install to " & TTY.URL (Prefix)
-                     & " finished successfully in "
-                     & TTY.Bold (Timer.Image) & " seconds.");
-      end;
+         declare
+            Timer  : Stopwatch.Instance;
+            Prefix : constant Alire.Absolute_Path :=
+                       (if Cmd.Prefix.all = ""
+                        then Alire.Platforms.Current.Prefix_Folder
+                        else Adirs.Full_Name (Cmd.Prefix.all));
+         begin
+            Cmd.Root.Install
+              (Prefix     => Prefix,
+               Cmd_Args   => Args,
+               Export_Env => True);
+
+            Trace.Info ("Install to " & TTY.URL (Prefix)
+                        & " finished successfully in "
+                        & TTY.Bold (Timer.Image) & " seconds.");
+         end;
+
+      else
+
+         --  Install all given targets
+
+         for Target of Args loop
+            Trace.Always ("XXX: " & Target);
+            --  Install_One (Alire.Dependencies.From_String (Target));
+         end loop;
+
+      end if;
    end Execute;
 
    ----------------------

--- a/src/alr/alr-commands-install.adb
+++ b/src/alr/alr-commands-install.adb
@@ -1,5 +1,7 @@
 with Ada.Directories;
 
+with Alire.Platforms.Current;
+
 with Stopwatch;
 
 package body Alr.Commands.Install is
@@ -18,17 +20,19 @@ package body Alr.Commands.Install is
       Cmd.Requires_Valid_Session;
 
       declare
-         Timer : Stopwatch.Instance;
+         Timer  : Stopwatch.Instance;
+         Prefix : constant Alire.Absolute_Path :=
+                    (if Cmd.Prefix.all = ""
+                     then Alire.Platforms.Current.Prefix_Folder
+                     else Adirs.Full_Name (Cmd.Prefix.all));
       begin
          Cmd.Root.Install
-           (Prefix     =>
-              (if Cmd.Prefix.all = ""
-               then Cmd.Root.Prefix_Dir
-               else Adirs.Full_Name (Cmd.Prefix.all)),
+           (Prefix     => Prefix,
             Cmd_Args   => Args,
             Export_Env => True);
 
-         Trace.Info ("Install finished successfully in "
+         Trace.Info ("Install to " & TTY.URL (Prefix)
+                     & " finished successfully in "
                      & TTY.Bold (Timer.Image) & " seconds.");
       end;
    end Execute;
@@ -41,8 +45,9 @@ package body Alr.Commands.Install is
    function Long_Description (Cmd : Command)
                               return AAA.Strings.Vector
    is (AAA.Strings.Empty_Vector
-       .Append ("Invokes gprbuild to compile all targets in the current"
-         & " crate."));
+       .Append ("Invokes gprinstall to install all projects.")
+       .Append ("The default install location is "
+         & TTY.URL (Alire.Platforms.Current.Prefix_Folder)));
 
    --------------------
    -- Setup_Switches --

--- a/src/alr/alr-commands-install.ads
+++ b/src/alr/alr-commands-install.ads
@@ -35,10 +35,11 @@ package Alr.Commands.Install is
 
    overriding
    function Usage_Custom_Parameters (Cmd : Command) return String
-   is ("[--] [gprinstall switches and arguments]");
+   is ("[crate[versions]]... [--] [gprinstall switches and arguments]");
 
 private
    type Command is new Commands.Command with record
-      Prefix : aliased GNAT.Strings.String_Access;
+      Target : aliased GNAT.Strings.String_Access; -- Crate[version] to install
+      Prefix : aliased GNAT.Strings.String_Access; -- Prefix for gprinstall
    end record;
 end Alr.Commands.Install;

--- a/src/alr/alr-commands-install.ads
+++ b/src/alr/alr-commands-install.ads
@@ -1,0 +1,44 @@
+with AAA.Strings;
+
+private with GNAT.Strings;
+
+package Alr.Commands.Install is
+
+   type Command is new Commands.Command with private;
+
+   overriding
+   function Name (Cmd : Command) return CLIC.Subcommand.Identifier
+   is ("install");
+
+   overriding
+   function Switch_Parsing (This : Command)
+                            return CLIC.Subcommand.Switch_Parsing_Kind
+   is (CLIC.Subcommand.Before_Double_Dash);
+   --  For this command we want the args after -- to pass them to gprinstall
+
+   overriding
+   procedure Execute (Cmd  : in out Command;
+                      Args :        AAA.Strings.Vector);
+
+   overriding
+   function Long_Description (Cmd : Command)
+                              return AAA.Strings.Vector;
+
+   overriding
+   procedure Setup_Switches
+     (Cmd    : in out Command;
+      Config : in out CLIC.Subcommand.Switches_Configuration);
+
+   overriding
+   function Short_Description (Cmd : Command) return String
+   is ("GPRinstall the project tree");
+
+   overriding
+   function Usage_Custom_Parameters (Cmd : Command) return String
+   is ("[--] [gprinstall switches and arguments]");
+
+private
+   type Command is new Commands.Command with record
+      Prefix : aliased GNAT.Strings.String_Access;
+   end record;
+end Alr.Commands.Install;

--- a/src/alr/alr-commands-run.adb
+++ b/src/alr/alr-commands-run.adb
@@ -27,8 +27,9 @@ package body Alr.Commands.Run is
       use Ada.Text_IO;
 
       Found_At : constant AAA.Strings.Vector :=
-        Files.Locate_File_Under (Cmd.Root.Path,
-                                 Exe_Name, Max_Depth => Max_Search_Depth);
+        Files.Locate_File_Under (Cmd.Root.Prefix_Dir,
+                                 Exe_Name,
+                                 Max_Depth => Max_Search_Depth);
    begin
       Put ("   " & Exe_Name);
       case Found_At.Length is
@@ -64,7 +65,7 @@ package body Alr.Commands.Run is
 
       procedure List is
          Candidates : constant AAA.Strings.Vector := Files.Locate_File_Under
-           (Cmd.Root.Path,
+           (Cmd.Root.Prefix_Dir,
             Cmd.Root.Release.Default_Executable,
             Max_Depth => Max_Search_Depth);
          --  Candidate default executable

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -27,6 +27,7 @@ with Alr.Commands.Exec;
 with Alr.Commands.Get;
 with Alr.Commands.Index;
 with Alr.Commands.Init;
+with Alr.Commands.Install;
 with Alr.Commands.Pin;
 with Alr.Commands.Printenv;
 with Alr.Commands.Publish;
@@ -508,6 +509,7 @@ begin
    -- Commands --
    Sub_Cmd.Register ("General", new Sub_Cmd.Builtin_Help);
    Sub_Cmd.Register ("General", new Config.Command);
+   Sub_Cmd.Register ("General", new Install.Command);
    Sub_Cmd.Register ("General", new Printenv.Command);
    Sub_Cmd.Register ("General", new Toolchain.Command);
    Sub_Cmd.Register ("General", new Version.Command);

--- a/src/alr/alr-paths.ads
+++ b/src/alr/alr-paths.ads
@@ -2,10 +2,8 @@ with Ada.Directories;
 
 with Alire;
 with Alire.Config.Edit;
-with Alire.Environment;
 
 with Alr.Defaults;
-with Alr.OS_Lib;
 
 package Alr.Paths is
 
@@ -45,11 +43,6 @@ package Alr.Paths is
    function Alr_Config_Folder return Absolute_Path;
    --  Root folder containing persistent configuration: indexes, templates
 
-   function Alr_Source_Folder return Absolute_Path;
-   --  Folder inside Alr_Config_Folder containing a clone of the alr repo
-   --  This folder can be overridden via environment variable
-   --  Alire.Environment.Source.
-
    Alr_Working_Folder : constant Relative_Path;
    --  Folder within a working release that will contain metadata/build files,
    --  dependency releases, and session.
@@ -86,9 +79,6 @@ private
 
    function Alr_Config_Folder return String
    is (Alire.Config.Edit.Path);
-
-   function Alr_Source_Folder return String
-   is (OS_Lib.Getenv (Alire.Environment.Source, Alr_Config_Folder / "alire"));
 
    function Dependencies_Folder return String
    is (Alr_Working_Cache_Folder / "dependencies");


### PR DESCRIPTION
I'm playing with an hypothetical new `alr install` that relies on `gprinstall`. It seems to work well. What I'm currently doing is:

- gprinstalling by default to `${CRATE_ROOT}`/alire/prefix.
- Exporting that part as `ALIRE_PREFIX` in our environment.

I tried the `for Artifacts ("path") use (...)` of GPR files and also works as expected. So, an executable run within our `alr printenv` can locate shared resources via `ALIRE_PREFIX`.

But, all in all, I have not much experience with installation and gprinstall. I have some fuzzy ideas were I'd like to hear your feedback @Fabien-Chouteau (and interested parties, e.g. @stcarrez):

- Should we add something explicit to the manifest about exported resources? 
   - There seems to be no need if relying on gprinstall. 
   - But it could be useful for e.g. the automatic generation of documentation.
   - If so, it could be a simple flag, 
   - or it could be a list of the paths being installed. 
      - Would we in that case want to take over from gprinstall and install resources ourselves? Or at least verify?

My stance on this right now lends to not duplicating the work of gprinstall. At most have an `export-resources` flag, or even peek into project files for `Artifacts` clauses (that could be too hackish if there are cases involved).

Separate issue: at present, gprinstall is only called through `alr install` but:

- Might we want to call gprinstall after each gprbuild (it seems fast enough)? 
   - We could in this case export a couple extra paths for binaries/libraries in `alr printenv`
   - Crates would not need to export paths explicitly for executables they build.
      - Our current situation is probably not ideal wrt to build profiles possibly generating executables in different places.

In this regard, I suspect that gprinstall is probably very solid and will simplify our lives down the road. We are currently doing everything in-tree, which I'm wary of (except for edition were we want the actual sources and not some installed headers -- I've been bitten by this in the past and it was a pain). 