### PR TITLE
Prepend projects to GPR_PROJECT_PATH

### DIFF
--- a/src/alire/alire-environment.adb
+++ b/src/alire/alire-environment.adb
@@ -128,8 +128,12 @@ package body Alire.Environment is
                           Tool_Root.Current.Project_Paths;
       begin
          if not Sorted_Paths.Is_Empty then
-            for Path of Sorted_Paths loop
-               This.Append ("GPR_PROJECT_PATH", Path, "crates");
+            for Path of reverse Sorted_Paths loop
+               --  Reverse should not matter as our paths shouldn't overlap,
+               --  but at least is nicer for user inspection to respect
+               --  alphabetical order.
+
+               This.Prepend ("GPR_PROJECT_PATH", Path, "crates");
             end loop;
          end if;
       end;

--- a/testsuite/tests/printenv/basic/test.py
+++ b/testsuite/tests/printenv/basic/test.py
@@ -44,5 +44,13 @@ assert_match('export ALIRE="True"\n'
              '.*',
              p.out, flags=re.S)
 
+# Verify that project paths are prepended before anything that the user already
+# has configured in the environment, so for example GNAT libraries do not get
+# mixed (compiler in PATH is ours but libraries are from the user).
+os.environ["GPR_PROJECT_PATH"] = "canary"
+assert_match(
+    '.*'
+    f'export GPR_PROJECT_PATH="{expected_gpr_path}{os.pathsep}canary"\n',
+    run_alr('printenv', quiet=False).out)
 
 print('SUCCESS')


### PR DESCRIPTION
We were appending which could cause mix-ups when there was another compiler in
the user path (as we are already prepending in the case of PATH)

Fixes #982