### PR TITLE
Add Savannah from GNU to trusted sites

### DIFF
--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -54,6 +54,7 @@ package body Alire.Publish is
                        .Append ("bitbucket.org")
                        .Append ("github.com")
                        .Append ("gitlab.com")
+                       .Append ("savannah.nongnu.org")
                        .Append ("sf.net");
 
    type Data is limited record


### PR DESCRIPTION
Fixes #1084 