### PR TITLE
Alire.Utils.Switches: add -gnateE when debug info enabled

### DIFF
--- a/src/alire/alire-utils-gnat_switches.ads
+++ b/src/alire/alire-utils-gnat_switches.ads
@@ -14,6 +14,7 @@ is
    GNAT_Enable_Inlining                       : constant Switch := "-gnatn";
    GNAT_Asserts_And_Contracts                 : constant Switch := "-gnata";
    GNAT_Debug_Info                            : constant Switch := "-g";
+   GNAT_Extra_Exception_Info                  : constant Switch := "-gnateE";
    GNAT_Suppress_Runtime_Check                : constant Switch := "-gnatp";
    GNAT_Enable_Overflow_Check                 : constant Switch := "-gnato";
    GNAT_Disable_Warn_No_Exception_Propagation : constant Switch := "-gnatw.X";

--- a/src/alire/alire-utils-switches-knowledge.adb
+++ b/src/alire/alire-utils-switches-knowledge.adb
@@ -60,6 +60,7 @@ package body Alire.Utils.Switches.Knowledge is
       Register (GNAT_Warnings_As_Errors, "Warnings as errors");
       Register (GNAT_Function_Sections, "Separate ELF section for each function");
       Register (GNAT_Data_Sections, "Separate ELF section for each variable");
+      Register (GNAT_Extra_Exception_Info, "Extra information in exception messages");
 
       Register (GNAT_Ada83, "Ada 83 Compatibility Mode");
       Register (GNAT_Ada95, "Ada 95 Mode");

--- a/src/alire/alire-utils-switches.adb
+++ b/src/alire/alire-utils-switches.adb
@@ -93,7 +93,9 @@ package body Alire.Utils.Switches is
    function Get_List (S : Debug_Info_Switches) return Switch_List
    is (case S.Kind is
           when No     => Empty_List,
-          when Yes    => Empty_List.Append (GNAT_Debug_Info),
+          when Yes    => Empty_List
+                         .Append (GNAT_Debug_Info)
+                         .Append (GNAT_Extra_Exception_Info),
           when Custom => S.List);
 
    --------------


### PR DESCRIPTION
-gnateE adds extra info in exception messages.