### PR TITLE
Lazy index loading (1/2)

### DIFF
--- a/src/alire/alire-externals-from_output.adb
+++ b/src/alire/alire-externals-from_output.adb
@@ -47,7 +47,7 @@ package body Alire.Externals.From_Output is
 
       declare
          use GNAT.Regpat;
-         Matches : Match_Array (1 .. Match_Count'Last);
+         Matches : Match_Array (1 .. 1); -- We should have at most one match
          Lines   : AAA.Strings.Vector;
          Status  : constant Integer :=
                      OS_Lib.Subprocess.Unchecked_Spawn_And_Capture
@@ -82,7 +82,7 @@ package body Alire.Externals.From_Output is
                                   & Version);
 
                      Releases.Insert
-                       (Index.Crate (Name).Base
+                       (Index.Crate (Name, Index.Query_Mem_Only).Base
                         .Retagging (Semantic_Versioning.Parse (Version))
                         .Providing (This.Provides)
                         .Replacing (Origins.New_External ("path " & Path))

--- a/src/alire/alire-externals-from_system.adb
+++ b/src/alire/alire-externals-from_system.adb
@@ -50,7 +50,7 @@ package body Alire.Externals.From_System is
                                       & Candidate);
 
                         Releases.Insert
-                          (Index.Crate (Name).Base
+                          (Index.Crate (Name, Index.Query_Mem_Only).Base
                            .Retagging (Result.Value)
                            .Providing (This.Provides)
                            .Replacing (Origins.New_System (Candidate))

--- a/src/alire/alire-index.adb
+++ b/src/alire/alire-index.adb
@@ -2,10 +2,13 @@ with Ada.Containers.Indefinite_Ordered_Maps;
 with Ada.Containers.Indefinite_Ordered_Sets;
 
 with Alire.Containers;
+with Alire.Index_On_Disk.Loading;
 
 with Alire.Utils.TTY;
 
 package body Alire.Index is
+
+   package Index_Loading renames Index_On_Disk.Loading;
 
    package Release_Set_Maps is new
      Ada.Containers.Indefinite_Ordered_Maps
@@ -43,7 +46,7 @@ package body Alire.Index is
                   Policy : Policies.For_Index_Merging :=
                     Policies.Merge_Priorizing_Existing) is
    begin
-      if Exists (Crate.Name) then
+      if Contents.Contains (Crate.Name) then
          declare
             Old : Crates.Crate := Contents (Crate.Name);
          begin
@@ -175,18 +178,30 @@ package body Alire.Index is
    -- Exists --
    ------------
 
-   function Exists (Name : Crate_Name) return Boolean is
-     (Contents.Contains (Name));
+   function Exists (Name : Crate_Name;
+                    Opts : Query_Options := Query_Defaults)
+                    return Boolean
+   is
+   begin
+      if Opts.Load_From_Disk then
+         Index_Loading.Load (Name,
+                             Opts.Detect_Externals,
+                             Strict => False);
+      end if;
+
+      return Contents.Contains (Name);
+   end Exists;
 
    ------------
    -- Exists --
    ------------
 
    function Exists (Name : Crate_Name;
-                    Version : Semantic_Versioning.Version)
+                    Version : Semantic_Versioning.Version;
+                    Opts : Query_Options := Query_Defaults)
                     return Boolean is
    begin
-      if Exists (Name) then
+      if Exists (Name, Opts) then
          for R of Contents (Name).Releases loop
             if R.Name = Name and then R.Version = Version then
                return True;
@@ -202,8 +217,15 @@ package body Alire.Index is
    ----------
 
    function Find (Name : Crate_Name;
-                  Version : Semantic_Versioning.Version) return Release is
+                  Version : Semantic_Versioning.Version;
+                  Opts    : Query_Options := Query_Defaults) return Release is
    begin
+      if Opts.Load_From_Disk then
+         Index_Loading.Load (Name,
+                             Opts.Detect_Externals,
+                             Strict => False);
+      end if;
+
       for R of Contents (Name).Releases loop
          if R.Name = Name and then R.Version = Version then
             return R;
@@ -256,20 +278,22 @@ package body Alire.Index is
    -- Releases_Satisfying --
    -------------------------
 
-   function Releases_Satisfying (Dep              : Dependencies.Dependency;
-                                 Env              : Properties.Vector;
-                                 Use_Equivalences : Boolean := True;
-                                 Available_Only   : Boolean := True;
-                                 With_Origin      : Origins.Kinds_Set :=
-                                   (others => True))
-                                 return Releases.Containers.Release_Set
+   function Releases_Satisfying
+     (Dep              : Dependencies.Dependency;
+      Env              : Properties.Vector;
+      Opts             : Query_Options := Query_Defaults;
+      Use_Equivalences : Boolean := True;
+      Available_Only   : Boolean := True;
+      With_Origin      : Origins.Kinds_Set :=
+        (others => True))
+      return Releases.Containers.Release_Set
    is
       Result : Releases.Containers.Release_Set;
    begin
 
       --  Regular crates
 
-      if Exists (Dep.Crate) then
+      if Exists (Dep.Crate, Opts) then
          for Release of Crate (Dep.Crate).Releases loop
             if With_Origin (Release.Origin.Kind)
               and then Release.Satisfies (Dep)

--- a/src/alire/alire-index.adb
+++ b/src/alire/alire-index.adb
@@ -158,7 +158,11 @@ package body Alire.Index is
    ----------------
 
    function All_Crates return access constant Crates.Containers.Maps.Map is
-     (Contents'Access);
+   begin
+      Index_Loading.Load_All.Assert;
+
+      return Contents'Access;
+   end All_Crates;
 
    -----------
    -- Crate --

--- a/src/alire/alire-index.ads
+++ b/src/alire/alire-index.ads
@@ -93,32 +93,47 @@ package Alire.Index is
    --  BASIC QUERIES  --
    ---------------------
 
+   --  The following queries will automatically load crates from the indexes
+
+   type Query_Options is record
+      Detect_Externals : Boolean := True;
+      Load_From_Disk   : Boolean := True;
+   end record;
+
+   Query_Defaults : constant Query_Options := (others => <>);
+
    function Crate (Name : Crate_Name) return Crates.Crate
      with Pre =>
        Exists (Name) or else
        raise Checked_Error with "Requested crate not in index: " & (+Name);
 
-   function Exists (Name : Crate_Name) return Boolean;
+   function Exists (Name : Crate_Name;
+                    Opts : Query_Options := Query_Defaults)
+                    return Boolean;
 
    function Exists (Name : Crate_Name;
-                    Version : Semantic_Versioning.Version)
+                    Version : Semantic_Versioning.Version;
+                    Opts : Query_Options := Query_Defaults)
                     return Boolean;
 
    function Has_Externals (Name : Crate_Name) return Boolean;
 
-   function Releases_Satisfying (Dep              : Dependencies.Dependency;
-                                 Env              : Properties.Vector;
-                                 Use_Equivalences : Boolean := True;
-                                 Available_Only   : Boolean := True;
-                                 With_Origin      : Origins.Kinds_Set :=
-                                   (others => True))
-                                 return Releases.Containers.Release_Set;
+   function Releases_Satisfying
+     (Dep              : Dependencies.Dependency;
+      Env              : Properties.Vector;
+      Opts             : Query_Options := Query_Defaults;
+      Use_Equivalences : Boolean := True;
+      Available_Only   : Boolean := True;
+      With_Origin      : Origins.Kinds_Set :=
+        (others => True))
+      return Releases.Containers.Release_Set;
    --  Return all releases in the catalog able to provide this dependency,
    --  also optionally considering their "provides" equivalences, and also
    --  optionally including unavailable on the platform.
 
    function Find (Name    : Crate_Name;
-                  Version : Semantic_Versioning.Version) return Release
+                  Version : Semantic_Versioning.Version;
+                  Opts    : Query_Options := Query_Defaults) return Release
      with Pre =>
        Exists (Name, Version) or else
      raise Checked_Error with

--- a/src/alire/alire-index.ads
+++ b/src/alire/alire-index.ads
@@ -151,5 +151,6 @@ package Alire.Index is
    --  package.
 
    function All_Crates return access constant Crates.Containers.Maps.Map;
+   --  Using this call will force a full index load
 
 end Alire.Index;

--- a/src/alire/alire-index.ads
+++ b/src/alire/alire-index.ads
@@ -96,16 +96,17 @@ package Alire.Index is
    --  The following queries will automatically load crates from the indexes
 
    type Query_Options is record
-      Detect_Externals : Boolean := True;
+      Detect_Externals : Boolean := False;
       Load_From_Disk   : Boolean := True;
    end record;
 
    Query_Defaults : constant Query_Options := (others => <>);
+   Query_Fully    : constant Query_Options := (others => True);
+   Query_Mem_Only : constant Query_Options := (others => False);
 
-   function Crate (Name : Crate_Name) return Crates.Crate
-     with Pre =>
-       Exists (Name) or else
-       raise Checked_Error with "Requested crate not in index: " & (+Name);
+   function Crate (Name : Crate_Name;
+                   Opts : Query_Options := Query_Defaults)
+                   return Crates.Crate;
 
    function Exists (Name : Crate_Name;
                     Opts : Query_Options := Query_Defaults)
@@ -133,12 +134,7 @@ package Alire.Index is
 
    function Find (Name    : Crate_Name;
                   Version : Semantic_Versioning.Version;
-                  Opts    : Query_Options := Query_Defaults) return Release
-     with Pre =>
-       Exists (Name, Version) or else
-     raise Checked_Error with
-       "Requested milestone not in index: "
-       & (+Name) & "=" & Semantic_Versioning.Image (Version);
+                  Opts    : Query_Options := Query_Defaults) return Release;
 
    --  Counts
 
@@ -150,7 +146,7 @@ package Alire.Index is
    --  a proper type to be returned and manipulated via the functions in this
    --  package.
 
-   function All_Crates return access constant Crates.Containers.Maps.Map;
-   --  Using this call will force a full index load
+   function All_Crates (Opts : Query_Options := Query_Defaults)
+                        return access constant Crates.Containers.Maps.Map;
 
 end Alire.Index;

--- a/src/alire/alire-index_on_disk-loading.adb
+++ b/src/alire/alire-index_on_disk-loading.adb
@@ -376,6 +376,11 @@ package body Alire.Index_On_Disk.Loading is
             Indexes : constant Set := Find_All (Path, Result);
          begin
             Result.Assert;
+            if Indexes.Is_Empty then
+               Warnings.Warn_Once ("No indexes configured");
+               return;
+            end if;
+
             Load (Crate, Detect_Externals, Strict, Indexes, Path => "");
             return;
          end;

--- a/src/alire/alire-index_on_disk-loading.ads
+++ b/src/alire/alire-index_on_disk-loading.ads
@@ -31,12 +31,8 @@ package Alire.Index_On_Disk.Loading is
    --  instead of proceeding with default behaviors, such as getting the
    --  community index.
 
-   procedure Setup_And_Load (From   : Absolute_Path;
-                             Strict : Boolean;
-                             Force  : Boolean := False);
-   --  If there are no crates loaded, load from all configured indexes at the
-   --  configured location. If Force, load even if some crates are already
-   --  loaded. If no index is configured, set up the default community index.
+   procedure Setup (From : Absolute_Path := Default_Path);
+   --  If no index is configured, set up the default community index
 
    function Load_All (From   : Absolute_Path := Default_Path;
                       Strict : Boolean := False;

--- a/src/alire/alire-index_on_disk-loading.ads
+++ b/src/alire/alire-index_on_disk-loading.ads
@@ -13,6 +13,9 @@ package Alire.Index_On_Disk.Loading is
 
    function Default return Set;
 
+   function Default_Path return Absolute_Path;
+   --  Where to look for indexes if no path given
+
    function Find_All
      (Under  : Absolute_Path;
       Result : out Outcome;
@@ -35,8 +38,11 @@ package Alire.Index_On_Disk.Loading is
    --  configured location. If Force, load even if some crates are already
    --  loaded. If no index is configured, set up the default community index.
 
-   function Load_All (From : Absolute_Path; Strict : Boolean) return Outcome;
-   --  Load all indexes available at the given location
+   function Load_All (From   : Absolute_Path := Default_Path;
+                      Strict : Boolean := False;
+                      Force  : Boolean := False) return Outcome;
+   --  Load all indexes available at the given location. If force, reload even
+   --  if an index was already loaded previously.
 
    procedure Load (Crate            : Crate_Name;
                    Detect_Externals : Boolean;

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -3,7 +3,7 @@ with Ada.Text_IO;
 
 with AAA.Strings;
 
-with Alire.Config.Edit;
+with Alire.Config;
 with Alire.Crates;
 with Alire.Directories;
 with Alire.Errors;
@@ -184,9 +184,7 @@ package body Alire.Publish is
 
       --  Check not duplicated
 
-      Index_On_Disk.Loading.Setup_And_Load
-        (From   => Config.Edit.Indexes_Directory,
-         Strict => True);
+      Index_On_Disk.Loading.Load_All (Strict => True).Assert;
       if Index.Exists (Release.Name, Release.Version) then
          Raise_Checked_Error
            ("Target release " & Release.Milestone.TTY_Image

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -5,6 +5,7 @@ with Alire.Dependencies.Containers;
 with Alire.Directories;
 with Alire.Environment;
 with Alire.Errors;
+with Alire.Index_On_Disk.Loading;
 with Alire.Manifest;
 with Alire.Origins;
 with Alire.OS_Lib;
@@ -1179,6 +1180,9 @@ package body Alire.Roots is
             end if;
          end loop;
       end if;
+
+      --  Need full index until "provides" are fixed
+      Index_On_Disk.Loading.Load_All.Assert;
 
       --  Ensure we have complete pin information
 

--- a/src/alire/alire-solver.adb
+++ b/src/alire/alire-solver.adb
@@ -110,6 +110,10 @@ package body Alire.Solver is
                      Options : Query_Options := Default_Options)
                      return Solution
    is
+      Index_Query_Options : constant Index.Query_Options :=
+                              (Load_From_Disk   => True,
+                               Detect_Externals => Options.Detecting = Detect);
+
       Progress : Trace.Ongoing := Trace.Activity ("Solving dependencies");
 
       Timer    : Stopwatch.Instance;
@@ -759,22 +763,11 @@ package body Alire.Solver is
 
                Check_Version_Pin;
 
-            elsif Index.Exists (Dep.Crate) or else
+            elsif Index.Exists (Dep.Crate, Index_Query_Options) or else
                   Index.Has_Externals (Dep.Crate) or else
-              not Index.Releases_Satisfying (Dep, Props).Is_Empty
-              --  TODO: Worth caching?
+              not Index.Releases_Satisfying (Dep, Props,
+                                             Index_Query_Options).Is_Empty
             then
-
-               --  Detect externals for this dependency now, so they are
-               --  available as regular releases. Note that if no release
-               --  fulfills the dependency, it will be resolved as a hint
-               --  below.
-
-               if Options.Detecting = Detect then
-                  Timer.Hold;
-                  Index.Detect_Externals (Dep.Crate, Props);
-                  Timer.Release;
-               end if;
 
                --  Check the releases now, from newer to older (unless required
                --  in reverse). We keep track that none is valid, as this is

--- a/src/alire/alire-solver.ads
+++ b/src/alire/alire-solver.ads
@@ -77,11 +77,13 @@ package Alire.Solver is
    --  Merely check the catalog
 
    function Exists (Name    : Alire.Crate_Name;
-                    Version : Semantic_Versioning.Version)
+                    Version : Semantic_Versioning.Version;
+                    Opts    : Index.Query_Options := Index.Query_Defaults)
                     return Boolean renames Alire.Index.Exists;
 
    function Find (Name    : Alire.Crate_Name;
-                  Version : Semantic_Versioning.Version)
+                  Version : Semantic_Versioning.Version;
+                  Opts    : Index.Query_Options := Index.Query_Defaults)
                   return Release
    renames Alire.Index.Find;
 

--- a/src/alire/alire-toolchains.adb
+++ b/src/alire/alire-toolchains.adb
@@ -266,7 +266,8 @@ package body Alire.Toolchains is
 
          --  Find the newest regular release in our index:
          if not Index.Releases_Satisfying (Any_Tool (Crate),
-                                           Root.Platform_Properties).Is_Empty
+                                           Root.Platform_Properties,
+                                           Opts => Index.Query_Fully).Is_Empty
          then
             Pick_Up_Tool (Crate, Fill_Version_Choices (Crate));
          else

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -22,6 +22,12 @@ package body Alr.Commands.Build is
          Reportaise_Wrong_Arguments ("Only one build mode can be selected");
       end if;
 
+      --  If a build profile has been set in the manifest we apply it now.
+      --  There will be a default otherwise.
+
+      Alire.Crate_Configuration.Root_Build_Profile :=
+        Cmd.Root.Configuration.Build_Profile (Cmd.Root.Name);
+
       if Cmd.Release_Mode then
          Alire.Crate_Configuration.Root_Build_Profile := Release;
       elsif Cmd.Validation_Mode then

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -22,14 +22,6 @@ package body Alr.Commands.Build is
          Reportaise_Wrong_Arguments ("Only one build mode can be selected");
       end if;
 
-      --  If a build profile has been set in the manifest we apply it now.
-      --  There will be a default otherwise.
-
-      Alire.Crate_Configuration.Root_Build_Profile :=
-        Cmd.Root.Configuration.Build_Profile (Cmd.Root.Name);
-
-      --  Build profile in the command line takes precedence
-
       if Cmd.Release_Mode then
          Alire.Crate_Configuration.Root_Build_Profile := Release;
       elsif Cmd.Validation_Mode then
@@ -55,10 +47,6 @@ package body Alr.Commands.Build is
                      return Boolean
    is
    begin
-
-      Cmd.Requires_Full_Index;
-
-      Cmd.Requires_Valid_Session;
 
       --  If we were invoked from another command (e.g. run) we apply the
       --  profile found in the manifest as no override in the command line can

--- a/src/alr/alr-commands-edit.adb
+++ b/src/alr/alr-commands-edit.adb
@@ -75,8 +75,6 @@ package body Alr.Commands.Edit is
            ("No editor defined in config key '" & Keys.Editor_Cmd & "'.");
       end if;
 
-      Cmd.Requires_Full_Index;
-
       Cmd.Requires_Valid_Session;
 
       Cmd.Root.Export_Build_Environment;

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -328,8 +328,6 @@ package body Alr.Commands.Get is
               ("--dirname is incompatible with other switches");
          end if;
 
-         Cmd.Requires_Full_Index;
-
          if not Alire.Index.Exists (Allowed.Crate) then
             Reportaise_Command_Failed
               ("Crate [" & Args (1) & "] does not exist in the catalog.");

--- a/src/alr/alr-commands-pin.adb
+++ b/src/alr/alr-commands-pin.adb
@@ -40,8 +40,6 @@ package body Alr.Commands.Pin is
          --  We let to re-pin without checks because the requested version may
          --  be different.
 
-         Cmd.Requires_Full_Index;
-
          Root.Add_Version_Pin (Dep.Crate, Version);
 
       end Pin;
@@ -55,8 +53,6 @@ package body Alr.Commands.Pin is
          if not Solution.State (Dep.Crate).Is_User_Pinned then
             Reportaise_Command_Failed ("Requested crate is already unpinned");
          end if;
-
-         Cmd.Requires_Full_Index;
 
          Root.Remove_Pin (Dep.Crate);
       end Unpin;
@@ -204,8 +200,6 @@ package body Alr.Commands.Pin is
                   Trace.Info ("Abandoned by user.");
                   return;
                end if;
-
-               Cmd.Requires_Full_Index; -- Next statement recomputes a solution
 
                New_Root.Add_Path_Pin (Crate => Optional_Crate,
                                       Path  => Cmd.URL.all);

--- a/src/alr/alr-commands-printenv.adb
+++ b/src/alr/alr-commands-printenv.adb
@@ -27,8 +27,6 @@ package body Alr.Commands.Printenv is
          Reportaise_Wrong_Arguments ("Specify at most one subcommand");
       end if;
 
-      Cmd.Requires_Full_Index;
-
       Cmd.Requires_Valid_Session;
 
       declare

--- a/src/alr/alr-commands-search.adb
+++ b/src/alr/alr-commands-search.adb
@@ -113,8 +113,6 @@ package body Alr.Commands.Search is
               ("Search substring and --list are incompatible");
          end if;
 
-         Cmd.Requires_Full_Index;
-
          Alire.Index.Search.Print_Crates
            (Substring => (case Args.Count is
                              when 0      => "",
@@ -153,8 +151,6 @@ package body Alr.Commands.Search is
 
       --  End of option verification, start of search. First load the index,
       --  required to look at its entries.
-
-      Cmd.Requires_Full_Index;
 
       Tab.Append (TTY.Bold ("NAME"));
       Tab.Append (TTY.Bold ("STATUS"));

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -250,13 +250,8 @@ package body Alr.Commands.Show is
             else Alire.Dependencies.From_String
               (Cmd.Root.Release.Milestone.Image));
       begin
-         if Args.Count = 1 then
-            Cmd.Load (Allowed.Crate,
-                      Externals => Cmd.Detect);
-
-            if not Alire.Index.Exists (Allowed.Crate) then
-               raise Alire.Query_Unsuccessful;
-            end if;
+         if Args.Count = 1 and then not Alire.Index.Exists (Allowed.Crate) then
+            raise Alire.Query_Unsuccessful;
          end if;
 
          --  Execute

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -51,6 +51,8 @@ package body Alr.Commands.Show is
                         (Alire.Dependencies.New_Dependency
                            (Name, Versions),
                          Platform.Properties,
+                         Opts => (Detect_Externals => Cmd.Detect,
+                                  Load_From_Disk   => True),
                          Use_Equivalences => False,
                          Available_Only   => False));
 
@@ -250,7 +252,11 @@ package body Alr.Commands.Show is
             else Alire.Dependencies.From_String
               (Cmd.Root.Release.Milestone.Image));
       begin
-         if Args.Count = 1 and then not Alire.Index.Exists (Allowed.Crate) then
+         if Args.Count = 1 and then
+           not Alire.Index.Exists (Allowed.Crate,
+                                   Opts => (Detect_Externals => Cmd.Detect,
+                                            Load_From_Disk   => True))
+         then
             raise Alire.Query_Unsuccessful;
          end if;
 

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -517,8 +517,6 @@ package body Alr.Commands.Test is
          end if;
       end if;
 
-      Cmd.Requires_Full_Index;
-
       --  Pre-find candidates to not have duplicate tests if overlapping
       --  requested.
       Find_Candidates;

--- a/src/alr/alr-commands-toolchain.adb
+++ b/src/alr/alr-commands-toolchain.adb
@@ -181,8 +181,6 @@ package body Alr.Commands.Toolchain is
          end if;
       end if;
 
-      Cmd.Requires_Full_Index;
-
       Installation :
       declare
 
@@ -301,12 +299,11 @@ package body Alr.Commands.Toolchain is
    ----------
 
    procedure List (Cmd : in out Command) is
+      pragma Unreferenced (Cmd);
       use Alire;
       use type Dependencies.Dependency;
       Table : AAA.Table_IO.Table;
    begin
-      Cmd.Requires_Full_Index;
-
       if Alire.Shared.Available.Is_Empty then
          Trace.Info ("Nothing installed in configuration prefix "
                      & TTY.URL (Alire.Config.Edit.Path));
@@ -380,7 +377,6 @@ package body Alr.Commands.Toolchain is
       end Find_Version;
 
    begin
-      Cmd.Requires_Full_Index;
 
       --  If no version was given, find if only one is installed
 
@@ -455,7 +451,6 @@ package body Alr.Commands.Toolchain is
 
       if Cmd.S_Select then
 
-         Cmd.Requires_Full_Index;
          Alire.Index.Detect_Externals
            (Alire.GNAT_External_Crate, Alire.Platforms.Current.Properties);
 
@@ -496,7 +491,6 @@ package body Alr.Commands.Toolchain is
          end loop;
 
       elsif Cmd.Install then
-         Cmd.Requires_Full_Index;
          Alire.Index.Detect_Externals
            (Alire.GNAT_External_Crate, Alire.Platforms.Current.Properties);
 

--- a/src/alr/alr-commands-toolchain.adb
+++ b/src/alr/alr-commands-toolchain.adb
@@ -8,6 +8,7 @@ with Alire.Containers;
 with Alire.Dependencies;
 with Alire.Errors;
 with Alire.Index;
+with Alire.Index_On_Disk.Loading;
 with Alire.Milestones;
 with Alire.Origins.Deployers;
 with Alire.Platforms.Current;
@@ -166,6 +167,9 @@ package body Alr.Commands.Toolchain is
       end Identify_Origins;
 
    begin
+
+      Alire.Index.Detect_Externals (Alire.GNAT_Crate,
+                                    Alire.Platforms.Current.Properties);
 
       --  We want to ensure that we are installing compatible tools. The user
       --  can force through this, so we consider that a bad situation may
@@ -378,6 +382,9 @@ package body Alr.Commands.Toolchain is
 
    begin
 
+      Cmd.Requires_Full_Index;
+      --  Needed until "provides" are fixed
+
       --  If no version was given, find if only one is installed
 
       if not AAA.Strings.Contains (Target, "=") then
@@ -451,8 +458,8 @@ package body Alr.Commands.Toolchain is
 
       if Cmd.S_Select then
 
-         Alire.Index.Detect_Externals
-           (Alire.GNAT_External_Crate, Alire.Platforms.Current.Properties);
+         Cmd.Requires_Full_Index;
+         --  We need this temporarily as "provides" still don't work 100%
 
          if Cmd.Local then
             Cmd.Requires_Valid_Session;
@@ -464,6 +471,7 @@ package body Alr.Commands.Toolchain is
                                          else Alire.Config.Global),
                                         Allow_Incompatible => Alire.Force);
          else
+
             for Elt of Args loop
                Pending.Insert (Alire.Dependencies.From_String (Elt).Crate);
             end loop;
@@ -491,14 +499,20 @@ package body Alr.Commands.Toolchain is
          end loop;
 
       elsif Cmd.Install then
-         Alire.Index.Detect_Externals
-           (Alire.GNAT_External_Crate, Alire.Platforms.Current.Properties);
+
+         Alire.Index_On_Disk.Loading.Load_All.Assert;
+         --  We need these two temporarily as "provides" still don't work
+         --  100%
 
          for Elt of Args loop
             Install (Cmd, Elt, Name_Sets.Empty_Set, Set_As_Default => False);
          end loop;
 
       elsif not Cmd.Disable then
+
+         Alire.Index_On_Disk.Loading.Load_All.Assert;
+         --  We need these two temporarily as "provides" still don't work
+         --  100%
 
          --  When no command is specified, print the list
          Cmd.List;

--- a/src/alr/alr-commands-update.adb
+++ b/src/alr/alr-commands-update.adb
@@ -43,8 +43,6 @@ package body Alr.Commands.Update is
          Index.Update_All;
       end if;
 
-      Cmd.Requires_Full_Index;
-
       Cmd.Root.Update (Parse_Allowed,
                        Silent   => False,
                        Interact => True);

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -155,7 +155,6 @@ package body Alr.Commands.Withing is
       end if;
 
       if Cmd.Solve then
-         Cmd.Requires_Full_Index; -- Load possible hints
          Cmd.Root.Solution.Print (Root_Release,
                                   Alire.Platforms.Current.Properties,
                                   Detailed => True,
@@ -304,14 +303,12 @@ package body Alr.Commands.Withing is
             if Cmd.URL.all /= "" then
                Cmd.Add_With_Pin (New_Root, Args);
             else
-               Cmd.Requires_Full_Index;
                Add (New_Root, Args);
             end if;
 
          elsif Cmd.Del then
             Del (New_Root, Args);
          elsif Cmd.From then
-            Cmd.Requires_Full_Index;
             From (New_Root, Args);
          else
             raise Program_Error with "List should have already happened";

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -307,7 +307,6 @@ package body Alr.Commands is
       if Cmd not in Commands.Toolchain.Command'Class and then
         Alire.Toolchains.Assistant_Enabled
       then
-         Cmd.Requires_Full_Index;
          Alire.Toolchains.Assistant (Conf.Global);
       end if;
 
@@ -350,7 +349,6 @@ package body Alr.Commands is
 
                   if Checked.Solution.Is_Attempted then
                      --  Check deps on disk match those in lockfile
-                     Cmd.Requires_Full_Index (Strict => False);
                      Checked.Sync_From_Manifest (Silent   => False,
                                                  Interact => False);
                      return;
@@ -403,7 +401,6 @@ package body Alr.Commands is
          --  upcoming) we are done. Otherwise, do a silent update.
 
          if Sync then
-            Cmd.Requires_Full_Index (Strict => False);
             Checked.Sync_From_Manifest (Silent   => False,
                                         Interact => False,
                                         Force    => True);

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -270,10 +270,8 @@ package body Alr.Commands is
                                   Force_Reload : Boolean := False) is
       pragma Unreferenced (Cmd);
    begin
-      Alire.Index_On_Disk.Loading.Setup_And_Load
-        (From   => Alire.Config.Edit.Indexes_Directory,
-         Strict => Strict,
-         Force  => Force_Reload);
+      Alire.Index_On_Disk.Loading.Load_All (Strict => Strict,
+                                            Force  => Force_Reload).Assert;
    end Requires_Full_Index;
 
    ----------------------------


### PR DESCRIPTION
This is the first of two PRs that remove the need to load the full index for many operations.

The idea is that we know what indexes are configured, where they are on disk, and where each crate lives therein, so any time a crate is needed, we can load it at that time. All in all, this should speed-up things when indexes grow, and fewer external detections should be attempted.

There is a catch that makes this not as straightforward as it seems, which is that "provides" fields mean that a provided crate may require loading whichever other crates provide it, and this is unknown in advance until the whole index has been loaded at least once.

This part is what goes into the follow-up PR: the first time we "see" an index, it is loaded in full and `provider -> provided` mappings are stored in a new metadata file that is invalidated whenever indexes are added or updated. From then on, we know all the crates that must be loaded when one is requested, and lazy load works as intended in all cases.

Fixes #910, fixes #381