### PR TITLE
Refactor Alire.Features.Index to Alire.Index_On_Disk.Loading

### DIFF
--- a/src/alire/alire-features.ads
+++ b/src/alire/alire-features.ads
@@ -1,9 +1,0 @@
-package Alire.Features with Preelaborate is
-
-   --  "Mirror" of Alr.Commands.*
-   --  This hierarchy categorizes the client-facing features, in the sense that
-   --  these are "bulk" actions that a user/client app may want to perform.
-   --  Right now, most of that functionality is in Alr.Commands.* packages.
-   --  Progressively we should migrate it here, making it more self-contained.
-
-end Alire.Features;

--- a/src/alire/alire-index_on_disk-loading.adb
+++ b/src/alire/alire-index_on_disk-loading.adb
@@ -2,7 +2,6 @@ with Ada.Directories;
 
 with Alire.Config.Edit;
 with Alire.Index;
-with Alire.OS_Lib;
 with Alire.Warnings;
 
 with GNAT.OS_Lib;
@@ -10,7 +9,7 @@ with GNAT.OS_Lib;
 with TOML;
 with TOML.File_IO;
 
-package body Alire.Features.Index is
+package body Alire.Index_On_Disk.Loading is
 
    --  Forward declarations
 
@@ -198,14 +197,14 @@ package body Alire.Features.Index is
                              Force  : Boolean := False)
    is
       Result  : Outcome;
-      Indexes : Features.Index.Index_On_Disk_Set;
+      Indexes : Index_On_Disk_Set;
    begin
       if Alire.Index.Crate_Count /= 0 and then not Force then
          Trace.Detail ("Index already loaded, loading skipped");
          return;
       end if;
 
-      Indexes := Features.Index.Find_All (From, Result);
+      Indexes := Find_All (From, Result);
       if not Result.Success then
          Raise_Checked_Error (Message (Result));
          return;
@@ -215,8 +214,7 @@ package body Alire.Features.Index is
          Trace.Detail
            ("No indexes configured, adding default community index");
          declare
-            Outcome : constant Alire.Outcome :=
-                        Features.Index.Add_Or_Reset_Community;
+            Outcome : constant Alire.Outcome := Add_Or_Reset_Community;
          begin
             if not Outcome.Success then
                Raise_Checked_Error
@@ -227,7 +225,7 @@ package body Alire.Features.Index is
       end if;
 
       declare
-         Outcome : constant Alire.Outcome := Features.Index.Load_All
+         Outcome : constant Alire.Outcome := Load_All
            (From   => Alire.Config.Edit.Indexes_Directory,
             Strict => Strict);
       begin
@@ -254,7 +252,6 @@ package body Alire.Features.Index is
       ---------------
 
       procedure Check_One (Dir : Dirs.Directory_Entry_Type) is
-         use OS_Lib.Operators;
          Metafile : constant String :=
                       Dirs.Full_Name (Dir) / Index_On_Disk.Metadata_Filename;
          Metadata : TOML.TOML_Value;
@@ -388,4 +385,4 @@ package body Alire.Features.Index is
       return Outcome_Success;
    end Update_All;
 
-end Alire.Features.Index;
+end Alire.Index_On_Disk.Loading;

--- a/src/alire/alire-index_on_disk-loading.ads
+++ b/src/alire/alire-index_on_disk-loading.ads
@@ -1,8 +1,6 @@
 with Ada.Containers.Indefinite_Ordered_Sets;
 
-with Alire.Index_On_Disk;
-
-package Alire.Features.Index is
+package Alire.Index_On_Disk.Loading is
 
    -------------------
    -- Index loading --
@@ -52,4 +50,4 @@ package Alire.Features.Index is
    --  re-adds it at the required branch by Index.Community_Branch with the
    --  same priority (i.e., maintaining the relative ordering);
 
-end Alire.Features.Index;
+end Alire.Index_On_Disk.Loading;

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -7,7 +7,7 @@ with Alire.Config.Edit;
 with Alire.Crates;
 with Alire.Directories;
 with Alire.Errors;
-with Alire.Features.Index;
+with Alire.Index_On_Disk.Loading;
 with Alire.GitHub;
 with Alire.Hashes;
 with Alire.Index;
@@ -183,8 +183,9 @@ package body Alire.Publish is
 
       --  Check not duplicated
 
-      Features.Index.Setup_And_Load (From   => Config.Edit.Indexes_Directory,
-                                     Strict => True);
+      Index_On_Disk.Loading.Setup_And_Load
+        (From   => Config.Edit.Indexes_Directory,
+         Strict => True);
       if Index.Exists (Release.Name, Release.Version) then
          Raise_Checked_Error
            ("Target release " & Release.Milestone.TTY_Image

--- a/src/alr/alr-commands-index.adb
+++ b/src/alr/alr-commands-index.adb
@@ -1,11 +1,12 @@
 with AAA.Table_IO;
 
 with Alire.Config.Edit;
-with Alire.Features.Index;
-with Alire.Index_On_Disk;
+with Alire.Index_On_Disk.Loading;
 with Alire.Utils;
 
 package body Alr.Commands.Index is
+
+   package Index_Load renames Alire.Index_On_Disk.Loading;
 
    --  Forward declarations
 
@@ -25,7 +26,7 @@ package body Alr.Commands.Index is
       Before : constant String := Cmd.Bfr.all;
 
       Result : constant Alire.Outcome :=
-                 Alire.Features.Index.Add
+                 Alire.Index_On_Disk.Loading.Add
                    (Origin => Cmd.Add.all,
                     Name   => Cmd.Name.all,
                     Under  => Alire.Config.Edit.Indexes_Directory,
@@ -44,8 +45,8 @@ package body Alr.Commands.Index is
 
    procedure Delete (Name : String) is
       Result  : Alire.Outcome;
-      Indexes : constant Alire.Features.Index.Index_On_Disk_Set :=
-                  Alire.Features.Index.Find_All
+      Indexes : constant Index_Load.Index_On_Disk_Set :=
+                  Index_Load.Find_All
                     (Alire.Config.Edit.Indexes_Directory, Result);
       Found   : Boolean := False;
    begin
@@ -147,8 +148,8 @@ package body Alr.Commands.Index is
       use Alire;
 
       Result  : Alire.Outcome;
-      Indexes : constant Alire.Features.Index.Index_On_Disk_Set :=
-                  Alire.Features.Index.Find_All
+      Indexes : constant Index_Load.Index_On_Disk_Set :=
+                  Index_Load.Find_All
                     (Alire.Config.Edit.Indexes_Directory, Result);
 
       Table : AAA.Table_IO.Table;
@@ -212,8 +213,7 @@ package body Alr.Commands.Index is
    ---------------------
 
    procedure Reset_Community is
-      Result : constant Alire.Outcome :=
-                 Alire.Features.Index.Add_Or_Reset_Community;
+      Result : constant Alire.Outcome := Index_Load.Add_Or_Reset_Community;
    begin
       if not Result.Success then
          Reportaise_Command_Failed (Result.Message);
@@ -291,7 +291,7 @@ package body Alr.Commands.Index is
 
    procedure Update_All is
       Result : constant Alire.Outcome :=
-                 Alire.Features.Index.Update_All
+                 Index_Load.Update_All
                    (Alire.Config.Edit.Indexes_Directory);
    begin
       if not Result.Success then

--- a/src/alr/alr-commands-version.adb
+++ b/src/alr/alr-commands-version.adb
@@ -1,6 +1,6 @@
 with Alire.Config.Edit;
-with Alire.Features.Index;
 with Alire.Index;
+with Alire.Index_On_Disk.Loading;
 with Alire.Milestones;
 with Alire.Properties;
 with Alire.Roots.Optional;
@@ -30,8 +30,8 @@ package body Alr.Commands.Version is
       use all type Alire.Roots.Optional.States;
       Table : Alire.Utils.Tables.Table;
       Index_Outcome : Alire.Outcome;
-      Indexes : constant Alire.Features.Index.Index_On_Disk_Set :=
-                  Alire.Features.Index.Find_All
+      Indexes : constant Alire.Index_On_Disk.Loading.Index_On_Disk_Set :=
+                  Alire.Index_On_Disk.Loading.Find_All
                     (Alire.Config.Edit.Indexes_Directory, Index_Outcome);
       Root : constant Alire.Roots.Optional.Root :=
                Alire.Roots.Optional.Search_Root (Alire.Directories.Current);

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -10,7 +10,7 @@ with Alire.Platforms;
 with Alire_Early_Elaboration;
 with Alire.Config.Edit;
 with Alire.Errors;
-with Alire.Features.Index;
+with Alire.Index_On_Disk.Loading;
 with Alire.Lockfiles;
 with Alire.Paths;
 with Alire.Platforms.Current;
@@ -245,7 +245,7 @@ package body Alr.Commands is
                                   Force_Reload : Boolean := False) is
       pragma Unreferenced (Cmd);
    begin
-      Alire.Features.Index.Setup_And_Load
+      Alire.Index_On_Disk.Loading.Setup_And_Load
         (From   => Alire.Config.Edit.Indexes_Directory,
          Strict => Strict,
          Force  => Force_Reload);


### PR DESCRIPTION
The Alire.Features.* hierarchy was ill-conceived and never went anywere, so I'm getting rid of it by renaming the only child there to a more sensible location/name.