### PR TITLE
Reduce gprbuild startup time by using its --autoconf parameter

### DIFF
--- a/src/alire/alire-paths.ads
+++ b/src/alire/alire-paths.ads
@@ -5,6 +5,9 @@ package Alire.Paths with Preelaborate is
    Crate_File_Name : constant String := "alire.toml";
    --  Name of the manifest file in a regular workspace
 
+   Cache_Project_File_Name : constant String := "build.cgpr";
+   --  Name of the "cache" file used by gprbuild
+
    Cache_Folder_Inside_Working_Folder : constant Relative_Path := "cache";
 
    Deps_Folder_Inside_Cache_Folder : constant Relative_Path := "dependencies";

--- a/src/alire/alire-spawn.adb
+++ b/src/alire/alire-spawn.adb
@@ -1,6 +1,7 @@
 with Alire_Early_Elaboration;
+with Ada.Directories;
+with Alire.Config;
 with Alire.Paths;
-with Alire.Root;
 with Alire.OS_Lib.Subprocess;
 
 package body Alire.Spawn is
@@ -35,10 +36,22 @@ package body Alire.Spawn is
       use AAA.Strings;
       use Alire.OS_Lib.Operators;
 
+      Containing_Directory : constant String :=
+        Ada.Directories.Containing_Directory (Project_File);
+
+      Toolchain : constant String :=
+        Alire.Config.DB.Get
+          (Alire.Config.Keys.Toolchain_Use & ".gnat",
+           Alire.Paths.Cache_Project_File_Name);
+
+      Autoconf_File : constant String :=
+        Containing_Directory /
+          Alire.Paths.Working_Folder_Inside_Root /
+            Alire.Paths.Cache_Folder_Inside_Working_Folder /
+              Toolchain;
+
       Autoconf_Param : constant String :=
-        "--autoconf=" &
-        (Alire.Root.Current.Working_Folder
-        / Alire.Paths.Cache_Project_File_Name);
+        "--autoconf=" & Autoconf_File;
 
    begin
       if Alire.OS_Lib.Subprocess.Locate_In_Path ("gprbuild") = "" then

--- a/src/alire/alire-spawn.adb
+++ b/src/alire/alire-spawn.adb
@@ -1,4 +1,6 @@
 with Alire_Early_Elaboration;
+with Alire.Paths;
+with Alire.Root;
 with Alire.OS_Lib.Subprocess;
 
 package body Alire.Spawn is
@@ -31,6 +33,13 @@ package body Alire.Spawn is
                        Extra_Args   : AAA.Strings.Vector)
    is
       use AAA.Strings;
+      use Alire.OS_Lib.Operators;
+
+      Autoconf_Param : constant String :=
+        "--autoconf=" &
+        (Alire.Root.Current.Working_Folder
+        / Alire.Paths.Cache_Project_File_Name);
+
    begin
       if Alire.OS_Lib.Subprocess.Locate_In_Path ("gprbuild") = "" then
          Alire.Raise_Checked_Error
@@ -44,6 +53,7 @@ package body Alire.Spawn is
                  "-j0" & -- Build in parallel
                  "-p"  & -- Create missing obj, lib and exec dirs
                  "-P"  & Project_File &
+                 Autoconf_Param &
                  Extra_Args,
                Understands_Verbose => True);
    end Gprbuild;

--- a/src/alr/alr-commands-clean.adb
+++ b/src/alr/alr-commands-clean.adb
@@ -2,8 +2,10 @@ with Ada.Directories;
 
 with Alire.Config.Edit;
 with Alire.Directories;
+with Alire.OS_Lib;
 with Alire.Paths;
 with Alire.Platforms.Current;
+with Alire.Root;
 with Alire.Spawn;
 
 package body Alr.Commands.Clean is
@@ -118,7 +120,17 @@ package body Alr.Commands.Clean is
                       Args :        AAA.Strings.Vector)
    is
       use AAA.Strings;
+      use Alire.OS_Lib.Operators;
+
+      Autoconf_File : constant String :=
+        Alire.Root.Current.Working_Folder
+        / Alire.Paths.Cache_Project_File_Name;
+
    begin
+
+      if Ada.Directories.Exists (Autoconf_File) then
+         Ada.Directories.Delete_File (Autoconf_File);
+      end if;
 
       if not (Cmd.Cache or else Cmd.Temp) then
          Cmd.Requires_Valid_Session;

--- a/src/alr/alr-commands-clean.adb
+++ b/src/alr/alr-commands-clean.adb
@@ -6,6 +6,8 @@ with Alire.OS_Lib;
 with Alire.Paths;
 with Alire.Platforms.Current;
 with Alire.Root;
+with Alire.Roots.Optional;
+
 with Alire.Spawn;
 
 package body Alr.Commands.Clean is
@@ -121,15 +123,27 @@ package body Alr.Commands.Clean is
    is
       use AAA.Strings;
       use Alire.OS_Lib.Operators;
+      use Alire.Roots.Optional;
 
-      Autoconf_File : constant String :=
-        Alire.Root.Current.Working_Folder
-        / Alire.Paths.Cache_Project_File_Name;
+      Root : constant Alire.Roots.Optional.Root :=
+        Alire.Roots.Optional.Search_Root (Alire.Directories.Current);
 
    begin
 
-      if Ada.Directories.Exists (Autoconf_File) then
-         Ada.Directories.Delete_File (Autoconf_File);
+      if Root.Status = Valid then
+         declare
+            Autoconf_File : constant String :=
+              Alire.Root.Current.Working_Folder
+                / Alire.Paths.Cache_Project_File_Name;
+         begin
+            if Ada.Directories.Exists (Autoconf_File) then
+
+               Trace.Detail ("Cleaning gprbuild cache file...");
+
+               Ada.Directories.Delete_File (Autoconf_File);
+
+            end if;
+         end;
       end if;
 
       if not (Cmd.Cache or else Cmd.Temp) then

--- a/src/alr/alr-commands-clean.adb
+++ b/src/alr/alr-commands-clean.adb
@@ -2,12 +2,8 @@ with Ada.Directories;
 
 with Alire.Config.Edit;
 with Alire.Directories;
-with Alire.OS_Lib;
 with Alire.Paths;
 with Alire.Platforms.Current;
-with Alire.Root;
-with Alire.Roots.Optional;
-
 with Alire.Spawn;
 
 package body Alr.Commands.Clean is
@@ -122,29 +118,7 @@ package body Alr.Commands.Clean is
                       Args :        AAA.Strings.Vector)
    is
       use AAA.Strings;
-      use Alire.OS_Lib.Operators;
-      use Alire.Roots.Optional;
-
-      Root : constant Alire.Roots.Optional.Root :=
-        Alire.Roots.Optional.Search_Root (Alire.Directories.Current);
-
    begin
-
-      if Root.Status = Valid then
-         declare
-            Autoconf_File : constant String :=
-              Alire.Root.Current.Working_Folder
-                / Alire.Paths.Cache_Project_File_Name;
-         begin
-            if Ada.Directories.Exists (Autoconf_File) then
-
-               Trace.Detail ("Cleaning gprbuild cache file...");
-
-               Ada.Directories.Delete_File (Autoconf_File);
-
-            end if;
-         end;
-      end if;
 
       if not (Cmd.Cache or else Cmd.Temp) then
          Cmd.Requires_Valid_Session;


### PR DESCRIPTION
Hello,
Everytime gprbuild is executed it has to parse its gprconfig database which could be slow especially on slow filesystems.
I propose to provide --autoconf= parameter to gprbuild so it parses its databse only once : for further executions a cache of this database is used.
This cache is written into alire subdirectory and deleted with an alr clean command.

Execution times on my PC running Arch Linux with an SSD:
Before optimisation:
alr build
ⓘ Building hello/hello.gpr...                    
gprbuild: "hello" up to date
Build finished successfully in 1.27 seconds.

After optimisation:
alr build
ⓘ Building hello/hello.gpr...                    
gprbuild: "hello" up to date
Build finished successfully in 0.42 seconds.
