### PR TITLE
Fix solver user interactions related to timeouts

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -43,3 +43,4 @@ macos   = { OS = "macOS" }
 [[pins]]
 aaa = { url = "https://github.com/mosteo/aaa", commit = "906d9eaf4fb8efabfbc3d8cfb34d04ceec340e13" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "e250e4e42d9743b782788cf61b4ddc10a45e69e2" }
+stopwatch = { url = "https://github.com/mosteo/stopwatch", commit = "f607a63b714f09bbf6126de9851cbc21cf8666c9" }

--- a/src/alire/alire-solver.ads
+++ b/src/alire/alire-solver.ads
@@ -59,6 +59,12 @@ package Alire.Solver is
    --  * Allow_Shared: crates in the shared config can appear in solutions.
    --  * Only_Local: only crates in the local workspace will be used.
 
+   type Timeout_Policies is
+     (Ask,     -- Normal interaction with user
+      Stop,    -- Abort at first timeout
+      Continue -- Never ask and continue searching
+     );
+
    subtype Pin_Map  is User_Pins.Maps.Map;
    subtype Release  is Types.Release;
    subtype Solution is Solutions.Solution;
@@ -118,6 +124,7 @@ package Alire.Solver is
       Detecting    : Detection_Policies    := Detect;
       Hinting      : Hinting_Policies      := Hint;
       Sharing      : Sharing_Policies      := Allow_Shared;
+      On_Timeout   : Timeout_Policies      := Ask;
 
       Timeout      : Duration              := 5.0;
       --  Time until reporting problems finding a complete solution
@@ -125,8 +132,10 @@ package Alire.Solver is
       Timeout_More : Duration              := 10.0;
       --  Extra period if the user wants to keep looking
 
-      Interactive  : Boolean               := True;
-      --  If not interactive, the first timeout will be applied without asking
+      Elapsed      : Duration              := 0.0;
+      --  Extra elapsed time that has been already used in a previous search
+      --  configuration. No real use case for the user to modify it, but this
+      --  allows avoiding a big-ish refactoring that isn't worth the trouble.
    end record;
 
    Default_Options : constant Query_Options := (others => <>);
@@ -134,8 +143,8 @@ package Alire.Solver is
    --  or otherwise consider a subset of incomplete solutions.
 
    Default_Options_Not_Interactive : constant Query_Options :=
-                                       (Interactive => False,
-                                        others      => <>);
+                                       (On_Timeout => Stop,
+                                        others     => <>);
 
    Exhaustive_Options : constant Query_Options :=
                           (Completeness => All_Incomplete,

--- a/src/alr/alr-commands-search.adb
+++ b/src/alr/alr-commands-search.adb
@@ -63,9 +63,9 @@ package body Alr.Commands.Search is
                          (R.Dependencies (Platform.Properties),
                           Platform.Properties,
                           Alire.Solutions.Empty_Valid_Solution,
-                          Options => (Age         => Query_Policy,
-                                      Interactive => False,
-                                      others      => <>))
+                          Options => (Age        => Query_Policy,
+                                      On_Timeout => Solver.Stop,
+                                      others     => <>))
                        then " "
                        else Flag_Unsolv)));
             Tab.Append (TTY.Version (Semantic_Versioning.Image (R.Version)));


### PR DESCRIPTION
Answering 'No' wasn't always working. Answering 'Always' wasn't always working.

Both were related to the solver increasing its own exhaustiveness configuration and re-launching the search.