### PR TITLE
Speed-up search of incomplete solutions

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -42,5 +42,5 @@ macos   = { OS = "macOS" }
 # Some dependencies require precise versions during the development cycle:
 [[pins]]
 aaa = { url = "https://github.com/mosteo/aaa", commit = "906d9eaf4fb8efabfbc3d8cfb34d04ceec340e13" }
-gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "e250e4e42d9743b782788cf61b4ddc10a45e69e2" }
+gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "92bb91130a9ec628b4c48b7ef9fe7f24d9dc25fa" }
 stopwatch = { url = "https://github.com/mosteo/stopwatch", commit = "f607a63b714f09bbf6126de9851cbc21cf8666c9" }

--- a/src/alire/alire-dependencies-containers.adb
+++ b/src/alire/alire-dependencies-containers.adb
@@ -1,5 +1,23 @@
 package body Alire.Dependencies.Containers is
 
+   --------------------
+   -- Image_One_Line --
+   --------------------
+
+   function Image_One_Line (This : Set) return String is
+      Result : AAA.Strings.Vector;
+   begin
+      if This.Is_Empty then
+         return "(empty)";
+      end if;
+
+      for Dep of This loop
+         Result.Append (Dep.TTY_Image);
+      end loop;
+
+      return Result.Flatten (", ");
+   end Image_One_Line;
+
    -----------
    -- Merge --
    -----------
@@ -32,7 +50,7 @@ package body Alire.Dependencies.Containers is
    -- To_Set --
    ------------
 
-   function To_Set (This : List) return Sets.Set is
+   function To_Set (This : List'Class) return Set is
    begin
       return Result : Set do
          for Dep of This loop

--- a/src/alire/alire-dependencies-containers.ads
+++ b/src/alire/alire-dependencies-containers.ads
@@ -33,10 +33,12 @@ package Alire.Dependencies.Containers with Preelaborate is
      Ada.Containers.Indefinite_Ordered_Sets (Dependency,
                                              Lexicographical_Sort);
 
-   subtype Set is Sets.Set;
+   type Set is new Sets.Set with null record;
 
-   function To_Set (This : List) return Sets.Set;
+   function To_Set (This : List'Class) return Set;
    --  For presentation, we prefer dependencies to be shown in order
+
+   function Image_One_Line (This : Set) return String;
 
 private
 

--- a/src/alire/alire-dependencies-containers.ads
+++ b/src/alire/alire-dependencies-containers.ads
@@ -35,6 +35,8 @@ package Alire.Dependencies.Containers with Preelaborate is
 
    type Set is new Sets.Set with null record;
 
+   Empty_Set : constant Set;
+
    function To_Set (This : List'Class) return Set;
    --  For presentation, we prefer dependencies to be shown in order
 
@@ -43,5 +45,7 @@ package Alire.Dependencies.Containers with Preelaborate is
 private
 
    Empty_Map : constant Map := (Maps.Empty_Map with null record);
+
+   Empty_Set : constant Set := (Sets.Empty_Set with null record);
 
 end Alire.Dependencies.Containers;

--- a/src/alire/alire-dependencies-states-maps.adb
+++ b/src/alire/alire-dependencies-states-maps.adb
@@ -28,6 +28,28 @@ package body Alire.Dependencies.States.Maps is
       end return;
    end From_TOML;
 
+   --------------------
+   -- Image_One_Line --
+   --------------------
+
+   function Image_One_Line (This : Map) return String is
+      Result : AAA.Strings.Vector;
+   begin
+      if This.Is_Empty then
+         return "(empty)";
+      end if;
+
+      for I in This.Iterate loop
+         Result.Append (State_Maps.Key (I).As_String
+                        & "->"
+                        & (if This (I).Has_Release
+                          then This (I).Milestone_Image
+                          else This (I).Fulfilment'Image));
+      end loop;
+
+      return Result.Flatten (", ");
+   end Image_One_Line;
+
    ---------------
    -- Including --
    ---------------

--- a/src/alire/alire-dependencies-states-maps.ads
+++ b/src/alire/alire-dependencies-states-maps.ads
@@ -24,4 +24,6 @@ package Alire.Dependencies.States.Maps is
 
    overriding function To_TOML (This : Map) return TOML.TOML_Value;
 
+   function Image_One_Line (This : Map) return String;
+
 end Alire.Dependencies.States.Maps;

--- a/src/alire/alire-solver.adb
+++ b/src/alire/alire-solver.adb
@@ -1240,7 +1240,7 @@ package body Alire.Solver is
       begin
          Expand ((Id        => <>,
                   Parent    => 0,
-                  Seen      => Dependencies.Containers.Empty,
+                  Seen      => Dependencies.Containers.Empty_Set,
                   Expanded  => Empty,
                   Target    => Full_Dependencies,
                   Remaining => Empty,


### PR DESCRIPTION
Better pruning of the search space by discarding some branches earlier.

We also had a bug that was duplicating the search space with every extra dependency. That meant an exponential increase in time for every extra dependency. Fortunately, this only affected incomplete solutions.

In practice there are no visible changes as the solutions found are ultimately the same. There are some tweaks to informative messages to give a bit more of context to the user and report times.