### PR TITLE
Fix retrieval of git root and prefix inside repo

### DIFF
--- a/src/alire/alire-optional.ads
+++ b/src/alire/alire-optional.ads
@@ -4,10 +4,8 @@ package Alire.Optional with Preelaborate is
 
    --  Optional basic types
 
-   function Absolute_Path_Image (Path : Absolute_Path)
-                                 return String is (String (Path));
    package Absolute_Paths is
-     new Standard.Optional.Values (Absolute_Path, Absolute_Path_Image);
+     new Standard.Optional.Values (Alire.Absolute_Path, Absolute_Path_Image);
    subtype Absolute_Path is Absolute_Paths.Optional;
 
    package Crate_Names is

--- a/src/alire/alire-optional.ads
+++ b/src/alire/alire-optional.ads
@@ -4,6 +4,12 @@ package Alire.Optional with Preelaborate is
 
    --  Optional basic types
 
+   function Absolute_Path_Image (Path : Absolute_Path)
+                                 return String is (String (Path));
+   package Absolute_Paths is
+     new Standard.Optional.Values (Absolute_Path, Absolute_Path_Image);
+   subtype Absolute_Path is Absolute_Paths.Optional;
+
    package Crate_Names is
      new Standard.Optional.Values (Crate_Name, As_String);
    subtype Crate_Name is Crate_Names.Optional;

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -12,6 +12,7 @@ with Alire.GitHub;
 with Alire.Hashes;
 with Alire.Index;
 with Alire.Manifest;
+with Alire.Optional;
 with Alire.Origins.Deployers;
 with Alire.OS_Lib.Subprocess;
 with Alire.Paths;
@@ -968,9 +969,11 @@ package body Alire.Publish is
       ------------------------
 
       procedure Check_Nested_Crate (Root_Path : Absolute_Path) is
-         Git_Info  : constant VCSs.Git.Worktree_Data := Git.Worktree (Path);
+         Git_Root : constant Optional.Absolute_Path := Git.Root;
       begin
-         if not VFS.Is_Same_Dir (+Git_Info.Worktree, Root_Path) then
+         if Git_Root.Is_Empty or else
+           not VFS.Is_Same_Dir (Git_Root.Value, Root_Path)
+         then
 
             --  To make our life easier for now, do not allow complex cases
             --  like using a manifest from elsewhere to package a nested crate.
@@ -983,7 +986,7 @@ package body Alire.Publish is
 
             Put_Info
               ("Crate at " & TTY.URL (Root_Path)
-               & " is nested in repo at " & TTY.URL (+Git_Info.Worktree));
+               & " is nested in repo at " & TTY.URL (Git_Root.Value));
 
             declare
                Nested_Path : constant Relative_Path :=

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -971,7 +971,7 @@ package body Alire.Publish is
       procedure Check_Nested_Crate (Root_Path : Absolute_Path) is
          Git_Root : constant Optional.Absolute_Path := Git.Root;
       begin
-         if Git_Root.Is_Empty or else
+         if Git_Root.Has_Element and then
            not VFS.Is_Same_Dir (Git_Root.Value, Root_Path)
          then
 

--- a/src/alire/alire-vcss-git.adb
+++ b/src/alire/alire-vcss-git.adb
@@ -6,6 +6,8 @@ with Alire.Errors;
 with Alire.Utils.Tools;
 with Alire.VFS;
 
+with GNAT.Source_Info;
+
 package body Alire.VCSs.Git is
 
    -------------
@@ -35,6 +37,24 @@ package body Alire.VCSs.Git is
         OS_Lib.Subprocess.Checked_Spawn_And_Capture
           ("git", Arguments, Err_To_Out => True);
    end Run_Git_And_Capture;
+
+   -----------------------------------
+   -- Unchecked_Run_Git_And_Capture --
+   -----------------------------------
+
+   procedure Unchecked_Run_Git_And_Capture (Arguments : AAA.Strings.Vector;
+                                            Output    : out AAA.Strings.Vector;
+                                            Code      : out Integer)
+   is
+   begin
+      --  Make sure git is installed
+      Utils.Tools.Check_Tool (Utils.Tools.Git);
+      Code := OS_Lib.Subprocess.Unchecked_Spawn_And_Capture
+        (Command             => "git",
+         Arguments           => Arguments,
+         Output              => Output,
+         Err_To_Out          => True);
+   end Unchecked_Run_Git_And_Capture;
 
    ------------
    -- Branch --
@@ -544,33 +564,36 @@ package body Alire.VCSs.Git is
                                       Dir  : Directory_Path)
                                       return Relative_Path
    is
-      use all type UString;
-      Result : UString;
-      Root   : constant Absolute_Path := +This.Worktree (Dir).Worktree;
-      Curr   : Unbounded_Absolute_Path := +Ada.Directories.Full_Name (Dir);
+      use Ada.Directories;
+      use Alire.Directories.Operators;
+      Guard  : Directories.Guard (Directories.Enter (Full_Name (Dir)))
+        with Unreferenced;
    begin
-      if not GNAT.OS_Lib.Is_Directory (Dir) then
-         Raise_Checked_Error ("Starting dir not a real dir: " & Dir);
-      end if;
-
-      if VFS.Is_Same_Dir (Root, Dir) then
-         return ".";
-      end if;
-
-      --  We simply go up until being at the git root. The equivalence of
-      --  directories is ensured by VFS.Is_Same_Dir even for a root returned
-      --  by git using different short/long naming on Windows.
-
-      while not VFS.Is_Same_Dir (Root, +Curr) loop
-         if Result /= "" then
-            Result := GNAT.OS_Lib.Directory_Separator & Result;
-         end if;
-
-         Result := Ada.Directories.Simple_Name (+Curr) & Result;
-         Curr   := +Ada.Directories.Containing_Directory (+Curr);
-      end loop;
-
-      return +Result;
+      return "." /
+        Run_Git_And_Capture
+         (Empty_Vector & "rev-parse" & "--show-prefix").First_Element;
    end Get_Rel_Path_Inside_Repo;
+
+   ----------
+   -- Root --
+   ----------
+
+   function Root (This : VCS) return Optional.Absolute_Path is
+      Code   : Integer;
+      Output : AAA.Strings.Vector;
+   begin
+      Unchecked_Run_Git_And_Capture
+        (Empty_Vector & "rev-parse" & "--show-toplevel",
+         Output,
+         Code);
+
+      if Code /= 0 then
+         Trace.Debug ("git rev-parse returned code: " & Code'Image
+                      & " at " & GNAT.Source_Info.Source_Location);
+         return Optional.Absolute_Paths.Empty;
+      else
+         return Optional.Absolute_Paths.Unit (Output.First_Element);
+      end if;
+   end Root;
 
 end Alire.VCSs.Git;

--- a/src/alire/alire-vcss-git.adb
+++ b/src/alire/alire-vcss-git.adb
@@ -564,6 +564,7 @@ package body Alire.VCSs.Git is
                                       Dir  : Directory_Path)
                                       return Relative_Path
    is
+      pragma Unreferenced (This);
       use Ada.Directories;
       use Alire.Directories.Operators;
       Guard  : Directories.Guard (Directories.Enter (Full_Name (Dir)))
@@ -579,6 +580,7 @@ package body Alire.VCSs.Git is
    ----------
 
    function Root (This : VCS) return Optional.Absolute_Path is
+      pragma Unreferenced (This);
       Code   : Integer;
       Output : AAA.Strings.Vector;
    begin

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -1,4 +1,5 @@
 with AAA.Strings;
+with Alire.Optional;
 with Alire.Utils;
 
 package Alire.VCSs.Git is
@@ -122,7 +123,12 @@ package Alire.VCSs.Git is
                                       Dir  : Directory_Path)
                                       return Relative_Path;
    --  Return the relative path from the VCSs root to Dir. Will raise if Dir is
-   --  not a real dir or not actually inside a gir repo.
+   --  not a real dir or not actually inside a gir repo. This is a wrapper on
+   --  git rev-parse --show-prefix
+
+   function Root (This : VCS) return Optional.Absolute_Path;
+   --  Return the repo absolute root path, if in a repo; otherwise Empty. This
+   --  is a wrapper on git rev-parse --show-toplevel
 
    function Transform_To_Public (Remote : String) return URL;
    --  For a Known_Transformable_Host, return the https:// equivalent of a

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -123,7 +123,7 @@ package Alire.VCSs.Git is
                                       Dir  : Directory_Path)
                                       return Relative_Path;
    --  Return the relative path from the VCSs root to Dir. Will raise if Dir is
-   --  not a real dir or not actually inside a gir repo. This is a wrapper on
+   --  not a real dir or not actually inside a git repo. This is a wrapper on
    --  git rev-parse --show-prefix
 
    function Root (This : VCS) return Optional.Absolute_Path;

--- a/src/alire/alire.adb
+++ b/src/alire/alire.adb
@@ -24,6 +24,13 @@ package body Alire is
      (AAA.Strings.To_Lower_Case (+L) < AAA.Strings.To_Lower_Case (+R));
 
    -------------------------
+   -- Absolute_Path_Image --
+   -------------------------
+
+   function Absolute_Path_Image (Path : Alire.Absolute_Path) return String
+   is (String (Path));
+
+   -------------------------
    -- Check_Absolute_Path --
    -------------------------
 

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -144,6 +144,9 @@ package Alire with Preelaborate is
    subtype Absolute_Path is Any_Path
      with Dynamic_Predicate => Check_Absolute_Path (Absolute_Path);
 
+   function Absolute_Path_Image (Path : Absolute_Path) return String;
+   --  Needed for later instantiations
+
    subtype Unbounded_Absolute_Path is UString
      with Dynamic_Predicate =>
        +Unbounded_Absolute_Path = "" or else


### PR DESCRIPTION
Fixes #1021.

Remove custom logic in favor of the proper own `git` subcommands.