### PR TITLE
Change default GPRbuild switches

### DIFF
--- a/src/alire/alire-spawn.adb
+++ b/src/alire/alire-spawn.adb
@@ -40,14 +40,10 @@ package body Alire.Spawn is
 
       Command ("gprbuild",
                Empty_Vector &
-
-                 "-gnatwU" &
-                 --  Suppress warnings on unused (may happen in prj_alr.ads)
-
-                 "-j0" &
-                 "-p" &
-                 "-P" &
-                 Project_File &
+                 "-s"  & -- Recompile if compiler switches have changed
+                 "-j0" & -- Build in parallel
+                 "-p"  & -- Create missing obj, lib and exec dirs
+                 "-P"  & Project_File &
                  Extra_Args,
                Understands_Verbose => True);
    end Gprbuild;


### PR DESCRIPTION
 - Remove `-gnatwU` (Recompile if compiler switches have changed):
     It is a legacy from the time when the index was in Ada. Removal may
     trigger some issue on crates with warnings-as-error. But the longer
     we wait the bigger of a problem it will be.

 - Add `-s` (Recompile if compiler switches have changed):
     As discussed in #952, it makes sense to have this default for all
     builds.