### PR TITLE
Fix early parsing of verbosity switches

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -45,7 +45,7 @@ aaa = { url = "https://github.com/mosteo/aaa.git", commit = "22fcef5c465ece2f9cf
 ada_toml = { url = "https://github.com/pmderodat/ada-toml.git", commit = "2a671ffb1039a036f2bb68bdc88afc8d3dc68c10" }
 ajunitgen = { url = "https://github.com/mosteo/ajunitgen.git", commit = "e5d01db5e7834d15c4066f0a8e33d780deae3cc9" }
 ansiada = { url = "https://github.com/mosteo/ansi-ada.git", commit = "acf9afca3afe1f8b8843c061f3cef860d7567307" }
-clic = { url = "https://github.com/alire-project/clic.git", commit = "076686cc304bfc7ba82cf4ca5be17cd01e258af2" }
+clic = { url = "https://github.com/alire-project/clic.git", commit = "185519d65b089c3238e24cfe87f1d22db1f3e0d9" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "e250e4e42d9743b782788cf61b4ddc10a45e69e2" }
 minirest = { url = "https://github.com/mosteo/minirest.git", commit = "4550aa356d55b9cd55f26acd34701f646021c5ff" }
 optional = { url = "https://github.com/mosteo/optional.git", commit = "0c7d20c0c8b48ccb6b25fb648d48382e598c25c3" }


### PR DESCRIPTION
We were recognizing them even after the subcommand. This also meant that it would have been impossible to have regular output if a `-v` is intended for the subcommand, e.g. in `alr exec -- whatever -v`.

Also bumps the clic submodule to use the hint about a global being given after the subcommand.

Fixes https://github.com/alire-project/alire/issues/1027