### PR TITLE
Export build-switches to TOML

### DIFF
--- a/src/alire/alire-properties-build_switches.adb
+++ b/src/alire/alire-properties-build_switches.adb
@@ -326,6 +326,8 @@ package body Alire.Properties.Build_Switches is
          --  Can't happen, unless the dispatch to us itself was erroneous
       end if;
 
+      Var.T := Env.Clone;
+
       return Props : Conditional.Properties do
          Var.Modif := From_TOML (From, Env);
          Props := Props and Var;
@@ -339,9 +341,8 @@ package body Alire.Properties.Build_Switches is
 
    overriding
    function To_TOML (This : Variable) return TOML.TOML_Value is
-      pragma Unreferenced (This);
    begin
-      return No_TOML_Value;
+      return This.T;
    end To_TOML;
 
    -------------

--- a/src/alire/alire-properties-build_switches.ads
+++ b/src/alire/alire-properties-build_switches.ads
@@ -70,6 +70,7 @@ private
 
    type Variable is new Property with record
       Modif : Profile_Modifier;
+      T     : TOML.TOML_Value; -- Original import
    end record;
 
 end Alire.Properties.Build_Switches;


### PR DESCRIPTION
Without this, any manifest that contains `[build-switches]` will fail during `alr get` or `alr with`.