### PR TITLE
Speed-up detection of installed externals in RPM-based distros

### DIFF
--- a/src/alire/alire-origins-deployers-system-rpm_wrappers.adb
+++ b/src/alire/alire-origins-deployers-system-rpm_wrappers.adb
@@ -19,6 +19,18 @@ package body Alire.Origins.Deployers.System.RPM_Wrappers is
          when Dnf => "dnf",
          when Yum => "yum");
 
+   ------------------------------
+   -- Package_Name_With_Archit --
+   ------------------------------
+
+   function Package_Name_With_Archit (Name : String) return String
+   is (if Contains (Name, ".")
+       then Name
+       else Name
+            & "."
+            & To_Lower_Case
+                (Platforms.Current.Host_Architecture'Image));
+
    -----------------------
    -- Already_Installed --
    -----------------------
@@ -29,13 +41,7 @@ package body Alire.Origins.Deployers.System.RPM_Wrappers is
       --  Name of the package narrowed down by architecture, to avoid being
       --  confused by i386 packages
       Full_Pkg_Name : constant String :=
-                        (if Contains (This.Base.Package_Name, ".")
-                         then This.Base.Package_Name
-                         else
-                            This.Base.Package_Name
-                         & "."
-                         & To_Lower_Case
-                           (Platforms.Current.Host_Architecture'Image));
+                        Package_Name_With_Archit (This.Base.Package_Name);
 
       Wrapper : constant String := Wrapper_Command (This);
 
@@ -71,13 +77,7 @@ package body Alire.Origins.Deployers.System.RPM_Wrappers is
       --  Name of the package narrowed down by architecture, to avoid being
       --  confused by i386 packages
       Full_Pkg_Name : constant String :=
-                    (if Contains (This.Base.Package_Name, ".")
-                     then This.Base.Package_Name
-                     else
-                        This.Base.Package_Name
-                        & "."
-                        & To_Lower_Case
-                            (Platforms.Current.Host_Architecture'Image));
+                        Package_Name_With_Archit (This.Base.Package_Name);
 
       --------------------------
       -- Detect_Not_Installed --

--- a/src/alire/alire-origins-deployers-system-rpm_wrappers.adb
+++ b/src/alire/alire-origins-deployers-system-rpm_wrappers.adb
@@ -2,6 +2,7 @@ with AAA.Strings; use AAA.Strings;
 
 with Alire.OS_Lib.Subprocess;
 with Alire.Errors;
+with Alire.Platforms.Current;
 
 with GNAT.Regpat;
 
@@ -24,28 +25,36 @@ package body Alire.Origins.Deployers.System.RPM_Wrappers is
 
    overriding
    function Already_Installed (This : Deployer) return Boolean is
-      Pck    : String renames This.Base.Package_Name;
+
+      --  Name of the package narrowed down by architecture, to avoid being
+      --  confused by i386 packages
+      Full_Pkg_Name : constant String :=
+                        (if Contains (This.Base.Package_Name, ".")
+                         then This.Base.Package_Name
+                         else
+                            This.Base.Package_Name
+                         & "."
+                         & To_Lower_Case
+                           (Platforms.Current.Host_Architecture'Image));
 
       Wrapper : constant String := Wrapper_Command (This);
 
       Output : constant AAA.Strings.Vector :=
                  Subprocess.Checked_Spawn_And_Capture
-                   (Wrapper,
+                   ("rpm",
                     Empty_Vector &
-                      "-y" &
-                      "list" &
-                      "--installed" &
-                      This.Base.Package_Name,
+                      "--query" &
+                      Full_Pkg_Name,
                     Valid_Exit_Codes => (0, 1), -- Returned when not found
                     Err_To_Out     => True);
    begin
       if not Output.Is_Empty
         and then
-          Output.First_Element = Pck
+          not Contains (Output.First_Element, "not installed")
       then
          return True;
       else
-         Trace.Detail ("Cannot find package '" & Pck &
+         Trace.Detail ("Cannot find package '" & Full_Pkg_Name &
                          "' in " & Wrapper & " installed list: '" &
                          Output.Flatten & "'");
          return False;
@@ -59,49 +68,115 @@ package body Alire.Origins.Deployers.System.RPM_Wrappers is
    overriding
    function Detect (This : Deployer) return Version_Outcomes.Outcome is
 
-      Regexp : constant String := "^" & This.Base.Package_Name &
-                 "[^\s]+\s+(?:\d+:)?([0-9.]+)";
-      --  A line looks like:
-      --  gtk3.x86_64    1:3.24.24-1.fc33    updates
+      --  Name of the package narrowed down by architecture, to avoid being
+      --  confused by i386 packages
+      Full_Pkg_Name : constant String :=
+                    (if Contains (This.Base.Package_Name, ".")
+                     then This.Base.Package_Name
+                     else
+                        This.Base.Package_Name
+                        & "."
+                        & To_Lower_Case
+                            (Platforms.Current.Host_Architecture'Image));
 
-      Wrapper : constant String := Wrapper_Command (This);
+      --------------------------
+      -- Detect_Not_Installed --
+      --------------------------
 
-      Output    : constant AAA.Strings.Vector :=
-        Subprocess.Checked_Spawn_And_Capture
-          (Wrapper,
-           Empty_Vector &
-             "-y" &
-             "list" &
-             This.Base.Package_Name,
-           Valid_Exit_Codes => (0, 1), -- Returned when not found
-           Err_To_Out       => True);
+      function Detect_Not_Installed return Version_Outcomes.Outcome is
 
-      use GNAT.Regpat;
-      Matches : Match_Array (1 .. 1);
+         Regexp : constant String := "^" & Full_Pkg_Name &
+                    "[^\s]+\s+(?:\d+:)?([0-9.]+)";
+         --  A line looks like:
+         --  gtk3.x86_64    1:3.24.24-1.fc33    updates
+
+         Wrapper : constant String := Wrapper_Command (This);
+
+         Output    : constant AAA.Strings.Vector :=
+                       Subprocess.Checked_Spawn_And_Capture
+                         (Wrapper,
+                          Empty_Vector &
+                            "-y" &
+                            "list" &
+                            Full_Pkg_Name,
+                          Valid_Exit_Codes => (0, 1), -- 1 when not found
+                          Err_To_Out       => True);
+
+         use GNAT.Regpat;
+         Matches : Match_Array (1 .. 1);
+      begin
+         for Line of Output loop
+            Trace.Debug ("Extracting native version from " & Wrapper &
+                           " output: " & Line);
+            Match (Regexp, Line, Matches);
+            if Matches (1) /= No_Match then
+               Trace.Debug ("Candidate version string: "
+                            & Line (Matches (1).First .. Matches (1).Last));
+               return
+                 Version_Outcomes.New_Result
+                   (Semantic_Versioning.Parse
+                      (Line (Matches (1).First .. Matches (1).Last),
+                       Relaxed => True)); --  Relaxed because some Fedora
+               --  versions have extra version pts,
+               --  e.g. 5.8-3.fc33
+            else
+               Trace.Debug
+                 ("Unexpected version format, could not identify version");
+            end if;
+         end loop;
+
+         Trace.Debug ("System deployer could not detect: " & This.Base.Image);
+         return Version_Outcomes.Outcome_Failure ("could not be detected",
+                                                  Report => False);
+      end Detect_Not_Installed;
+
+      ----------------------
+      -- Detect_Installed --
+      ----------------------
+      --  Return "" if no installed matching version
+      function Detect_Installed return String
+      is
+         Output    : constant AAA.Strings.Vector :=
+                       Subprocess.Checked_Spawn_And_Capture
+                         ("rpm",
+                          Empty_Vector &
+                            "--query" &
+                            "--info" &
+                            Full_Pkg_Name,
+                          Valid_Exit_Codes => (0, 1), -- 1 when not found
+                          Err_To_Out       => True);
+
+      begin
+         --  The line we want looks like:
+         --  Version     : x.y.z
+
+         for Line of Output loop
+            if Has_Prefix (Line, "Version ") then
+               return Trim (Tail (Line, ':'));
+            end if;
+         end loop;
+
+         return "";
+      end Detect_Installed;
+
    begin
-      for Line of Output loop
-         Trace.Debug ("Extracting native version from " & Wrapper &
-                        " output: " & Line);
-         Match (Regexp, Line, Matches);
-         if Matches (1) /= No_Match then
-            Trace.Debug ("Candidate version string: "
-                         & Line (Matches (1).First .. Matches (1).Last));
-            return
-              Version_Outcomes.New_Result
-                (Semantic_Versioning.Parse
-                   (Line (Matches (1).First .. Matches (1).Last),
-                    Relaxed => True)); --  Relaxed because some Fedora
-                                       --  versions have extra version pts,
-                                       --  e.g. 5.8-3.fc33
-         else
-            Trace.Debug
-              ("Unexpected version format, could not identify version");
-         end if;
-      end loop;
 
-      Trace.Debug ("System deployer could not detect: " & This.Base.Image);
-      return Version_Outcomes.Outcome_Failure ("could not be detected",
-                                               Report => False);
+      --  Try first a quick detection
+      declare
+         Result : constant String := Detect_Installed;
+      begin
+         if Result /= "" then
+            Trace.Debug ("Candidate version string: " & Result);
+            return Version_Outcomes.New_Result
+              (Semantic_Versioning.Parse (Result, Relaxed => True));
+            --  The output format of rpm will not have epoch nor the own fedora
+            --  release trail after '-'.
+         end if;
+      end;
+
+      --  This is much slower
+      return Detect_Not_Installed;
+
    end Detect;
 
    -------------


### PR DESCRIPTION
Although the yum/dnf wrappers are needed for the installation proper, we can
speed up detections of already installed packages by using rpm directly.
Unfortunately, rpm cannot give info on not installed packages, but this still
should speed up things greatly for the usual case of gnat/gprbuild being installed.

Fixes https://github.com/alire-project/alire/issues/1028

@BeChris, as you did the original implementation, would you be so kind to check if you see any obvious problem with these changes?