### PR TITLE
Alire.Properties.Configurations: revert forced mixed case

### DIFF
--- a/src/alire/alire-crate_configuration.adb
+++ b/src/alire/alire-crate_configuration.adb
@@ -27,7 +27,8 @@ package body Alire.Crate_Configuration is
 
    function Builtin_Build_Profile is new Typedef_From_Enum
      (Alire.Utils.Switches.Profile_Kind,
-      "Build_Profile");
+      "Build_Profile",
+      Lower_Case => True);
 
    use Config_Type_Definition_Holder;
 
@@ -172,7 +173,8 @@ package body Alire.Crate_Configuration is
          This.Set_Value
            (Profile_Maps.Key (Cursor),
             (Name => +Builtin_Build_Profile.Name,
-             Value => TOML.Create_String (Profile_Maps.Element (Cursor)'Img)));
+             Value => TOML.Create_String
+               (To_Lower_Case (Profile_Maps.Element (Cursor)'Img))));
       end loop;
 
    end Make_Build_Profile_Map;

--- a/src/alire/alire-properties-configurations.adb
+++ b/src/alire/alire-properties-configurations.adb
@@ -52,10 +52,9 @@ package body Alire.Properties.Configurations is
 
          declare
             Val : constant String := Str_Array.Item (Index).As_String;
-            Val_Str : constant Unbounded_String :=
-              +(if Wrap_With_Quotes
-                then """" & To_Mixed_Case (Val) & """"
-                else To_Mixed_Case (Val));
+            Val_Str : constant Unbounded_String := +(if Wrap_With_Quotes
+                                                     then """" & Val & """"
+                                                     else Val);
          begin
             if First then
                Res := Res & Val_Str;
@@ -427,7 +426,7 @@ package body Alire.Properties.Configurations is
                                 return String
    is
       use ASCII;
-      Name : constant String := To_Mixed_Case (+This.Name);
+      Name : constant String := +This.Name;
       Indent : constant String := "   ";
    begin
       case This.Kind is
@@ -444,7 +443,7 @@ package body Alire.Properties.Configurations is
             return Indent & "type " & Name & "_Kind is (" &
               To_String (This.Values) & ");" & LF &
               Indent & Name & " : constant " & Name & "_Kind := " &
-              To_Mixed_Case (Value.As_String) & ";";
+              Value.As_String & ";";
 
          when Real =>
 
@@ -511,7 +510,7 @@ package body Alire.Properties.Configurations is
             return Indent & "type " & Name & "_Kind is (" &
               To_String (This.Values, Wrap_With_Quotes => True) & ");" & LF &
               Indent & Name & " : " & Name & "_Kind := """ &
-              To_Mixed_Case (Value.As_String) & """;";
+              Value.As_String & """;";
 
          when Real =>
 
@@ -902,7 +901,11 @@ package body Alire.Properties.Configurations is
          Values  => TOML.Create_Array);
    begin
       for P in T loop
-         Ret.Values.Append (TOML.Create_String (P'Img));
+         if Lower_Case then
+            Ret.Values.Append (TOML.Create_String (To_Lower_Case (P'Img)));
+         else
+            Ret.Values.Append (TOML.Create_String (P'Img));
+         end if;
       end loop;
       return Ret;
    end Typedef_From_Enum;

--- a/src/alire/alire-properties-configurations.ads
+++ b/src/alire/alire-properties-configurations.ads
@@ -97,6 +97,7 @@ package Alire.Properties.Configurations with Preelaborate is
    generic
       type T is (<>);
       Type_Name : String;
+      Lower_Case : Boolean := False;
    function Typedef_From_Enum return Config_Type_Definition;
 
    function String_Typedef (Name : String) return Config_Type_Definition;

--- a/testsuite/tests/build_profile/alr_build_switches/test.py
+++ b/testsuite/tests/build_profile/alr_build_switches/test.py
@@ -37,7 +37,7 @@ def check_config_not_changed():
 
 
 # Check default profiles for root and dependency
-check_config(bin_config, 'Development')
+check_config(bin_config, 'development')
 
 # Check that the project builds
 run_alr('build')
@@ -45,22 +45,22 @@ run_alr('build')
 # Build in validation mode
 run_alr('build', '--validation')
 check_config_changed()
-check_config(bin_config, 'Validation')
+check_config(bin_config, 'validation')
 
 # Build in validation mode
 run_alr('build', '--development')
 check_config_changed()
-check_config(bin_config, 'Development')
+check_config(bin_config, 'development')
 
 # Build in release mode
 run_alr('build', '--release')
 check_config_changed()
-check_config(bin_config, 'Release')
+check_config(bin_config, 'release')
 
 # Alr with will re-generate the crate config and default to DEVELOPMENT
 alr_with('lib_1', path='../lib_1')
 check_config_changed()
-check_config(bin_config, 'Development')
+check_config(bin_config, 'development')
 
 # Build with default profile, the config should not change
 run_alr('build')

--- a/testsuite/tests/build_profile/custom_profiles/test.py
+++ b/testsuite/tests/build_profile/custom_profiles/test.py
@@ -28,9 +28,9 @@ lib2_config = '../lib_2/config/lib_2_config.gpr'
 bin_config = 'config/bin_1_config.gpr'
 
 # Check default profiles for root and dependency
-check_config(lib1_config, 'Release', ['-O3', '-gnatn'])
-check_config(lib2_config, 'Release', ['-O3', '-gnatn'])
-check_config(bin_config, 'Development', ['-Og', '-g', '-gnatwa', '-gnaty3'])
+check_config(lib1_config, 'release', ['-O3', '-gnatn'])
+check_config(lib2_config, 'release', ['-O3', '-gnatn'])
+check_config(bin_config, 'development', ['-Og', '-g', '-gnatwa', '-gnaty3'])
 
 # Create custom Release profile for lib_1
 with open('../lib_1/alire.toml', "a") as manifest:
@@ -54,9 +54,9 @@ with open(alr_manifest(), "a") as manifest:
     manifest.write('lib_2 = "validation"\n')
 
 run_alr('update')
-check_config(lib1_config, 'Release', ['-Os', '-gnata', '-gnat12'])
-check_config(lib2_config, 'Validation', ['-Og', '-gnatX'])
-check_config(bin_config, 'Development', ['-Og', '-g', '-gnatwa', '-gnaty3'])
+check_config(lib1_config, 'release', ['-Os', '-gnata', '-gnat12'])
+check_config(lib2_config, 'validation', ['-Og', '-gnatX'])
+check_config(bin_config, 'development', ['-Og', '-g', '-gnatwa', '-gnaty3'])
 
 # Check that the project builds
 run_alr('build')

--- a/testsuite/tests/build_profile/custom_switches/test.py
+++ b/testsuite/tests/build_profile/custom_switches/test.py
@@ -53,8 +53,8 @@ expected_switches = ['-opt-switch',
                      '-style-switch2',
                      '-ada-version']
 
-check_config(lib1_config, 'Release', expected_switches)
-check_config(lib2_config, 'Release', expected_switches)
-check_config(bin_config, 'Development', expected_switches)
+check_config(lib1_config, 'release', expected_switches)
+check_config(lib2_config, 'release', expected_switches)
+check_config(bin_config, 'development', expected_switches)
 
 print('SUCCESS')

--- a/testsuite/tests/build_profile/default/test.py
+++ b/testsuite/tests/build_profile/default/test.py
@@ -28,24 +28,24 @@ lib2_config = "../lib_2/config/lib_2_config.gpr"
 bin_config = "config/bin_1_config.gpr"
 
 # Check default profiles for root and dependency
-check_config(lib1_config, 'Release', ['-O3', '-gnatn'])
-check_config(lib2_config, 'Release', ['-O3', '-gnatn'])
-check_config(bin_config, 'Development', ['-Og', '-g', '-gnatwa', '-gnaty3'])
+check_config(lib1_config, 'release', ['-O3', '-gnatn'])
+check_config(lib2_config, 'release', ['-O3', '-gnatn'])
+check_config(bin_config, 'development', ['-Og', '-g', '-gnatwa', '-gnaty3'])
 
 # Check if we can change the profile of a dependency
 with open(alr_manifest(), "a") as manifest:
     manifest.write('[build-profiles]\n')
     manifest.write('lib_1 = "development"\n')
 run_alr('update')
-check_config(lib1_config, 'Development', ['-Og'])
+check_config(lib1_config, 'development', ['-Og'])
 
 # Check wildcard profile setting
 with open(alr_manifest(), "a") as manifest:
     manifest.write('"*" = "validation"\n')
 run_alr('update')
-check_config(lib1_config, 'Development', ['-Og'])
-check_config(lib2_config, 'Validation', ['-gnatwe'])
-check_config(bin_config, 'Validation', ['-gnatwe'])
+check_config(lib1_config, 'development', ['-Og'])
+check_config(lib2_config, 'validation', ['-gnatwe'])
+check_config(bin_config, 'validation', ['-gnatwe'])
 
 # Check that the project builds
 run_alr('build')


### PR DESCRIPTION
Forcing mixed case for enum values breaks existing crates (atomic).