### PR TITLE
Don't try to detect external tools when they're from binary archives

### DIFF
--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -43,6 +43,11 @@ package Alire.Config with Preelaborate is
       --  assistant to select a gnat compiler and corresponding gprbuild
       --  will be launched.
 
+      Toolchain_External : constant Config_Key := "toolchain.external";
+      --  We use this key to store whether a tool in the toolchain requires
+      --  external detection. It stores a boolean per tool, e.g, for gprbuild:
+      --  toolchain.external.gprbuild
+
       Toolchain_Use : constant Config_Key := "toolchain.use";
       --  We use this key internally to store the configured tools picked
       --  up by the user. Not really intended to be set up by users, so

--- a/src/alire/alire-shared.adb
+++ b/src/alire/alire-shared.adb
@@ -22,7 +22,8 @@ package body Alire.Shared is
    -- Available --
    ---------------
 
-   function Available return Releases.Containers.Release_Set is
+   function Available (Detect_Externals : Boolean := True)
+                       return Releases.Containers.Release_Set is
 
       Result : Releases.Containers.Release_Set;
 
@@ -66,11 +67,15 @@ package body Alire.Shared is
 
       --  Include external toolchain members
 
-      Index.Detect_Externals (GNAT_External_Crate,
-                              Root.Platform_Properties);
+      if Detect_Externals then
+         Index.Detect_Externals (GNAT_External_Crate,
+                                 Root.Platform_Properties);
+      end if;
 
       for Tool of Toolchains.Tools loop
-         Index.Detect_Externals (Tool, Root.Platform_Properties);
+         if Detect_Externals then
+            Index.Detect_Externals (Tool, Root.Platform_Properties);
+         end if;
 
          for Release of Index.Releases_Satisfying (Toolchains.Any_Tool (Tool),
                                                    Root.Platform_Properties)
@@ -261,9 +266,11 @@ package body Alire.Shared is
    -- Release --
    -------------
 
-   function Release (Target : Milestones.Milestone) return Releases.Release is
+   function Release (Target           : Milestones.Milestone;
+                     Detect_Externals : Boolean := True)
+                     return Releases.Release is
    begin
-      for Release of Available loop
+      for Release of Available (Detect_Externals) loop
          if Release.Milestone = Target then
             return Release;
          end if;

--- a/src/alire/alire-shared.ads
+++ b/src/alire/alire-shared.ads
@@ -9,10 +9,13 @@ package Alire.Shared is
    --  Stuff about shared/binary crates that are deployed not in the local
    --  workspace but in the shared configuration folder.
 
-   function Available return Releases.Containers.Release_Set;
+   function Available (Detect_Externals : Boolean := True)
+                       return Releases.Containers.Release_Set;
    --  Returns the releases installed at the shared location
 
-   function Release (Target : Milestones.Milestone) return Releases.Release;
+   function Release (Target : Milestones.Milestone;
+                     Detect_Externals : Boolean := True)
+                     return Releases.Release;
    --  Retrieve the release corresponding to Target, if it exists. Will raise
    --  Constraint_Error if not among Available.
 

--- a/src/alire/alire-toolchains-solutions.adb
+++ b/src/alire/alire-toolchains-solutions.adb
@@ -23,7 +23,8 @@ package body Alire.Toolchains.Solutions is
          elsif Toolchains.Tool_Is_Configured (Tool) then
             Result := Result.Including
               (Release        => Shared.Release
-                 (Tool_Milestone (Tool)),
+                 (Target           => Tool_Milestone (Tool),
+                  Detect_Externals => Tool_Is_External (Tool)),
                Env            => Root.Platform_Properties,
                Add_Dependency => True,
                Shared         => True);

--- a/src/alire/alire-toolchains.adb
+++ b/src/alire/alire-toolchains.adb
@@ -337,6 +337,10 @@ package body Alire.Toolchains is
         (Level,
          Key   => Tool_Key (Release.Name),
          Value => Release.Milestone.Image);
+      Alire.Config.Edit.Set
+        (Level,
+         Key   => Tool_Key (Release.Name, For_Is_External),
+         Value => Boolean'(not Release.Origin.Is_Regular)'Image);
    end Set_As_Default;
 
    -----------------------------


### PR DESCRIPTION
Fixes https://github.com/alire-project/alire/issues/962

While the issue with msys's pacman is fixed upstream, this should alleviate the problem. With this PR, we store whether the tool is externally detected when selected, so later during every use we do not need to query pacman in the most usual case of using one of our indexed binary tools.