### PR TITLE
Bump index version

### DIFF
--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -153,6 +153,11 @@ private
        +("If true, Alire will warn about the use of caret (^) "
          & "for pre-1 dependencies.")),
 
+      (+Keys.Warning_Old_Index,
+       Cfg_Bool,
+       +("When unset (default) or true, the community index will be added " &
+          "automatically when required if no other index is configured.")),
+
       (+Keys.Toolchain_Assistant,
        Cfg_Bool,
        +("If true, and assistant to select the default toolchain will run "

--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -155,8 +155,9 @@ private
 
       (+Keys.Warning_Old_Index,
        Cfg_Bool,
-       +("When unset (default) or true, the community index will be added " &
-          "automatically when required if no other index is configured.")),
+       +("When unset (default) or true, a warning will be emitted when " &
+           "using a compatible index with a lower version than the newest" &
+           " known.")),
 
       (+Keys.Toolchain_Assistant,
        Cfg_Bool,

--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -60,9 +60,23 @@ package Alire.Config with Preelaborate is
       Warning_Caret : constant Config_Key := "warning.caret";
       --  Set to false to disable warnings about caret/tilde use for ^0 deps.
 
+      Warning_Old_Index : constant Config_Key := "warning.old_index";
+      --  Warn about old but compatible index in use
+
       Msys2_Do_Not_Install : constant Config_Key := "msys2.do_not_install";
       Msys2_Install_Dir    : constant Config_Key := "msys2.install_dir";
       Msys2_Installer      : constant Config_Key := "msys2.installer";
       Msys2_Installer_URL  : constant Config_Key := "msys2.installer_url";
    end Keys;
+
+   --------------
+   -- Defaults --
+   --------------
+
+   package Defaults is
+
+      Warning_Old_Index : constant Boolean := True;
+
+   end Defaults;
+
 end Alire.Config;

--- a/src/alire/alire-index.ads
+++ b/src/alire/alire-index.ads
@@ -39,12 +39,12 @@ package Alire.Index is
      and then Branch_String (Branch_String'Last) /= '-'
      and then (for some C of Branch_String => C = '-');
 
-   Community_Branch : constant String := "stable-1.1";
+   Community_Branch : constant String := "devel-1.2";
    --  The branch used for the community index. Must be updated when new index
    --  features are introduced.
 
-   Min_Compatible_Version : constant String := "1.0.9";
-   --  1.0.9 never existed, but this way we can test old index compatibility
+   Min_Compatible_Version : constant String := "1.1";
+   --  Update as needed in case of backward-incompatible changes
 
    Max_Compatible_Version : constant String :=
                               AAA.Strings.Tail (Community_Branch, '-');

--- a/src/alire/alire-index_on_disk-loading.ads
+++ b/src/alire/alire-index_on_disk-loading.ads
@@ -15,11 +15,13 @@ package Alire.Index_On_Disk.Loading is
 
    function Find_All
      (Under  : Absolute_Path;
-      Result : out Outcome) return Set;
-   --  Find all indexes available on a disk location. If valid indexes are
-   --  found or none, set Result to Outcome_Success and return the
+      Result : out Outcome;
+      Cached : Boolean := True) return Set;
+   --  Find all indexes available on a disk location. If valid indexes
+   --  are found or none, set Result to Outcome_Success and return the
    --  corresponding set. If at least one found index is invalid, set Result to
-   --  an outcome failure and return en empty set.
+   --  an outcome failure and return en empty set. If cached, return the last
+   --  known set of indexes. See also Drop_Index_Cache below too.
    --
    --  We abort at the first invalid index as it's likely in this case that
    --  users misconfigured something, so this helps them notice the issue
@@ -62,6 +64,9 @@ package Alire.Index_On_Disk.Loading is
    --  Adds the community index, if not already configured. If configured,
    --  re-adds it at the required branch by Index.Community_Branch with the
    --  same priority (i.e., maintaining the relative ordering);
+
+   procedure Drop_Index_Cache;
+   --  Force detection of indexes on disk on next call to Find_All
 
 private
 

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -5,6 +5,7 @@ with Alire.Errors;
 with Alire.Directories;
 with Alire.Index_On_Disk.Directory;
 with Alire.Index_On_Disk.Git;
+with Alire.Index_On_Disk.Loading;
 with Alire.TOML_Index;
 with Alire.TOML_Keys;
 with Alire.VCSs;
@@ -91,6 +92,9 @@ package body Alire.Index_On_Disk is
          return Outcome_Failure ("Expected index directory does not exist: " &
                                    This.Metadata_Directory);
       end if;
+
+      --  Force a reload of cached indexes in any posterior index load
+      Loading.Drop_Index_Cache;
 
       return Outcome_Success;
    exception

--- a/src/alire/alire.adb
+++ b/src/alire/alire.adb
@@ -96,11 +96,20 @@ package body Alire is
    -- Put_Warning --
    -----------------
 
-   procedure Put_Warning (Text : String; Level : Trace.Levels := Info) is
+   procedure Put_Warning (Text           : String;
+                          Level          : Trace.Levels := Info;
+                          Disable_Config : String := "")
+   is
    begin
       Trace.Log (TTY.Text_With_Fallback (TTY.Warn ("⚠ "), "warning: ")
                  & Text,
                  Level);
+      if Disable_Config /= "" then
+         Trace.Log (TTY.Text_With_Fallback (TTY.Warn ("⚠ "), "warning: ")
+                    & "You can disable this warning with configuration key '"
+                    & TTY.Emph (Disable_Config) & "'",
+                    Level);
+      end if;
    end Put_Warning;
 
    ------------

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -264,8 +264,12 @@ package Alire with Preelaborate is
    procedure Put_Info (Text : String; Level : Trace.Levels := Info);
    --  Prepend Text with a blue "🛈", or "Note: " & if no color/tty.
 
-   procedure Put_Warning (Text : String; Level : Trace.Levels := Info);
-   --  Prepend Text with a yellow "⚠", or "Warning: " if no color/tty
+   procedure Put_Warning (Text           : String;
+                          Level          : Trace.Levels := Info;
+                          Disable_Config : String := "");
+   --  Prepend Text with a yellow "⚠", or "Warning: " if no color/tty. If
+   --  Disable_setting /= "", append a line informing about how to disable
+   --  this warning.
 
    procedure Put_Success (Text : String; Level : Trace.Levels := Info);
    --  Prepend Text with a green check mark, or "Success:" if no color/tty.

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -55,6 +55,11 @@ def prepare_env(config_dir, env):
     # require a configured compiler will have to set it up explicitly.
     run_alr("-c", config_dir, "toolchain", "--disable-assistant")
 
+    # Disable warning on old index, to avoid having to update index versions
+    # when they're still compatible.
+    run_alr("-c", config_dir, "config", "--global",
+            "--set", "warning.old_index", "false")
+
     # If distro detection is disabled via environment, configure so in alr
     if "ALIRE_DISABLE_DISTRO" in env:
         if env["ALIRE_DISABLE_DISTRO"] == "true":

--- a/testsuite/tests/index/branch-mismatch/test.py
+++ b/testsuite/tests/index/branch-mismatch/test.py
@@ -24,6 +24,9 @@ os.system('git ' + gitconfig + ' add .')
 os.system('git ' + gitconfig + ' commit -q -m initialize')
 os.chdir(start)
 
+# Enable the warning we are trying to test
+run_alr("config", "--global", "--set", "warning.old_index", "true")
+
 # Run the test. No alr version should use 'master' for the community index.
 # This produces a warning only, because the index version is valid.
 p = run_alr("search", "--crates",  # Causes loading of the index

--- a/testsuite/tests/index/old-compat-version/community/index/index.toml
+++ b/testsuite/tests/index/old-compat-version/community/index/index.toml
@@ -1,1 +1,1 @@
-version = "1.0.99"
+version = "1.1"

--- a/testsuite/tests/index/old-compat-version/test.py
+++ b/testsuite/tests/index/old-compat-version/test.py
@@ -8,12 +8,15 @@ from drivers.asserts import assert_match
 import re
 import os
 
+# Enable the warning we are trying to test
+run_alr("config", "--global", "--set", "warning.old_index", "true")
+
 # Run a command that loads the index. This produces a warning only, because the
 # index version is old but valid.
 p = run_alr("search", "--crates",  # Causes loading of the index
             quiet=False)
 
-assert_match(".*" + re.escape("Index 'community' version (1.0.99) is older") +
+assert_match(".*Index 'community' version .* is older"
              " than the newest supported by alr.*",
              p.out)
 


### PR DESCRIPTION
We got our first submission using new index features, so this requires an index version bump. Since we are also planning on releasing the next minor version soon, it is also a convenient time for this.

Added also an option to silence a benign warning that breaks many tests.