### PR TITLE
Alr.Commands.Init: change default version for new crates to 0.1.0-dev

### DIFF
--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -238,7 +238,7 @@ package body Alr.Commands.Init is
             end if;
             Put_Line ("name = " & Q (Lower_Name));
             Put_Line ("description = " & Q ("Shiny new project"));
-            Put_Line ("version = " & Q ("0.0.0"));
+            Put_Line ("version = " & Q ("0.1.0-dev"));
             Put_New_Line;
             Put_Line ("authors = " & Arr (Q (Username)));
             Put_Line ("maintainers = "

--- a/testsuite/tests/get/indirect-link/test.py
+++ b/testsuite/tests/get/indirect-link/test.py
@@ -32,9 +32,9 @@ run_alr('with', 'tier1')
 p = run_alr('with', '--solve')
 assert_match('.*' +
              re.escape('Dependencies (graph):\n'
-                       '   tier1=1.0.0 --> tier2*              \n'
-                       '   xxx=0.0.0   --> tier1=1.0.0 (^1.0.0)\n'
-                       '   xxx=0.0.0   --> tier2^1.0.0         ') + '.*',
+                       '   tier1=1.0.0   --> tier2*              \n'
+                       '   xxx=0.1.0-dev --> tier1=1.0.0 (^1.0.0)\n'
+                       '   xxx=0.1.0-dev --> tier2^1.0.0         ') + '.*',
              p.out, flags=re.S)
 
 

--- a/testsuite/tests/monorepo/basic/test.py
+++ b/testsuite/tests/monorepo/basic/test.py
@@ -37,7 +37,7 @@ os.chdir("mycrate")
 run_alr("show")  # Verify the crate is detected properly
 
 # This call creates the manifest and puts it in place in the index
-alr_publish("mycrate", "0.0.0", index_path=os.path.join(start_dir, "my_index"))
+alr_publish("mycrate", "0.1.0-dev", index_path=os.path.join(start_dir, "my_index"))
 
 # Verify that the crate can be got and compiled, and expected location
 os.chdir(start_dir)
@@ -58,7 +58,7 @@ assert os.path.isfile(os.path.join(
 # Also that the info file is there
 assert os.path.isfile(os.path.join(
     "alire", "cache", "dependencies",
-    f"mycrate_0.0.0_in_monoproject_{commit[:8]}")), \
+    f"mycrate_0.1.0_in_monoproject_{commit[:8]}")), \
     "Expected info file does not exist"
 
 print('SUCCESS')

--- a/testsuite/tests/monorepo/doubly-nested/test.py
+++ b/testsuite/tests/monorepo/doubly-nested/test.py
@@ -29,11 +29,11 @@ os.chdir(os.path.join("monoproject", "myparent", "mychild"))
 run_alr("show")  # Verify the crate is detected properly
 
 # This call publishes and "submits" the release to our local index
-alr_publish("mychild", "0.0.0", index_path=index_dir)
+alr_publish("mychild", "0.1.0-dev", index_path=index_dir)
 
 # Publish also its parent for later test
 os.chdir("..")
-alr_publish("myparent", "0.0.0", index_path=index_dir)
+alr_publish("myparent", "0.1.0-dev", index_path=index_dir)
 
 # Verify that the crate can be got and compiled, and expected location
 os.chdir(start_dir)
@@ -54,7 +54,7 @@ assert os.path.isdir(os.path.join("alire", "cache", "dependencies",
 # Verify that "with"ing the parent does not result in a new checkout
 alr_with("myparent", update=False)
 p = run_alr("-v", "update", quiet=False)
-assert "Skipping checkout of already available myparent=0.0.0" in p.out, \
+assert "Skipping checkout of already available myparent=0.1.0-dev" in p.out, \
     "Expected output not found: " + p.out
 
 # Verify the build is successful. As the dependencies were created with --bin,

--- a/testsuite/tests/monorepo/multi-commit/test.py
+++ b/testsuite/tests/monorepo/multi-commit/test.py
@@ -29,7 +29,7 @@ assert run(["git", "clone",
 # We are now at monoproject/mycrate.
 os.chdir("monoproject")
 os.chdir("crate1")
-alr_publish("crate1", "0.0.0", index_path=os.path.join(start_dir, "my_index"))
+alr_publish("crate1", "0.1.0-dev", index_path=os.path.join(start_dir, "my_index"))
 
 # We create a second crate at another commit
 os.chdir(os.path.join(start_dir, "monoproject.upstream"))
@@ -41,7 +41,7 @@ commit2 = commit_all("monoproject.upstream")
 os.chdir("monoproject")
 run(["git", "pull"]).check_returncode()
 os.chdir("crate2")
-alr_publish("crate2", "0.0.0", index_path=os.path.join(start_dir, "my_index"))
+alr_publish("crate2", "0.1.0-dev", index_path=os.path.join(start_dir, "my_index"))
 
 # Verify that the crates are usable as a dependency, and expected binary
 # locations
@@ -64,11 +64,11 @@ assert os.path.isfile(os.path.join(
 # Also that the info files are there
 assert os.path.isfile(os.path.join(
     "alire", "cache", "dependencies",
-    f"crate1_0.0.0_in_monoproject_{commit1[:8]}")), \
+    f"crate1_0.1.0_in_monoproject_{commit1[:8]}")), \
     "Expected info file does not exist"
 assert os.path.isfile(os.path.join(
     "alire", "cache", "dependencies",
-    f"crate2_0.0.0_in_monoproject_{commit2[:8]}")), \
+    f"crate2_0.1.0_in_monoproject_{commit2[:8]}")), \
     "Expected info file does not exist"
 
 print('SUCCESS')

--- a/testsuite/tests/monorepo/subdir-in-tar/test.py
+++ b/testsuite/tests/monorepo/subdir-in-tar/test.py
@@ -17,16 +17,16 @@ init_local_crate("xxx", enter=True)
 # generated location as the "online" location, and this works because we are
 # forcing.
 p = run(["alr", "-q", "-f", "-n", "publish", "--skip-build", "--tar"],
-        input=f"file:{os.getcwd()}/alire/archives/xxx-0.0.0.tbz2\n".encode())
+        input=f"file:{os.getcwd()}/alire/archives/xxx-0.1.0-dev.tbz2\n".encode())
 p.check_returncode()
 
 # Add improper subdir to manifest
-with open("alire/releases/xxx-0.0.0.toml", "at") as file:
+with open("alire/releases/xxx-0.1.0-dev.toml", "at") as file:
     file.write("subdir='.'\n")
 
 # Submit manifest to index
 os.chdir("..")
-alr_submit("xxx/alire/releases/xxx-0.0.0.toml", "my_index")
+alr_submit("xxx/alire/releases/xxx-0.1.0-dev.toml", "my_index")
 
 # Should complain on subdir field
 p = run_alr("show", "xxx", complain_on_error=False)

--- a/testsuite/tests/pin/change-path/test.py
+++ b/testsuite/tests/pin/change-path/test.py
@@ -38,7 +38,7 @@ p = run_alr("pin", quiet=False)
 assert_eq("""Note: Synchronizing workspace...
 Dependencies automatically updated as follows:
 
-   · yyy 0.0.0 (path=../nest2/yyy)
+   · yyy 0.1.0-dev (path=../nest2/yyy)
 
 yyy file:../nest2/yyy \n""",
           p.out)

--- a/testsuite/tests/pin/circularity/test.py
+++ b/testsuite/tests/pin/circularity/test.py
@@ -76,16 +76,16 @@ Pins (direct):
    dep3 = { path='../dep3' }
    dep4 = { path='../dep4' }
 Dependencies (solution):
-   dep2=0.0.0 (pinned) (origin: ../dep2)
-   dep3=0.0.0 (pinned) (origin: ../dep3)
-   dep4=0.0.0 (pinned) (origin: ../dep4)
+   dep2=0.1.0-dev (pinned) (origin: ../dep2)
+   dep3=0.1.0-dev (pinned) (origin: ../dep3)
+   dep4=0.1.0-dev (pinned) (origin: ../dep4)
 Dependencies (graph):
-   dep1=0.0.0 --> dep2=0.0.0 (*)
-   dep1=0.0.0 --> dep3=0.0.0 (*)
-   dep1=0.0.0 --> dep4=0.0.0 (*)
-   dep2=0.0.0 --> dep3=0.0.0 (*)
-   dep2=0.0.0 --> dep4=0.0.0 (*)
-   dep3=0.0.0 --> dep4=0.0.0 (*)
+   dep1=0.1.0-dev --> dep2=0.1.0-dev (*)
+   dep1=0.1.0-dev --> dep3=0.1.0-dev (*)
+   dep1=0.1.0-dev --> dep4=0.1.0-dev (*)
+   dep2=0.1.0-dev --> dep3=0.1.0-dev (*)
+   dep2=0.1.0-dev --> dep4=0.1.0-dev (*)
+   dep3=0.1.0-dev --> dep4=0.1.0-dev (*)
 """,
           p.out)
 

--- a/testsuite/tests/pin/version/test.py
+++ b/testsuite/tests/pin/version/test.py
@@ -39,7 +39,7 @@ Pins (direct):
 Dependencies (external):
    hello=7.7.7 (direct,missed,pin=7.7.7) (pinned)
 Dependencies (graph):
-   xxx=0.0.0 --> hello*
+   xxx=0.1.0-dev --> hello*
 """, p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/publish/local-repo-nonstd/test.py
+++ b/testsuite/tests/publish/local-repo-nonstd/test.py
@@ -13,7 +13,7 @@ import os
 
 
 def verify_manifest():
-    target = os.path.join("alire", "releases", "xxx-0.0.0.toml")
+    target = os.path.join("alire", "releases", "xxx-0.1.0-dev.toml")
     assert os.path.isfile(target), \
         "Index manifest not found at expected location"
     # Clean up for next test

--- a/testsuite/tests/publish/local-repo/test.py
+++ b/testsuite/tests/publish/local-repo/test.py
@@ -13,7 +13,7 @@ import os
 
 
 def verify_manifest():
-    target = os.path.join("alire", "releases", "xxx-0.0.0.toml")
+    target = os.path.join("alire", "releases", "xxx-0.1.0-dev.toml")
     assert os.path.isfile(target), \
         "Index manifest not found at expected location"
     # Clean up for next test

--- a/testsuite/tests/publish/pin-removal/test.py
+++ b/testsuite/tests/publish/pin-removal/test.py
@@ -36,7 +36,7 @@ os.chdir(crate)
 assert_match(".*\[\[pins\]\].*", content_of(alr_manifest()))
 
 # We publish with the pin in the manifest
-p = alr_publish(crate, "0.0.0",
+p = alr_publish(crate, "0.1.0-dev",
                 index_path=os.path.join(start_dir, "my_index"),
                 submit=False,
                 quiet=False)
@@ -46,7 +46,7 @@ assert_match(".*contains pins that will be removed.*", p.out)
 
 # Verify no pins in the generated file
 assert "[[pins]]" not in \
-    content_of(os.path.join("alire", "releases", f"{crate}-0.0.0.toml")), \
+    content_of(os.path.join("alire", "releases", f"{crate}-0.1.0-dev.toml")), \
     "Unexpected contents in published file"
 
 print('SUCCESS')

--- a/testsuite/tests/publish/remote-origin-nonstd/test.py
+++ b/testsuite/tests/publish/remote-origin-nonstd/test.py
@@ -12,7 +12,7 @@ import os
 
 
 def verify_manifest():
-    target = os.path.join("alire", "releases", "xxx-0.0.0.toml")
+    target = os.path.join("alire", "releases", "xxx-0.1.0-dev.toml")
     assert os.path.isfile(target), \
         "Index manifest not found at expected location"
     # Minimally check the expected contents are in the file
@@ -53,8 +53,8 @@ run_alr("publish", f"git+file:{target}", head_commit,
 verify_manifest()
 
 # Copy the new index manifest into the index
-copyfile(os.path.join("alire", "releases", "xxx-0.0.0.toml"),
-         os.path.join("my_index", "xx", "xxx", "xxx-0.0.0.toml"))
+copyfile(os.path.join("alire", "releases", "xxx-0.1.0-dev.toml"),
+         os.path.join("my_index", "xx", "xxx", "xxx-0.1.0-dev.toml"))
 
 p = run_alr("search", "--crates")
 assert "xxx" in p.out, "Crate not found in index contents"

--- a/testsuite/tests/publish/remote-origin/test.py
+++ b/testsuite/tests/publish/remote-origin/test.py
@@ -12,7 +12,7 @@ import os
 
 
 def verify_manifest():
-    target = os.path.join("alire", "releases", "xxx-0.0.0.toml")
+    target = os.path.join("alire", "releases", "xxx-0.1.0-dev.toml")
     assert os.path.isfile(target), \
         "Index manifest not found at expected location"
     # Minimally check the expected contents are in the file
@@ -50,8 +50,8 @@ run_alr("publish", f"git+file:{target}", head_commit, force=True)
 verify_manifest()
 
 # Copy the new index manifest into the index
-copyfile(os.path.join("alire", "releases", "xxx-0.0.0.toml"),
-         os.path.join("my_index", "xx", "xxx", "xxx-0.0.0.toml"))
+copyfile(os.path.join("alire", "releases", "xxx-0.1.0-dev.toml"),
+         os.path.join("my_index", "xx", "xxx", "xxx-0.1.0-dev.toml"))
 
 p = run_alr("search", "--crates")
 assert "xxx" in p.out, "Crate not found in index contents"

--- a/testsuite/tests/publish/tarball-plaindir-nonstd/test.py
+++ b/testsuite/tests/publish/tarball-plaindir-nonstd/test.py
@@ -26,25 +26,25 @@ with open(os.path.join("alire", canary), "wt") as file:
 # forcing.
 p = run(["alr", "-q", "-f", "-n", "publish", "--skip-build", "--tar",
          "--manifest", "xxx.toml"],
-        input=f"file:{os.getcwd()}/alire/archives/xxx-0.0.0.tbz2\n".encode())
+        input=f"file:{os.getcwd()}/alire/archives/xxx-0.1.0-dev.tbz2\n".encode())
 p.check_returncode()
 
 # Verify the generated file does not contain the alire folder
-p = run(["tar", "tf", "alire/archives/xxx-0.0.0.tbz2"],
+p = run(["tar", "tf", "alire/archives/xxx-0.1.0-dev.tbz2"],
         capture_output=True)
 p.check_returncode()
 assert "xxx-0.0.0/alire/" not in p.stdout.decode(), \
     "Unexpected contents in tarball: " + p.stdout.decode()
 
 # Verify the index manifest has been generated
-assert os.path.isfile("./alire/releases/xxx-0.0.0.toml")
+assert os.path.isfile("./alire/releases/xxx-0.1.0-dev.toml")
 
 os.chdir("..")
 
 # Add this manifest to our local index, and retrieve + build the crate
 os.makedirs("my_index/index/xx/xxx")
-copyfile("xxx/alire/releases/xxx-0.0.0.toml",
-         "my_index/index/xx/xxx/xxx-0.0.0.toml")
+copyfile("xxx/alire/releases/xxx-0.1.0-dev.toml",
+         "my_index/index/xx/xxx/xxx-0.1.0-dev.toml")
 
 run_alr("get", "--build", "xxx")  # Should not err
 

--- a/testsuite/tests/publish/tarball-plaindir/test.py
+++ b/testsuite/tests/publish/tarball-plaindir/test.py
@@ -23,25 +23,25 @@ with open(os.path.join("alire", canary), "wt") as file:
 # generated location as the "online" location, and this works because we are
 # forcing.
 p = run(["alr", "-q", "-f", "-n", "publish", "--skip-build", "--tar"],
-        input=f"file:{os.getcwd()}/alire/archives/xxx-0.0.0.tbz2\n".encode())
+        input=f"file:{os.getcwd()}/alire/archives/xxx-0.1.0-dev.tbz2\n".encode())
 p.check_returncode()
 
 # Verify the generated file does not contain the alire folder
-p = run(["tar", "tf", "alire/archives/xxx-0.0.0.tbz2"],
+p = run(["tar", "tf", "alire/archives/xxx-0.1.0-dev.tbz2"],
         capture_output=True)
 p.check_returncode()
 assert "xxx-0.0.0/alire/" not in p.stdout.decode(), \
     "Unexpected contents in tarball: " + p.stdout.decode()
 
 # Verify the index manifest has been generated
-assert os.path.isfile("./alire/releases/xxx-0.0.0.toml")
+assert os.path.isfile("./alire/releases/xxx-0.1.0-dev.toml")
 
 os.chdir("..")
 
 # Add this manifest to our local index, and retrieve + build the crate
 os.makedirs("my_index/index/xx/xxx")
-copyfile("xxx/alire/releases/xxx-0.0.0.toml",
-         "my_index/index/xx/xxx/xxx-0.0.0.toml")
+copyfile("xxx/alire/releases/xxx-0.1.0-dev.toml",
+         "my_index/index/xx/xxx/xxx-0.1.0-dev.toml")
 
 run_alr("get", "--build", "xxx")  # Should not err
 

--- a/testsuite/tests/publish/tarball-repo-nonstd/test.py
+++ b/testsuite/tests/publish/tarball-repo-nonstd/test.py
@@ -27,18 +27,18 @@ os.chdir("xxx")
 # forcing. ".tgz" is used, as bzip2 is not supported by `git archive`.
 p = run(["alr", "-q", "-f", "-n", "publish", "--skip-build", "--tar",
          "--manifest", "xxx.toml"],
-        input=f"file:{os.getcwd()}/alire/archives/xxx-0.0.0.tgz\n".encode())
+        input=f"file:{os.getcwd()}/alire/archives/xxx-0.1.0-dev.tgz\n".encode())
 p.check_returncode()
 
 # Verify the index manifest has been generated
-assert os.path.isfile("./alire/releases/xxx-0.0.0.toml")
+assert os.path.isfile("./alire/releases/xxx-0.1.0-dev.toml")
 
 os.chdir("..")
 
 # Add this manifest to our local index, and retrieve + build the crate
 os.makedirs("my_index/index/xx/xxx")
-copyfile("xxx/alire/releases/xxx-0.0.0.toml",
-         "my_index/index/xx/xxx/xxx-0.0.0.toml")
+copyfile("xxx/alire/releases/xxx-0.1.0-dev.toml",
+         "my_index/index/xx/xxx/xxx-0.1.0-dev.toml")
 
 run_alr("get", "--build", "xxx")  # Should not err
 

--- a/testsuite/tests/publish/tarball-repo/test.py
+++ b/testsuite/tests/publish/tarball-repo/test.py
@@ -25,18 +25,18 @@ os.chdir("xxx")
 # generated location as the "online" location, and this works because we are
 # forcing. ".tgz" is used, as bzip2 is not supported by `git archive`.
 p = run(["alr", "-q", "-f", "-n", "publish", "--skip-build", "--tar"],
-        input=f"file:{os.getcwd()}/alire/archives/xxx-0.0.0.tgz\n".encode())
+        input=f"file:{os.getcwd()}/alire/archives/xxx-0.1.0-dev.tgz\n".encode())
 p.check_returncode()
 
 # Verify the index manifest has been generated
-assert os.path.isfile("./alire/releases/xxx-0.0.0.toml")
+assert os.path.isfile("./alire/releases/xxx-0.1.0-dev.toml")
 
 os.chdir("..")
 
 # Add this manifest to our local index, and retrieve + build the crate
 os.makedirs("my_index/index/xx/xxx")
-copyfile("xxx/alire/releases/xxx-0.0.0.toml",
-         "my_index/index/xx/xxx/xxx-0.0.0.toml")
+copyfile("xxx/alire/releases/xxx-0.1.0-dev.toml",
+         "my_index/index/xx/xxx/xxx-0.1.0-dev.toml")
 
 run_alr("get", "--build", "xxx")  # Should not err
 

--- a/testsuite/tests/solver/one-dep-two-constraints/test.py
+++ b/testsuite/tests/solver/one-dep-two-constraints/test.py
@@ -18,7 +18,8 @@ run_alr('with', 'hello^1')
 p = run_alr('with', '--solve')
 assert_match('.*'  # skip solution
              'Dependencies \(graph\):\n'
-             '   hello=1.0.1 --> libhello=1.1.0 \(\^1.0\).*',
+             '   hello=1.0.1   --> libhello=1.1.0 \(\^1.0\)\n'
+             '   xxx=0.1.0-dev --> hello=1.0.1 \(\^1\).*',
              p.out, flags=re.S)
 
 # Add dependency on superhello*. Solution is superhello=1.0 --> libhello=1.0.1

--- a/testsuite/tests/with/external/test.py
+++ b/testsuite/tests/with/external/test.py
@@ -25,7 +25,7 @@ assert_match('Dependencies \(direct\):\n'
              'Dependencies \(external\):\n'
              '   make\* \(direct,hinted\)\n'
              'Dependencies \(graph\):\n'
-             '   xxx=0.0.0 --> make\*\n'
+             '   xxx=0.1.0-dev --> make\*\n'
              '.*',  # skip plot or warning
              p.out, flags=re.S)
 

--- a/testsuite/tests/with/tree-switch/test.py
+++ b/testsuite/tests/with/tree-switch/test.py
@@ -28,7 +28,7 @@ run_alr('with', 'unobtanium', force=True)
 # Verify printout (but for test-dependent path)
 # Note that superhello was auto-narrowed down to ^1, but missed ones did not
 p = run_alr('with', '--tree')
-assert_match(re.escape('''xxx=0.0.0
+assert_match(re.escape('''xxx=0.1.0-dev
 +-- hello=1.0.1 (^1)
 |   +-- libhello=1.0.1 (^1.0)
 +-- superhello=1.0.0 (^1.0.0)


### PR DESCRIPTION
The intent is to have a better default for a good release scheme.
