### PR TITLE
Implement load of individual crates from index

### DIFF
--- a/src/alire/alire-index_on_disk-loading.adb
+++ b/src/alire/alire-index_on_disk-loading.adb
@@ -307,7 +307,7 @@ package body Alire.Index_On_Disk.Loading is
       end if;
 
       if not Result.Success then
-         return Empty;
+         return Default;
       end if;
 
       Trace.Detail ("Found" & Indexes.Length'Img & " indexes");

--- a/src/alire/alire-index_on_disk-loading.adb
+++ b/src/alire/alire-index_on_disk-loading.adb
@@ -26,7 +26,7 @@ package body Alire.Index_On_Disk.Loading is
                  Before : String := "") return Outcome is
 
       Result  : Outcome;
-      Indexes : constant Index_On_Disk_Set := Find_All (Under, Result);
+      Indexes : constant Set := Find_All (Under, Result);
 
       -----------------------
       -- Adjust_Priorities --
@@ -147,7 +147,7 @@ package body Alire.Index_On_Disk.Loading is
    function Add_Or_Reset_Community return Outcome is
       Result : Outcome with Warnings => Off;
       --  Spurious warning to be silenced in Debian stable/Ubuntu LTS GNATs.
-      Indexes : constant Sets.Set :=
+      Indexes : constant Set :=
                   Find_All (Config.Edit.Indexes_Directory, Result);
       use Sets;
    begin
@@ -197,7 +197,7 @@ package body Alire.Index_On_Disk.Loading is
                              Force  : Boolean := False)
    is
       Result  : Outcome;
-      Indexes : Index_On_Disk_Set;
+      Indexes : Set;
    begin
       if Alire.Index.Crate_Count /= 0 and then not Force then
          Trace.Detail ("Index already loaded, loading skipped");
@@ -241,11 +241,11 @@ package body Alire.Index_On_Disk.Loading is
 
    function Find_All
      (Under  : Absolute_Path;
-      Result : out Outcome) return Index_On_Disk_Set
+      Result : out Outcome) return Set
    is
       package Dirs renames Ada.Directories;
 
-      Set : Index_On_Disk_Set;
+      Indexes : Set;
 
       ---------------
       -- Check_One --
@@ -280,7 +280,7 @@ package body Alire.Index_On_Disk.Loading is
                                Result => Result);
                begin
                   if Result.Success then
-                     Set.Insert (Index);
+                     Indexes.Insert (Index);
                   end if;
                end;
             end if;
@@ -306,12 +306,12 @@ package body Alire.Index_On_Disk.Loading is
       end if;
 
       if not Result.Success then
-         return Sets.Empty_Set;
+         return Empty;
       end if;
 
-      Trace.Detail ("Found" & Set.Length'Img & " indexes");
+      Trace.Detail ("Found" & Indexes.Length'Img & " indexes");
 
-      return Set;
+      return Indexes;
    end Find_All;
 
    --------------
@@ -321,7 +321,7 @@ package body Alire.Index_On_Disk.Loading is
    function Load_All (From : Absolute_Path; Strict : Boolean) return Outcome
    is
       Result  : Outcome;
-      Indexes : constant Index_On_Disk_Set := Find_All (From, Result);
+      Indexes : constant Set := Find_All (From, Result);
    begin
       if not Result.Success then
          return Result;
@@ -364,7 +364,7 @@ package body Alire.Index_On_Disk.Loading is
 
    function Update_All (Under : Absolute_Path) return Outcome is
       Result  : Outcome;
-      Indexes : constant Index_On_Disk_Set := Find_All (Under, Result);
+      Indexes : constant Set := Find_All (Under, Result);
    begin
       if not Result.Success then
          return Result;

--- a/src/alire/alire-index_on_disk-loading.adb
+++ b/src/alire/alire-index_on_disk-loading.adb
@@ -348,17 +348,17 @@ package body Alire.Index_On_Disk.Loading is
 
       pragma Assert (not From.Is_Empty);
 
-      --  Deal with externals first
-
-      if Detect_Externals then
-         Alire.Index.Detect_Externals (Crate, Platforms.Current.Properties);
-      end if;
-
       --  Now load
 
       for Index of From loop
          Index.Load (Crate, Strict);
       end loop;
+
+      --  Deal with externals after their detectors are loaded
+
+      if Detect_Externals then
+         Alire.Index.Detect_Externals (Crate, Platforms.Current.Properties);
+      end if;
 
    end Load;
 

--- a/src/alire/alire-index_on_disk-loading.ads
+++ b/src/alire/alire-index_on_disk-loading.ads
@@ -11,6 +11,8 @@ package Alire.Index_On_Disk.Loading is
 
    type Set is new Sets.Set with null record;
 
+   function Default return Set;
+
    function Find_All
      (Under  : Absolute_Path;
       Result : out Outcome) return Set;
@@ -34,6 +36,17 @@ package Alire.Index_On_Disk.Loading is
    function Load_All (From : Absolute_Path; Strict : Boolean) return Outcome;
    --  Load all indexes available at the given location
 
+   procedure Load (Crate            : Crate_Name;
+                   Detect_Externals : Boolean;
+                   Strict           : Boolean;
+                   From             : Set := Default;
+                   Path             : Any_Path := "")
+   with Pre => Path = "" or else From.Is_Empty;
+   --  Load a single crate, optionally detecting its externals. If a set of
+   --  already detected indexes is provided, detection is not reattempted.
+   --  If no path for detection is given, default one is used.
+   --  May raise Checked_Error. Loading twice the same crate is idempotent.
+
    function Update_All (Under : Absolute_Path) return Outcome;
    --  Find and update all indexes at given location
 
@@ -49,5 +62,10 @@ package Alire.Index_On_Disk.Loading is
    --  Adds the community index, if not already configured. If configured,
    --  re-adds it at the required branch by Index.Community_Branch with the
    --  same priority (i.e., maintaining the relative ordering);
+
+private
+
+   function Default return Set is (Empty);
+   --  Workaround for a visibility bug that manifests in body otherwise
 
 end Alire.Index_On_Disk.Loading;

--- a/src/alire/alire-index_on_disk-loading.ads
+++ b/src/alire/alire-index_on_disk-loading.ads
@@ -9,11 +9,11 @@ package Alire.Index_On_Disk.Loading is
    package Sets is new Ada.Containers.Indefinite_Ordered_Sets
      (Index_On_Disk.Index'Class, Index_On_Disk."<", Index_On_Disk."=");
 
-   subtype Index_On_Disk_Set is Sets.Set;
+   type Set is new Sets.Set with null record;
 
    function Find_All
      (Under  : Absolute_Path;
-      Result : out Outcome) return Index_On_Disk_Set;
+      Result : out Outcome) return Set;
    --  Find all indexes available on a disk location. If valid indexes are
    --  found or none, set Result to Outcome_Success and return the
    --  corresponding set. If at least one found index is invalid, set Result to

--- a/src/alire/alire-index_on_disk-loading.ads
+++ b/src/alire/alire-index_on_disk-loading.ads
@@ -65,7 +65,7 @@ package Alire.Index_On_Disk.Loading is
 
 private
 
-   function Default return Set is (Empty);
+   function Default return Set is (Sets.Empty_Set with null record);
    --  Workaround for a visibility bug that manifests in body otherwise
 
 end Alire.Index_On_Disk.Loading;

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -120,8 +120,10 @@ package body Alire.Index_On_Disk is
    -- Load --
    ----------
 
-   procedure Load (This : Index'Class; Crate : Crate_Name; Strict : Boolean)
-   is null;
+   procedure Load (This : Index'Class; Crate : Crate_Name; Strict : Boolean) is
+   begin
+      TOML_Index.Load (This, Crate, Strict);
+   end Load;
 
    ----------
    -- Name --

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -117,6 +117,13 @@ package body Alire.Index_On_Disk is
    end Load;
 
    ----------
+   -- Load --
+   ----------
+
+   procedure Load (This : Index'Class; Crate : Crate_Name; Strict : Boolean)
+   is null;
+
+   ----------
    -- Name --
    ----------
 

--- a/src/alire/alire-index_on_disk.ads
+++ b/src/alire/alire-index_on_disk.ads
@@ -70,6 +70,9 @@ package Alire.Index_On_Disk is
    function Load (This : Index'Class; Strict : Boolean) return Outcome;
    --  Loads the actual index contents into the in-memory index
 
+   procedure Load (This : Index'Class; Crate : Crate_Name; Strict : Boolean);
+   --  Load releases for just one crate from the index
+
    function Update (This : Index) return Outcome is abstract;
    --  If the index allows updating (e.g. git), do it.
    --  Otherwise, silently do nothing and return success, since at this level

--- a/src/alire/alire-toml_index.ads
+++ b/src/alire/alire-toml_index.ads
@@ -25,6 +25,13 @@ package Alire.TOML_Index is
    --  Load the whole TOML catalog for the given index. If Strict, don't allow
    --  unknown enum values.
 
+   procedure Load
+     (Index    : Index_On_Disk.Index'Class;
+      Crate    : Crate_Name;
+      Strict   : Boolean);
+   --  Load just the releases for the given crate. Does not fail if the crate
+   --  does not exist in the index.
+
 private
 
    procedure Index_Release (Path : Relative_Path;

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -87,6 +87,10 @@ package Alire with Preelaborate is
 
    function TTY_Image (This : Crate_Name) return String;
 
+   function Index_Prefix (This : Crate_Name) return String
+     with Post => Index_Prefix'Result'Length = 2;
+   --  The two first letters in the crate name
+
    subtype Restricted_Name is String with Dynamic_Predicate =>
      Restricted_Name'Length >= Min_Name_Length and then
      Restricted_Name (Restricted_Name'First) /= '_' and then
@@ -288,6 +292,9 @@ private
    function Length (This : Crate_Name) return Positive is (This.Len);
 
    function As_String (This : Crate_Name) return String is (This.Name);
+
+   function Index_Prefix (This : Crate_Name) return String
+   is (This.Name (This.Name'First .. This.Name'First + 1));
 
    function "+" (P : Crate_Name) return String is (P.Name);
    function "+" (P : String) return Crate_Name

--- a/src/alr/alr-commands-index.adb
+++ b/src/alr/alr-commands-index.adb
@@ -45,7 +45,7 @@ package body Alr.Commands.Index is
 
    procedure Delete (Name : String) is
       Result  : Alire.Outcome;
-      Indexes : constant Index_Load.Index_On_Disk_Set :=
+      Indexes : constant Index_Load.Set :=
                   Index_Load.Find_All
                     (Alire.Config.Edit.Indexes_Directory, Result);
       Found   : Boolean := False;
@@ -148,7 +148,7 @@ package body Alr.Commands.Index is
       use Alire;
 
       Result  : Alire.Outcome;
-      Indexes : constant Index_Load.Index_On_Disk_Set :=
+      Indexes : constant Index_Load.Set :=
                   Index_Load.Find_All
                     (Alire.Config.Edit.Indexes_Directory, Result);
 

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -241,12 +241,6 @@ package body Alr.Commands.Show is
            ("Switch --external can only be combined with --system");
       end if;
 
-      if Args.Count = 1 or else
-        Cmd.Graph or else Cmd.Solve or else Cmd.Tree
-      then
-         Cmd.Requires_Full_Index;
-      end if;
-
       declare
          Allowed : constant Alire.Dependencies.Dependency :=
            (if Args.Count = 1
@@ -254,12 +248,13 @@ package body Alr.Commands.Show is
             else Alire.Dependencies.From_String
               (Cmd.Root.Release.Milestone.Image));
       begin
-         if Args.Count = 1 and not Alire.Index.Exists (Allowed.Crate) then
-            raise Alire.Query_Unsuccessful;
-         end if;
+         if Args.Count = 1 then
+            Cmd.Load (Allowed.Crate,
+                      Externals => Cmd.Detect);
 
-         if Cmd.Detect then
-            Alire.Index.Detect_Externals (Allowed.Crate, Platform.Properties);
+            if not Alire.Index.Exists (Allowed.Crate) then
+               raise Alire.Query_Unsuccessful;
+            end if;
          end if;
 
          --  Execute

--- a/src/alr/alr-commands-version.adb
+++ b/src/alr/alr-commands-version.adb
@@ -30,7 +30,7 @@ package body Alr.Commands.Version is
       use all type Alire.Roots.Optional.States;
       Table : Alire.Utils.Tables.Table;
       Index_Outcome : Alire.Outcome;
-      Indexes : constant Alire.Index_On_Disk.Loading.Index_On_Disk_Set :=
+      Indexes : constant Alire.Index_On_Disk.Loading.Set :=
                   Alire.Index_On_Disk.Loading.Find_All
                     (Alire.Config.Edit.Indexes_Directory, Index_Outcome);
       Root : constant Alire.Roots.Optional.Root :=

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -236,6 +236,23 @@ package body Alr.Commands is
       raise Wrong_Command_Arguments with Alire.Errors.Set (Message);
    end Reportaise_Wrong_Arguments;
 
+   ----------
+   -- Load --
+   ----------
+
+   procedure Load (Cmd       : Command'Class;
+                   Crate     : Alire.Crate_Name;
+                   Externals : Boolean := False;
+                   Strict    : Boolean := False)
+   is
+      pragma Unreferenced (Cmd);
+   begin
+      Alire.Index_On_Disk.Loading.Load
+        (Crate            => Crate,
+         Detect_Externals => Externals,
+         Strict           => Strict);
+   end Load;
+
    -------------------------
    -- Requires_Full_Index --
    -------------------------

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -69,6 +69,13 @@ package Alr.Commands is
    --  performing a silent update. If not Sync, only a minimal empty lockfile
    --  is created.
 
+   procedure Load (Cmd       : Command'Class;
+                   Crate     : Alire.Crate_Name;
+                   Externals : Boolean := False;
+                   Strict    : Boolean := False);
+   --  Load a specific crate from the index. Optionally detect externals and
+   --  enforce no unknown enum index values.
+
    ---------------------------
    --  command-line helpers --
    ---------------------------


### PR DESCRIPTION
Some operations do not require the whole index to be loaded to work. This PR implements a procedure to load selected crates, and uses it for `alr show <crate>`.

There are more possible optimizations down the road based on this, which we can add incrementally.