### PR TITLE
Alire.Environment: export <CRATE_NAME>_PREFIX for all crates of solution

### DIFF
--- a/src/alire/alire-environment.adb
+++ b/src/alire/alire-environment.adb
@@ -155,6 +155,8 @@ package body Alire.Environment is
       Env    : constant Properties.Vector := Root.Current.Environment;
       Rel    : constant Releases.Release := Root.Current.Release (Crate);
       Origin : constant String := Rel.Name_Str;
+
+      Release_Base : constant String := Root.Current.Release_Base (Rel.Name);
    begin
       Trace.Debug ("Loading environment for crate "
                    & Alire.Utils.TTY.Name (Crate)
@@ -168,8 +170,7 @@ package body Alire.Environment is
          begin
             declare
                Value : constant String :=
-                       Formatting.Format (Root.Current.Release_Base (Rel.Name),
-                                          Act.Value);
+                 Formatting.Format (Release_Base, Act.Value);
             begin
                case Act.Action is
 
@@ -210,6 +211,11 @@ package body Alire.Environment is
             end;
          end if;
       end loop;
+
+      --  Set the crate PREFIX location for access to resources
+      This.Set (AAA.Strings.To_Upper_Case (+Rel.Name) & "_PREFIX",
+                Release_Base,
+                "Crate prefix for resources location");
    end Load;
 
    -----------------

--- a/testsuite/tests/printenv/basic/test.py
+++ b/testsuite/tests/printenv/basic/test.py
@@ -21,21 +21,24 @@ os.chdir(glob('hello*')[0])
 p = run_alr('printenv', quiet=False)
 assert_eq(0, p.status)
 
-expected_gpr_path = []
-expected_gpr_path += [['.*', 'hello_1.0.1_filesystem']]
-expected_gpr_path += [['.*', 'alire', 'cache', 'dependencies', 'libhello_1\.0\.0_filesystem']]
-
-for i, path in enumerate(expected_gpr_path):
+def make_path(list):
     if platform.system() == 'Windows':
-        expected_gpr_path[i] = "\\\\".join(path)
+        return "\\\\".join(list)
     else:
-        expected_gpr_path[i] = "/".join(path)
+        return "/".join(list)
 
-expected_gpr_path = os.pathsep.join(expected_gpr_path)
+expected_hello_path = make_path(['.*', 'hello_1.0.1_filesystem'])
+expected_libhello_path = make_path(['.*', 'alire', 'cache', 'dependencies', 'libhello_1\.0\.0_filesystem'])
+
+expected_gpr_path = os.pathsep.join([expected_hello_path, expected_libhello_path])
 
 assert_match('export ALIRE="True"\n'
              '.*'
              'export GPR_PROJECT_PATH="' + expected_gpr_path + '"\n'
+             '.*'
+             'export HELLO_PREFIX="' + expected_hello_path + '"\n'
+             '.*'
+             'export LIBHELLO_PREFIX="' + expected_libhello_path + '"\n'
              '.*'
              'export TEST_GPR_EXTERNAL="gpr_ext_B"\n'
              '.*',


### PR DESCRIPTION
This is to be used for retrieval of crate resources, see #948.