### PR TITLE
Alire.Utils.Switches: Disable No_Exception_Propagation warning

### DIFF
--- a/src/alire/alire-utils-switches.adb
+++ b/src/alire/alire-utils-switches.adb
@@ -129,9 +129,11 @@ package body Alire.Utils.Switches is
           when None     => Empty_List,
           when Warnings => Empty_List
                            .Append (GNAT_All_Warnings)
+                           .Append (GNAT_Disable_Warn_No_Exception_Propagation)
                            .Append (GNAT_All_Validity_Checks),
           when Errors   => Empty_List
                            .Append (GNAT_All_Warnings)
+                           .Append (GNAT_Disable_Warn_No_Exception_Propagation)
                            .Append (GNAT_All_Validity_Checks)
                            .Append (GNAT_Warnings_As_Errors),
           when Custom   => S.List);


### PR DESCRIPTION
This switch was always added to the init crates and should have been
included in the first version of build profiles. The warnings are only
displayed for embedded project based on run-times without exception
propagation, and can be very annoying.