### PR TITLE
Alr.Commands.Init: Create share folder for resources

### DIFF
--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -37,6 +37,8 @@ package body Alr.Commands.Init is
          then Get_Current_Dir
          else Create (+Name, Normalize => True));
       Src_Directory : constant Virtual_File := Directory / "src";
+      Share_Directory : constant Virtual_File :=
+         Directory / "share" / Filesystem_String (Lower_Name);
 
       File : TIO.File_Type;
 
@@ -134,6 +136,10 @@ package body Alr.Commands.Init is
          Put_Line ("   package Binder is");
          Put_Line ("      for Switches (""Ada"") use (""-Es""); --  Symbolic traceback");
          Put_Line ("   end Binder;");
+         Put_New_Line;
+         Put_Line ("   package Install is");
+         Put_Line ("      for Artifacts (""."") use (""share"");");
+         Put_Line ("   end Install;");
          Put_New_Line;
          TIO.Put (File, "end " & Mixed_Name & ";");
          pragma Style_Checks ("M80");
@@ -295,6 +301,7 @@ package body Alr.Commands.Init is
       if not Cmd.No_Skel then
          Generate_Project_File;
          Src_Directory.Make_Dir;
+         Share_Directory.Make_Dir;
          if For_Library then
             Generate_Root_Package;
          else

--- a/testsuite/tests/workflows/init-options/test.py
+++ b/testsuite/tests/workflows/init-options/test.py
@@ -19,6 +19,8 @@ assert_match(".*Identifiers must be.*", p.out)
 run_alr('init', '--bin', 'xxx')
 compare(contents('xxx'), ['xxx/.gitignore',
                           'xxx/alire.toml',
+                          'xxx/share',
+                          'xxx/share/xxx',
                           'xxx/src',
                           'xxx/src/xxx.adb',
                           'xxx/xxx.gpr'])
@@ -29,6 +31,8 @@ run_alr('init', '--bin', 'aaa')
 compare(contents('aaa'), ['aaa/.gitignore',
                           'aaa/aaa.gpr',
                           'aaa/alire.toml',
+                          'aaa/share',
+                          'aaa/share/aaa',
                           'aaa/src',
                           'aaa/src/aaa.adb'])
 
@@ -62,6 +66,8 @@ os.chdir('zzz')
 run_alr('init', '--bin', '--in-place', 'zzz')
 compare(contents('.'), ['./.gitignore',
                         './alire.toml',
+                        './share',
+                        './share/zzz',
                         './src',
                         './src/zzz.adb',
                         './zzz.gpr'])


### PR DESCRIPTION
Note that gprinstall won't complain if this folder doesn't exists, so
users can decided to leave it empty or remove it in case they don't have
resources.