### PR TITLE
Alr.Command: fix gnatcov built-in alias

### DIFF
--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -107,7 +107,7 @@ package body Alr.Commands is
       Sub_Cmd.Set_Alias ("gnatcov",
                          AAA.Strings.Empty_Vector
                          .Append ("exec")
-                         .Append ("-P1")
+                         .Append ("-P2")
                          .Append ("--")
                          .Append ("gnatcov"));
    end Set_Builtin_Aliases;


### PR DESCRIPTION
The first argument of gnatcov must be the action (`instrument`, `coverage`, etc.).