### PR TITLE
Allow more than one conditional action

### DIFF
--- a/src/alire/alire-conditional_trees-toml_load.adb
+++ b/src/alire/alire-conditional_trees-toml_load.adb
@@ -119,6 +119,16 @@ package body Alire.Conditional_Trees.TOML_Load is
       is
          Table : constant TOML_Adapters.Key_Queue :=
                    From.Descend (Val, "values");
+
+         Case_Result : Tree;
+         --  We store properties coming from cases separately so for the action
+         --  syntax of:
+         --  [[actions]]
+         --  key = val
+         --  [actions.case]
+         --  key = val
+         --  respects the ordering of first the common case and then subcases.
+
       begin
          return Result : Tree do
 
@@ -133,7 +143,7 @@ package body Alire.Conditional_Trees.TOML_Load is
                begin
                   exit when Case_Key = ""; -- Table contains no more cases
 
-                  Result.Append
+                  Case_Result.Append
                     (Process_Case (From, Key, Case_Key, Case_Val));
                end;
             end loop;
@@ -147,6 +157,10 @@ package body Alire.Conditional_Trees.TOML_Load is
                          (Key     => Key,
                           Value   => Val,
                           Context => Key)));
+            end if;
+
+            if not Case_Result.Is_Empty then
+               Result.Append (Case_Result);
             end if;
          end return;
       end Process_Nested_Table;

--- a/src/alire/alire-toml_adapters.adb
+++ b/src/alire/alire-toml_adapters.adb
@@ -338,7 +338,7 @@ package body Alire.TOML_Adapters is
 
       function Image (Val : TOML_Value) return String is
         (case Val.Kind is
-            when TOML_String => Val.As_String,
+            when TOML_String  => Val.As_String,
             when TOML_Boolean => Val.As_Boolean'Img,
             when TOML_Integer => Val.As_Integer'Img,
             when others       => raise Unimplemented);
@@ -363,12 +363,23 @@ package body Alire.TOML_Adapters is
                              & (if Val.Length > 0
                                then " of " & Val.Item (1).Kind'Img
                                else ""));
+               for I in 1 .. Val.Length loop
+                  Trace.Always (Prefix & "array entry" & I'Img & ":");
+                  Print (Val.Item (I), Prefix & "   ");
+               end loop;
             when others =>
-               Trace.Always (Prefix & "value: " & Val.Kind'Img);
+               Trace.Always (Prefix & "value: " & Val.Kind'Img
+                             & "; img: "
+                             & (case Val.Kind is
+                                  when TOML_String  => Val.As_String,
+                                  when TOML_Integer => Val.As_Integer'Image,
+                                  when TOML_Boolean => Val.As_Boolean'Image,
+                                  when others       => "(unimplemented)"));
          end case;
       end Print;
 
    begin
+      Trace.Always ("Printing context: " & Errors.Stack (""));
       Print (Queue.Value, "");
    end Print;
 

--- a/src/alire/alire-toml_load.adb
+++ b/src/alire/alire-toml_load.adb
@@ -181,8 +181,6 @@ package body Alire.TOML_Load is
                Context => TOML_Keys.Pins));
       end if;
 
-      --  TODO: Process Forbidden
-
       --  Process Available
 
       if Allowed_Tables (Section, Available) then

--- a/testsuite/tests/action/conditional/test.py
+++ b/testsuite/tests/action/conditional/test.py
@@ -1,0 +1,53 @@
+"""
+Test conditional actions, mixed with unconditional ones
+"""
+
+import re
+
+from drivers.alr import run_alr, init_local_crate, alr_manifest
+from drivers.asserts import assert_eq, assert_match
+
+init_local_crate()
+
+# Edit the manifest to include all kinds of actions
+with open(alr_manifest(), "at") as manifest:
+    manifest.write("""
+[[actions]]
+type = "pre-build"
+command = ["echo", "1"]
+
+[[actions.'case(os)'.'...']]
+type = "pre-build"
+command = ["echo", "2"]
+
+[[actions]]
+[actions.'case(os)'.'...']
+type = "pre-build"
+command = ["echo", "3"]
+
+[[actions]]
+type = "pre-build"
+command = ["echo", "4"]
+    [actions.'case(os)'.'...']
+    type = "pre-build"
+    command = ["echo", "5"]
+""")
+
+# Verify actions are there
+assert_match(".*" +
+             re.escape("""   Pre_Build run: ${CRATE_DIR}/./echo 1
+   case OS is
+      when others => Pre_Build run: ${CRATE_DIR}/./echo 2
+   case OS is
+      when others => Pre_Build run: ${CRATE_DIR}/./echo 3
+   Pre_Build run: ${CRATE_DIR}/./echo 4
+   case OS is
+      when others => Pre_Build run: ${CRATE_DIR}/./echo 5
+""") + ".*",
+             run_alr("show").out)
+
+# Verify actions run in the proper order
+assert_eq("1\n2\n3\n4\n5\n",
+          run_alr("action", "pre-build").out)
+
+print('SUCCESS')

--- a/testsuite/tests/action/conditional/test.yaml
+++ b/testsuite/tests/action/conditional/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script

--- a/testsuite/tests/index/environment/test.py
+++ b/testsuite/tests/index/environment/test.py
@@ -12,9 +12,8 @@ import os
 # With conditionals
 p = run_alr('show', 'hello')
 
+# Test that unconditional properties are in the output
 assert_match('.*'
-             '      when others => Environment: CONDVAR=uvw\n'
-             '.*'
              '   Environment: VAR1=\${VAR1}:abc\n'
              '   Environment: VAR2=xyz:\${VAR2}\n'
              '   Environment: VAR3=pqr\n'
@@ -24,6 +23,13 @@ assert_match('.*'
              '   Environment: VAR7=abc\${_ALIRE_TEST_}abc\n'
              '   Environment: VAR8=abc\\\\\${_ALIRE_TEST_}abc\n'
              '   Environment: VAR9=\${_ALIRE_TEST_}\${_ALIRE_TEST_}\${_ALIRE_TEST_}\n'
+             '.*',
+             p.out, flags=re.S)
+
+# Test that conditional properties are in the output
+assert_match('.*'
+             '   case OS is\n'
+             '      when others => Environment: CONDVAR=uvw\n'
              '.*',
              p.out, flags=re.S)
 


### PR DESCRIPTION
This enhances the syntax for conditional actions, which were limited to a single conditional action and no possibility of mixing with unconditional actions.

Fixes #1063 