### PR TITLE
Use last build profile on `alr run`

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -4,6 +4,16 @@ This document is a development diary summarizing changes in `alr` that notably
 affect the user experience. It is intended as a one-stop point for users to
 stay on top of `alr` new features.
 
+## Release 1.3-dev
+
+### Reuse build profile of `alr build` when issuing `alr run`
+
+`alr run` will trigger a build to have an up-to-date executable, and before
+this PR this was always a development build. Now, the last profile used during
+an `alr build` will be reused.
+
+PR [#1080](https://github.com/alire-project/alire/pull/1080)
+
 ## Release 1.2
 
 ### New subcommand for listing and manual triggering of actions

--- a/src/alire/alire-crate_configuration.ads
+++ b/src/alire/alire-crate_configuration.ads
@@ -14,14 +14,13 @@ package Alire.Crate_Configuration is
 
    --  Types used to store build profiles/switches and declared variables
 
+   subtype Profile_Kind is Utils.Switches.Profile_Kind;
+
    Default_Root_Build_Profile : constant Utils.Switches.Profile_Kind :=
      Utils.Switches.Development;
 
    Default_Deps_Build_Profile : constant Utils.Switches.Profile_Kind :=
      Utils.Switches.Release;
-
-   Root_Build_Profile : Utils.Switches.Profile_Kind :=
-     Default_Root_Build_Profile;
 
    type Global_Config is tagged private;
 
@@ -31,6 +30,11 @@ package Alire.Crate_Configuration is
    function Build_Profile (This  : Global_Config;
                            Crate : Crate_Name)
                            return Utils.Switches.Profile_Kind
+     with Pre => This.Is_Valid;
+
+   procedure Set_Build_Profile (This    : in out Global_Config;
+                                Crate   : Crate_Name;
+                                Profile : Profile_Kind)
      with Pre => This.Is_Valid;
 
    procedure Load (This : in out Global_Config;

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -185,8 +185,13 @@ package body Alire.Roots is
          use Alire.Utils.Switches;
          use Alire.Crate_Configuration;
       begin
-         if Last_Build_Profile /= Root_Build_Profile
+         This.Load_Configuration;
+         if Last_Build_Profile /= This.Configuration.Build_Profile (This.Name)
          then
+            Trace.Detail
+              ("Root build profile changed: "
+               & Last_Build_Profile'Image & " --> "
+               & This.Configuration.Build_Profile (This.Name)'Image);
             This.Generate_Configuration;
          end if;
       end;
@@ -256,22 +261,43 @@ package body Alire.Roots is
                            return Crate_Configuration.Global_Config
    is
    begin
-      if not This.Configuration.Is_Valid then
-         Crate_Configuration.Load (This.Configuration.all, This);
-      end if;
+      This.Load_Configuration;
 
       return This.Configuration.all;
    end Configuration;
+
+   ------------------------
+   -- Load_Configuration --
+   ------------------------
+
+   procedure Load_Configuration (This : in out Root) is
+   begin
+      if not This.Configuration.Is_Valid then
+         Crate_Configuration.Load (This.Configuration.all, This);
+      end if;
+   end Load_Configuration;
+
+   -----------------------
+   -- Set_Build_Profile --
+   -----------------------
+
+   procedure Set_Build_Profile (This    : in out Root;
+                                Crate   : Crate_Name;
+                                Profile : Crate_Configuration.Profile_Kind)
+   is
+   begin
+      This.Load_Configuration;
+      This.Configuration.Set_Build_Profile (Crate, Profile);
+   end Set_Build_Profile;
 
    ----------------------------
    -- Generate_Configuration --
    ----------------------------
 
    procedure Generate_Configuration (This : in out Root) is
-      Conf : Alire.Crate_Configuration.Global_Config;
    begin
-      Conf.Load (This);
-      Conf.Generate_Config_Files (This);
+      This.Load_Configuration;
+      This.Configuration.Generate_Config_Files (This);
    end Generate_Configuration;
 
    ------------------

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -223,6 +223,12 @@ package Alire.Roots is
    --  Returns the global configuration for the root and dependencies. This
    --  configuration is computed the first time it is requested.
 
+   procedure Set_Build_Profile (This    : in out Root;
+                                Crate   : Crate_Name;
+                                Profile : Crate_Configuration.Profile_Kind)
+     with Pre => This.Release.Name = Crate or else
+                 This.Solution.Releases.Contains (Crate);
+
    procedure Generate_Configuration (This : in out Root);
    --  Generate or re-generate the crate configuration files
 
@@ -244,6 +250,10 @@ package Alire.Roots is
    --  The "/path/to/alire.lock" file inside Working_Folder
 
 private
+
+   procedure Load_Configuration (This : in out Root);
+   --  Force loading of the configuration; useful since the auto-load is not
+   --  triggered when doing This.Configuration here.
 
    function Load_Solution (Lockfile : String) return Solutions.Solution
    is (Lockfiles.Read (Lockfile).Solution);

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -22,18 +22,16 @@ package body Alr.Commands.Build is
          Reportaise_Wrong_Arguments ("Only one build mode can be selected");
       end if;
 
-      --  If a build profile has been set in the manifest we apply it now.
-      --  There will be a default otherwise.
-
-      Alire.Crate_Configuration.Root_Build_Profile :=
-        Cmd.Root.Configuration.Build_Profile (Cmd.Root.Name);
+      --  Build profile in the command line takes precedence. The configuration
+      --  will have been loaded at this time with all profiles found in
+      --  manifests.
 
       if Cmd.Release_Mode then
-         Alire.Crate_Configuration.Root_Build_Profile := Release;
+         Cmd.Root.Set_Build_Profile (Cmd.Root.Name, Release);
       elsif Cmd.Validation_Mode then
-         Alire.Crate_Configuration.Root_Build_Profile := Validation;
+         Cmd.Root.Set_Build_Profile (Cmd.Root.Name, Validation);
       elsif Cmd.Dev_Mode then
-         Alire.Crate_Configuration.Root_Build_Profile := Development;
+         Cmd.Root.Set_Build_Profile (Cmd.Root.Name, Development);
       end if;
 
       if not Execute (Cmd, Args,
@@ -55,12 +53,12 @@ package body Alr.Commands.Build is
    begin
 
       --  If we were invoked from another command (e.g. run) we apply the
-      --  profile found in the manifest as no override in the command line can
-      --  appear:
+      --  last profile used for building the crate
 
       if Cmd not in Command'Class then
-         Alire.Crate_Configuration.Root_Build_Profile :=
-           Cmd.Root.Configuration.Build_Profile (Cmd.Root.Name);
+         Cmd.Root.Set_Build_Profile
+           (Cmd.Root.Name,
+            Alire.Crate_Configuration.Last_Build_Profile);
       end if;
 
       declare

--- a/testsuite/tests/build_profile/alr_build_switches/test.py
+++ b/testsuite/tests/build_profile/alr_build_switches/test.py
@@ -12,6 +12,7 @@ init_local_crate('lib_1', binary=False, enter=False)
 init_local_crate('bin_1', binary=True, enter=True)
 run_alr('update')
 
+
 def check_config(path, profile):
     conf = content_of(path)
     assert_match('.*Build_Profile : Build_Profile_Kind := "%s"' % profile,
@@ -21,6 +22,7 @@ lib1_config = "../lib_1/config/lib_1_config.gpr"
 bin_config = "config/bin_1_config.gpr"
 
 mtime = os.path.getmtime(bin_config)
+
 
 def check_config_changed():
     global mtime

--- a/testsuite/tests/build_profile/last_profile/test.py
+++ b/testsuite/tests/build_profile/last_profile/test.py
@@ -19,10 +19,10 @@ run_alr("build", "--release")
 assert_match(".*last_build_profile=RELEASE.*",
              run_alr("config").out)
 
-# Check implicit profile when build is indirect
+# Check implicit profile when build is indirect is last that was used:
 
-run_alr("run")  # Causes a default build
-assert_match(".*last_build_profile=DEVELOPMENT.*",
+run_alr("run")  # Causes a build with the last used profile
+assert_match(".*last_build_profile=RELEASE.*",
              run_alr("config").out)
 
 # Check explicit profile requested in the manifest


### PR DESCRIPTION
Instead of always defaulting to development.

I wonder if `alr build` without an explicit profile should also default to the last explicit profile.

Edit: this PR includes a bit of refactoring to get rid of a global variable (`Alire.Crate_Configuration.Root_Build_Profile`) that was making the logic start to get convoluted with the recent changes.