### PR TITLE
Show providers of an abstract crate

### DIFF
--- a/doc/catalog-format-spec.md
+++ b/doc/catalog-format-spec.md
@@ -1128,7 +1128,7 @@ One may know that a particular compiler version has a problem with some code.
 This may be expressed with dependencies on the generic `gnat` crate, which
 although is not found in the catalog, is a crate that all GNAT compilers
 provide. (Such a crate without actual releases, but provided by other crates,
-is called a virtual crate.) For example:
+is called an abstract crate.) For example:
 
 ```toml
 gnat = ">=7"   # We require a minimum compiler version

--- a/testsuite/tests/show/provides/test.py
+++ b/testsuite/tests/show/provides/test.py
@@ -1,0 +1,21 @@
+"""
+Test the output of `alr show` for an abstract crate
+"""
+
+import subprocess
+import os
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq
+
+# gnat does not contain releases but several other crates provide it
+
+assert_eq("""Crate gnat is abstract and provided by:
+   gnat_cross_1
+   gnat_cross_2
+   gnat_external
+   gnat_native
+""",
+          run_alr("show", "gnat", quiet=False).out)
+
+print('SUCCESS')

--- a/testsuite/tests/show/provides/test.yaml
+++ b/testsuite/tests/show/provides/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    toolchain_index:
+        in_fixtures: true


### PR DESCRIPTION
I'm moving here to use "abstract" instead of "virtual" in Ada tradition. It wasn't very widespread in the docs anyway.