### PR TITLE
Alire.Manifest: Remove "Added by alr" comments

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -45,7 +45,7 @@ aaa = { url = "https://github.com/mosteo/aaa.git", commit = "22fcef5c465ece2f9cf
 ada_toml = { url = "https://github.com/pmderodat/ada-toml.git", commit = "2a671ffb1039a036f2bb68bdc88afc8d3dc68c10" }
 ajunitgen = { url = "https://github.com/mosteo/ajunitgen.git", commit = "e5d01db5e7834d15c4066f0a8e33d780deae3cc9" }
 ansiada = { url = "https://github.com/mosteo/ansi-ada.git", commit = "acf9afca3afe1f8b8843c061f3cef860d7567307" }
-clic = { url = "https://github.com/alire-project/clic.git", commit = "3ba91a010582606f0cccf10c5d6526278ae29adb" }
+clic = { url = "https://github.com/alire-project/clic.git", commit = "a7df570a4950065e252ed5f180fe6f2986aa8dcc" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "e250e4e42d9743b782788cf61b4ddc10a45e69e2" }
 minirest = { url = "https://github.com/mosteo/minirest.git", commit = "4550aa356d55b9cd55f26acd34701f646021c5ff" }
 optional = { url = "https://github.com/mosteo/optional.git", commit = "0c7d20c0c8b48ccb6b25fb648d48382e598c25c3" }

--- a/src/alire/alire-manifest.adb
+++ b/src/alire/alire-manifest.adb
@@ -9,8 +9,6 @@ with TOML_Slicer;
 
 package body Alire.Manifest is
 
-   Warning : constant String := "  # Added by alr";
-
    ------------
    -- Append --
    ------------
@@ -23,8 +21,8 @@ package body Alire.Manifest is
         (File       => Name,
          Lines      =>
            AAA.Strings.Empty_Vector
-             .Append ("[[" & TOML_Keys.Depends_On & "]]" & Warning)
-             .Append (Dep.Manifest_Image & Warning),
+             .Append ("[[" & TOML_Keys.Depends_On & "]]")
+             .Append (Dep.Manifest_Image),
            Backup     => False);
       --  No need to backup, as this is done already on a copy of the manifest
 
@@ -43,8 +41,8 @@ package body Alire.Manifest is
         (File       => File,
          Lines      =>
            AAA.Strings.Empty_Vector
-             .Append ("[[" & TOML_Keys.Pins & "]]" & Warning)
-             .Append (Pin.To_Manifest_Line (Crate) & " " & Warning),
+             .Append ("[[" & TOML_Keys.Pins & "]]")
+             .Append (Pin.To_Manifest_Line (Crate)),
          Backup     => False);
       --  No need to backup as this is done on a copy of the manifest already
    end Append;

--- a/testsuite/tests/with/dynamic-dependencies/test.py
+++ b/testsuite/tests/with/dynamic-dependencies/test.py
@@ -24,13 +24,11 @@ with open(manifest, 'a') as file:
 
 # Check adding a dependency
 run_alr('with', 'hello^1')
-assert 'hello = "^1"  # Added by alr' \
-       in content_of(manifest)
+assert 'hello = "^1"' in content_of(manifest)
 
 # Check removal
 run_alr('with', '--del', 'hello')
-assert 'hello = "^1"  # Added by alr' \
-       not in content_of(manifest)
+assert 'hello = "^1"' not in content_of(manifest)
 
 # Check that the dependency that precedes the dynamic expression is removable
 run_alr('with', '--del', 'libhello')

--- a/testsuite/tests/workflows/init-with-pin/test.py
+++ b/testsuite/tests/workflows/init-with-pin/test.py
@@ -16,8 +16,7 @@ os.chdir('xxx')
 # Make it depend on libhello, it is auto-narrowed down to ^1
 session_file = os.path.join('alire.toml')
 run_alr('with', 'libhello')
-check_line_in(session_file,
-              'libhello = "^1.0.0"  # Added by alr')
+check_line_in(session_file, 'libhello = "^1.0.0"')
 
 # Add the corresponding "with" line in xxx.gpr.
 #


### PR DESCRIPTION
On one hand I don't find them very useful, and on the other they are annoying to remove when cleaning the manifest.