### PR TITLE
New switches for `alr build` to apply profile to all dependencies

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -6,6 +6,19 @@ stay on top of `alr` new features.
 
 ## Release 1.3-dev
 
+### Propagate build profile to dependencies in `alr build`
+
+Two new mutually exclusive switches can be now added when indicating a build
+profile in the command line that propagate this profile to dependencies:
+
+- `alr build --validation --recurse-all`
+- `alr build --validation --recurse-unset`
+
+The `all` variant will override all profiles in the build, even the ones set in
+manifests. Conversely, the `unset` variant will only set profiles for crates
+that do not have an explicit profile set in some manifest (their own or a
+dependent crate).
+
 ### Reuse build profile of `alr build` when issuing `alr run`
 
 `alr run` will trigger a build to have an up-to-date executable, and before

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -10,21 +10,21 @@ stay on top of `alr` new features.
 
 Build profiles can be now tweaked from the command-line with the a new switch:
 
-- `alr build --profiles '*:development'`
+- `alr build --profiles '*=development'`
   `# Set all profiles to development`
-- `alr build --profiles '%:validation'`
+- `alr build --profiles '%=validation'`
   `# Set profiles without an override in a manifest to validation`
 
 Explicit crates can be given, intermixed with one of the wildcards, which apply
 to the rest of crates in the build:
 
-- `alr build --profiles '*:development,libhello:release'`
+- `alr build --profiles '*=development,libhello=release'`
   `# Set all profiles to development but for libhello`
 
 The existing switches `--release`, `--validation`, `--development` continue to
 control root crate profile and take the highest priority:
 
-- `alr build --validation --profiles '*:development'`
+- `alr build --validation --profiles '*=development'`
   `# Set the working crate to validation and the rest to development`
 
 ### Reuse build profile of `alr build` when issuing `alr run`

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -6,18 +6,26 @@ stay on top of `alr` new features.
 
 ## Release 1.3-dev
 
-### Propagate build profile to dependencies in `alr build`
+### Finer control of build profiles in `alr build`
 
-Two new mutually exclusive switches can be now added when indicating a build
-profile in the command line that propagate this profile to dependencies:
+Build profiles can be now tweaked from the command-line with the a new switch:
 
-- `alr build --validation --recurse-all`
-- `alr build --validation --recurse-unset`
+- `alr build --profiles '*:development'`
+  `# Set all profiles to development`
+- `alr build --profiles '%:validation'`
+  `# Set profiles without an override in a manifest to validation`
 
-The `all` variant will override all profiles in the build, even the ones set in
-manifests. Conversely, the `unset` variant will only set profiles for crates
-that do not have an explicit profile set in some manifest (their own or a
-dependent crate).
+Explicit crates can be given, intermixed with one of the wildcards, which apply
+to the rest of crates in the build:
+
+- `alr build --profiles '*:development,libhello:release'`
+  `# Set all profiles to development but for libhello`
+
+The existing switches `--release`, `--validation`, `--development` continue to
+control root crate profile and take the highest priority:
+
+- `alr build --validation --profiles '*:development'`
+  `# Set the working crate to validation and the rest to development`
 
 ### Reuse build profile of `alr build` when issuing `alr run`
 

--- a/src/alire/alire-crate_configuration.adb
+++ b/src/alire/alire-crate_configuration.adb
@@ -25,6 +25,9 @@ with TOML; use TOML;
 
 package body Alire.Crate_Configuration is
 
+   Separator : constant Character := ',';
+   Assign    : constant Character := ':';
+
    function Builtin_Build_Profile is new Typedef_From_Enum
      (Alire.Utils.Switches.Profile_Kind,
       "Build_Profile",
@@ -119,6 +122,7 @@ package body Alire.Crate_Configuration is
                                 return Boolean
    is
    begin
+      Trace.Always ("SETTER " & Setters'Image (This.Setter_Map (Crate)));
       return This.Setter_Map (Crate) = Default;
    end Is_Default_Profile;
 
@@ -820,11 +824,11 @@ package body Alire.Crate_Configuration is
 
       return Result : Profile_Maps.Map do
          declare
-            Pairs : constant Vector := Split (Str, ';');
+            Pairs : constant Vector := Split (Str, Separator);
          begin
             for Pair of Pairs loop
-               Result.Insert (+Head (Pair, ':'),
-                              Profile_Kind'Value (Tail (Pair, ':')));
+               Result.Insert (+Head (Pair, Assign),
+                              Profile_Kind'Value (Tail (Pair, Assign)));
             end loop;
          end;
       end return;
@@ -845,10 +849,11 @@ package body Alire.Crate_Configuration is
    begin
       for I in This.Profile_Map.Iterate loop
          Profiles.Append
-           (String'(Key (I).As_String & ":" & Element (I)'Image));
+           (String'(Key (I).As_String & Assign & Element (I)'Image));
       end loop;
 
-      Config.Edit.Set_Locally ("last_build_profile", Profiles.Flatten (";"));
+      Config.Edit.Set_Locally ("last_build_profile",
+                               Profiles.Flatten (Separator));
    end Save_Last_Build_Profiles;
 
 end Alire.Crate_Configuration;

--- a/src/alire/alire-crate_configuration.adb
+++ b/src/alire/alire-crate_configuration.adb
@@ -122,7 +122,6 @@ package body Alire.Crate_Configuration is
                                 return Boolean
    is
    begin
-      Trace.Always ("SETTER " & Setters'Image (This.Setter_Map (Crate)));
       return This.Setter_Map (Crate) = Default;
    end Is_Default_Profile;
 
@@ -288,8 +287,7 @@ package body Alire.Crate_Configuration is
    is
       Solution : constant Solutions.Solution := Root.Solution;
 
-      Rel_Vect : constant Containers.Crate_Name_Sets.Set :=
-                   Root.Nonabstract_Crates;
+      Rel_Vect : constant Crate_Name_Set := Root.Nonabstract_Crates;
    begin
 
       if not Solution.Is_Complete then
@@ -822,6 +820,10 @@ package body Alire.Crate_Configuration is
          return Profile_Maps.Empty_Map;
       end if;
 
+      --  We store the profiles in the same format as they're given by users in
+      --  the command line for no particular reason:
+      --  last_build_profile=crate1:profile1,crate2:profile2,...
+
       return Result : Profile_Maps.Map do
          declare
             Pairs : constant Vector := Split (Str, Separator);
@@ -847,6 +849,9 @@ package body Alire.Crate_Configuration is
       Profiles : Vector;
       use Profile_Maps;
    begin
+
+      --  See note on Last_Build_Profiles about the format
+
       for I in This.Profile_Map.Iterate loop
          Profiles.Append
            (String'(Key (I).As_String & Assign & Element (I)'Image));

--- a/src/alire/alire-crate_configuration.ads
+++ b/src/alire/alire-crate_configuration.ads
@@ -16,7 +16,7 @@ package Alire.Crate_Configuration is
 
    subtype Profile_Kind is Utils.Switches.Profile_Kind;
 
-   use type Profile_Kind;
+   use all type Profile_Kind;
 
    package Profile_Maps
    is new Ada.Containers.Indefinite_Ordered_Maps (Crate_Name, Profile_Kind);
@@ -63,6 +63,24 @@ package Alire.Crate_Configuration is
 
    function Must_Regenerate (This : Global_Config) return Boolean;
    --  Say if some profile has changed so config files must be regenerated
+
+   type Profile_Wildcards is (To_None,    --  No wildcard given
+                              To_Unset, --  '%' (not set otherwise)
+                              To_All);  --  '*' (total override)
+
+   type Parsed_Profiles is record
+      Profiles : Profile_Maps.Map;
+
+      Default_Apply   : Profile_Wildcards := To_None;
+      Default_Profile : Profile_Kind      := Development;
+   end record;
+
+   function Parse_Profiles (Img              : String;
+                            Accept_Wildcards : Boolean) return Parsed_Profiles;
+   --  Convert a string "crate1=profile1,crate2=profile2,[*|%=profile3]" to
+   --  its proper type. Only one of the wildcards may appear, and only when
+   --  Accept_Wildcards (since we shouldn't see them in our internally stored
+   --  last profiles.
 
 private
 

--- a/src/alire/alire-crate_configuration.ads
+++ b/src/alire/alire-crate_configuration.ads
@@ -32,6 +32,11 @@ package Alire.Crate_Configuration is
                            return Utils.Switches.Profile_Kind
      with Pre => This.Is_Valid;
 
+   function Is_Default_Profile (This  : Global_Config;
+                                Crate : Crate_Name)
+                                return Boolean;
+   --  Say if the current profile for the crate is a default one or not
+
    procedure Set_Build_Profile (This    : in out Global_Config;
                                 Crate   : Crate_Name;
                                 Profile : Profile_Kind)
@@ -59,10 +64,15 @@ private
    package Config_Type_Definition_Holder
    is new Ada.Containers.Indefinite_Holders (Config_Type_Definition);
 
+   type Setters is (Default,  -- Set by alire to a default value
+                    Manifest, -- Set by a crate manifest
+                    User);    -- Set by the alire user through API
+
    type Config_Setting is record
       Type_Def  : Config_Type_Definition_Holder.Holder;
       Value     : TOML.TOML_Value;
       Set_By    : Ada.Strings.Unbounded.Unbounded_String;
+      --  Free-form text as this can be any crate name and other things
    end record;
 
    package Config_Maps is new Ada.Containers.Hashed_Maps
@@ -75,6 +85,10 @@ private
    is new Ada.Containers.Indefinite_Ordered_Maps
      (Crate_Name, Alire.Utils.Switches.Profile_Kind);
 
+   package Profile_Setter_Maps
+   is new Ada.Containers.Indefinite_Ordered_Maps
+     (Crate_Name, Setters);
+
    package Switches_Maps
    is new Ada.Containers.Indefinite_Ordered_Maps
      (Crate_Name, Alire.Utils.Switches.Switch_List);
@@ -83,6 +97,11 @@ private
       Map : Config_Maps.Map;
 
       Profile_Map  : Profile_Maps.Map;
+      --  Mapping crate -> profile, exists for all crates in solution
+
+      Setter_Map   : Profile_Setter_Maps.Map;
+      --  Mapping crate -> setter, exists for all crates in solution
+
       Switches_Map : Switches_Maps.Map;
    end record;
 

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -298,9 +298,9 @@ package body Alire.Roots is
    is
    begin
       This.Load_Configuration;
-      for Rel of This.Solution.Releases.Including (This.Release.Get) loop
-         if Force or else This.Configuration.Is_Default_Profile (Rel.Name) then
-            This.Configuration.Set_Build_Profile (Rel.Name, Profile);
+      for Rel of This.Nonabstract_Crates loop
+         if Force or else This.Configuration.Is_Default_Profile (Rel) then
+            This.Configuration.Set_Build_Profile (Rel, Profile);
          end if;
       end loop;
    end Set_Build_Profiles;
@@ -933,6 +933,7 @@ package body Alire.Roots is
 
    begin
       This.Traverse (Filter'Access);
+      Result.Include (This.Name);
       return Result;
    end Nonabstract_Crates;
 

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -115,6 +115,11 @@ package Alire.Roots is
                           return Any_Path;
    --  Find the base folder in which a release can be found for the given root
 
+   function Nonabstract_Crates (This : in out Root)
+                                return Containers.Crate_Name_Sets.Set;
+   --  Return names of crates in the solution, including root, excluding
+   --  those that are provided by another crates. I.e., only actual releases.
+
    function Solution (This : in out Root) return Solutions.Solution with
      Pre => This.Has_Lockfile;
    --  Returns the solution stored in the lockfile
@@ -227,7 +232,14 @@ package Alire.Roots is
                                 Crate   : Crate_Name;
                                 Profile : Crate_Configuration.Profile_Kind)
      with Pre => This.Release.Name = Crate or else
-                 This.Solution.Releases.Contains (Crate);
+     This.Solution.Releases.Contains (Crate);
+
+   procedure Set_Build_Profiles (This    : in out Root;
+                                 Profile : Crate_Configuration.Profile_Kind;
+                                 Force   : Boolean);
+   --  Set all build profiles in the solution to the value given. Override
+   --  values in manifests if Force, otherwise only set crates without a
+   --  profile in their manifest.
 
    procedure Generate_Configuration (This : in out Root);
    --  Generate or re-generate the crate configuration files

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -117,8 +117,9 @@ package Alire.Roots is
 
    function Nonabstract_Crates (This : in out Root)
                                 return Containers.Crate_Name_Sets.Set;
-   --  Return names of crates in the solution, including root, excluding
-   --  those that are provided by another crates. I.e., only actual releases.
+   --  Return names of crates in the solution that have a buildable release,
+   --  including root, excluding those that are provided by another crate.
+   --  I.e., only actual regular releases.
 
    function Solution (This : in out Root) return Solutions.Solution with
      Pre => This.Has_Lockfile;

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -216,12 +216,16 @@ package Alire.Roots is
 
    function Build (This             : in out Root;
                    Cmd_Args         : AAA.Strings.Vector;
-                   Export_Build_Env : Boolean)
+                   Export_Build_Env : Boolean;
+                   Saved_Profiles   : Boolean := True)
                    return Boolean;
    --  Recursively build all dependencies that declare executables, and finally
    --  the root release. Also executes all pre-build/post-build actions for
    --  all releases in the solution (even those not built). Returns True on
-   --  successful build.
+   --  successful build. By default, profiles stored in the persistent crate
+   --  configuration are used (i.e. last explicit build); otherwise the ones
+   --  given in This.Configuration are used. These come in order of increasing
+   --  priority from: defaults -> manifests -> explicit set via API.
 
    function Configuration (This : in out Root)
                            return Crate_Configuration.Global_Config;
@@ -231,8 +235,7 @@ package Alire.Roots is
    procedure Set_Build_Profile (This    : in out Root;
                                 Crate   : Crate_Name;
                                 Profile : Crate_Configuration.Profile_Kind)
-     with Pre => This.Release.Name = Crate or else
-     This.Solution.Releases.Contains (Crate);
+     with Pre => This.Nonabstract_Crates.Contains (Crate);
 
    procedure Set_Build_Profiles (This    : in out Root;
                                  Profile : Crate_Configuration.Profile_Kind;
@@ -240,6 +243,11 @@ package Alire.Roots is
    --  Set all build profiles in the solution to the value given. Override
    --  values in manifests if Force, otherwise only set crates without a
    --  profile in their manifest.
+
+   procedure Set_Build_Profiles
+     (This     : in out Root;
+      Profiles : Crate_Configuration.Profile_Maps.Map);
+   --  Give explicit profiles per crate. These are always overriding.
 
    procedure Generate_Configuration (This : in out Root);
    --  Generate or re-generate the crate configuration files

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -57,6 +57,7 @@ package body Alr.Commands.Build is
 
       if Cmd.Recurse_Unset or else Cmd.Recurse_Force then
          Cmd.Root.Set_Build_Profiles (Profile, Force => Cmd.Recurse_Force);
+         Cmd.Root.Generate_Configuration;
       end if;
 
       if not Execute (Cmd, Args,

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -143,10 +143,10 @@ package body Alr.Commands.Build is
          & Switch_Profiles & " for more overrides.")
        .New_Line
        .Append (Switch_Profiles & "="
-         & TTY.Emph ("*|%|<crate1>:<profile>[,<crate2>:<profile>...]"))
+         & TTY.Emph ("*|%|<crate1>=<profile>[,<crate2>=<profile>...]"))
        .Append ("   Apply profiles to individual crates.")
-       .Append ("   Use " & TTY.Emph ("*:<profile>") & " to set all profiles.")
-       .Append ("   Use " & TTY.Emph ("%:<profile>") & " to set profiles of "
+       .Append ("   Use " & TTY.Emph ("*=<profile>") & " to set all profiles.")
+       .Append ("   Use " & TTY.Emph ("%=<profile>") & " to set profiles of "
          & "crates without a setting in a manifest only.")
        .New_Line
        .Append ("Running '" & TTY.Terminal ("alr build") & "' without profile "
@@ -184,7 +184,7 @@ package body Alr.Commands.Build is
         (Config,
          Cmd.Profiles'Access,
          "", Switch_Profiles & "=",
-         "Comma-separated list of <crate>:<profile> values (see description)");
+         "Comma-separated list of <crate>=<profile> values (see description)");
 
    end Setup_Switches;
 

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -97,11 +97,11 @@ package body Alr.Commands.Build is
       Profiles_Selected : constant Natural :=
                             Alire.Utils.Count_True ((Cmd.Release_Mode,
                                                      Cmd.Validation_Mode,
-                                                    Cmd.Dev_Mode));
+                                                     Cmd.Dev_Mode));
       Profile : Profile_Kind;
    begin
       if Profiles_Selected > 1 then
-         Reportaise_Wrong_Arguments ("Only one build mode can be selected");
+         Reportaise_Wrong_Arguments ("Only one build profile can be selected");
       end if;
 
       --  Build profile in the command line takes precedence. The configuration
@@ -152,6 +152,8 @@ package body Alr.Commands.Build is
          if Cmd.Root.Build (Args,
                             Export_Build_Env,
                             Saved_Profiles => Cmd not in Build.Command'Class)
+           --  That is, we apply the saved profiles unless the user is
+           --  explicitly invoking `alr build`.
          then
 
             Trace.Info ("Build finished successfully in "
@@ -190,18 +192,11 @@ package body Alr.Commands.Build is
        .Append ("   Use " & TTY.Emph ("%:<profile>") & " to set profiles of "
          & "crates without a setting in a manifest only.")
        .New_Line
-       .Append ("See ALIASES in " & TTY.Terminal ("alr help")
-         & " for common combinations, e.g.:")
-       .Append ("   " & TTY.Emph ("alr build-dev")
-         & ": set development profile for all crates.")
-         .Append ("   " & TTY.Emph ("alr build-validation")
-         & ": set validation profile for all crates.")
-       .New_Line
-       .Append ("Running " & TTY.Terminal ("alr build") & " without profile "
+       .Append ("Running '" & TTY.Terminal ("alr build") & "' without profile "
          & "switches defaults to development (root crate) + release "
-         & " (dependencies). Indirect builds through, e.g., "
-         & TTY.Terminal ("alr run") & " will use the last "
-         & TTY.Terminal ("alr build") & " configuration.")
+         & " (dependencies). Indirect builds through, e.g., '"
+         & TTY.Terminal ("alr run") & "' will use the last '"
+         & TTY.Terminal ("alr build") & "' configuration.")
       );
 
    --------------------

--- a/src/alr/alr-commands-build.ads
+++ b/src/alr/alr-commands-build.ads
@@ -47,23 +47,12 @@ package Alr.Commands.Build is
 
 private
 
-   Apply_Default : aliased String := "default"; -- To detect explicit setting
-   Apply_Root    : aliased String := "root";    -- Apply only to root release
-   Apply_Unset   : aliased String := "unset";   -- Apply to releases without
-   --  a setting in a manifest
-   Apply_All     : aliased String := "all";     -- Apply to all releases
-
-   Apply_Modes : constant array (Positive range <>)
-     of GNAT.OS_Lib.String_Access := (Apply_Default'Access,
-                                      Apply_Root'Access,
-                                      Apply_Unset'Access,
-                                      Apply_All'Access);
-
    type Command is new Commands.Command with record
       Release_Mode    : aliased Boolean := False;
       Validation_Mode : aliased Boolean := False;
       Dev_Mode        : aliased Boolean := False;
-      Apply_Profile   : aliased GNAT.OS_Lib.String_Access :=
-                          new String'(Apply_Default); -- One of the above
+      Profiles        : aliased GNAT.OS_Lib.String_Access;
+      --  A string of "crate:profile" values, with "*" meaning all crates and
+      --  "%" meaning all crates without a previous setting in a manifest.
    end record;
 end Alr.Commands.Build;

--- a/src/alr/alr-commands-build.ads
+++ b/src/alr/alr-commands-build.ads
@@ -48,5 +48,7 @@ private
       Release_Mode    : aliased Boolean := False;
       Validation_Mode : aliased Boolean := False;
       Dev_Mode        : aliased Boolean := False;
+      Recurse_Unset   : aliased Boolean := False;
+      Recurse_Force   : aliased Boolean := False;
    end record;
 end Alr.Commands.Build;

--- a/src/alr/alr-commands-build.ads
+++ b/src/alr/alr-commands-build.ads
@@ -1,5 +1,7 @@
 with AAA.Strings;
 
+private with GNAT.OS_Lib;
+
 package Alr.Commands.Build is
 
    type Command is new Commands.Command with private;
@@ -44,11 +46,24 @@ package Alr.Commands.Build is
    is ("[--] [gprbuild switches and arguments]");
 
 private
+
+   Apply_Default : aliased String := "default"; -- To detect explicit setting
+   Apply_Root    : aliased String := "root";    -- Apply only to root release
+   Apply_Unset   : aliased String := "unset";   -- Apply to releases without
+   --  a setting in a manifest
+   Apply_All     : aliased String := "all";     -- Apply to all releases
+
+   Apply_Modes : constant array (Positive range <>)
+     of GNAT.OS_Lib.String_Access := (Apply_Default'Access,
+                                      Apply_Root'Access,
+                                      Apply_Unset'Access,
+                                      Apply_All'Access);
+
    type Command is new Commands.Command with record
       Release_Mode    : aliased Boolean := False;
       Validation_Mode : aliased Boolean := False;
       Dev_Mode        : aliased Boolean := False;
-      Recurse_Unset   : aliased Boolean := False;
-      Recurse_Force   : aliased Boolean := False;
+      Apply_Profile   : aliased GNAT.OS_Lib.String_Access :=
+                          new String'(Apply_Default); -- One of the above
    end record;
 end Alr.Commands.Build;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -101,16 +101,6 @@ package body Alr.Commands is
 
    procedure Set_Builtin_Aliases is
    begin
-      Sub_Cmd.Set_Alias ("build-dev",
-                         AAA.Strings.Empty_Vector
-                         .Append ("build")
-                         .Append ("--profiles=*:development"));
-
-      Sub_Cmd.Set_Alias ("build-validation",
-                         AAA.Strings.Empty_Vector
-                         .Append ("build")
-                         .Append ("--profiles=*:validation"));
-
       Sub_Cmd.Set_Alias ("gnatprove",
                          AAA.Strings.Empty_Vector
                          .Append ("exec")

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -101,6 +101,16 @@ package body Alr.Commands is
 
    procedure Set_Builtin_Aliases is
    begin
+      Sub_Cmd.Set_Alias ("build-dev",
+                         AAA.Strings.Empty_Vector
+                         .Append ("build")
+                         .Append ("--profiles=*:development"));
+
+      Sub_Cmd.Set_Alias ("build-validation",
+                         AAA.Strings.Empty_Vector
+                         .Append ("build")
+                         .Append ("--profiles=*:validation"));
+
       Sub_Cmd.Set_Alias ("gnatprove",
                          AAA.Strings.Empty_Vector
                          .Append ("exec")

--- a/testsuite/tests/build_profile/bad_profile_lists/test.py
+++ b/testsuite/tests/build_profile/bad_profile_lists/test.py
@@ -1,0 +1,30 @@
+"""
+Check that improper profiles in the command-line don't slip by
+"""
+
+from drivers.alr import run_alr, init_local_crate
+from drivers.asserts import assert_match
+
+init_local_crate()
+
+
+def check(args, msg: str):
+    p = run_alr(*args, complain_on_error=False)
+    assert p.status != 0, f"Command 'alr {args}' should have errored"
+    assert_match(f".*{msg}.*", p.out)
+
+
+#  Conflicting use of wildcards
+check(["build", "--profiles=*=release,%=release"], msg="Only one of")
+
+#  Duplicate wildcard
+check(["build", "--profiles=*=release,*=release"], msg="Only one of")
+
+#  Invalid profile name
+check(["build", "--profiles=*=rilis"], msg="Invalid profile value")
+
+#  Duplicated crate
+check(["build", "--profiles=xxx=release,xxx=release"], msg="Duplicated crate")
+
+
+print('SUCCESS')

--- a/testsuite/tests/build_profile/bad_profile_lists/test.yaml
+++ b/testsuite/tests/build_profile/bad_profile_lists/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script

--- a/testsuite/tests/build_profile/last_profile/test.py
+++ b/testsuite/tests/build_profile/last_profile/test.py
@@ -10,19 +10,19 @@ init_local_crate("xxx")
 # Check profile is the default one (development) if unspecified
 
 run_alr("build")
-assert_match(".*last_build_profile=DEVELOPMENT.*",
+assert_match(".*last_build_profile=xxx:DEVELOPMENT.*",
              run_alr("config").out)
 
 # Check explicit profile in command line
 
 run_alr("build", "--release")
-assert_match(".*last_build_profile=RELEASE.*",
+assert_match(".*last_build_profile=xxx:RELEASE.*",
              run_alr("config").out)
 
 # Check implicit profile when build is indirect is last that was used:
 
 run_alr("run")  # Causes a build with the last used profile
-assert_match(".*last_build_profile=RELEASE.*",
+assert_match(".*last_build_profile=xxx:RELEASE.*",
              run_alr("config").out)
 
 # Check explicit profile requested in the manifest
@@ -32,7 +32,7 @@ with open(alr_manifest(), "at") as manifest:
                          "xxx = 'validation'\n"])
 
 run_alr("build")
-assert_match(".*last_build_profile=VALIDATION.*",
+assert_match(".*last_build_profile=xxx:VALIDATION.*",
              run_alr("config").out)
 
 print('SUCCESS')

--- a/testsuite/tests/build_profile/last_profile/test.py
+++ b/testsuite/tests/build_profile/last_profile/test.py
@@ -10,19 +10,19 @@ init_local_crate("xxx")
 # Check profile is the default one (development) if unspecified
 
 run_alr("build")
-assert_match(".*last_build_profile=xxx:DEVELOPMENT.*",
+assert_match(".*last_build_profile=xxx=DEVELOPMENT.*",
              run_alr("config").out)
 
 # Check explicit profile in command line
 
 run_alr("build", "--release")
-assert_match(".*last_build_profile=xxx:RELEASE.*",
+assert_match(".*last_build_profile=xxx=RELEASE.*",
              run_alr("config").out)
 
 # Check implicit profile when build is indirect is last that was used:
 
 run_alr("run")  # Causes a build with the last used profile
-assert_match(".*last_build_profile=xxx:RELEASE.*",
+assert_match(".*last_build_profile=xxx=RELEASE.*",
              run_alr("config").out)
 
 # Check explicit profile requested in the manifest
@@ -32,7 +32,7 @@ with open(alr_manifest(), "at") as manifest:
                          "xxx = 'validation'\n"])
 
 run_alr("build")
-assert_match(".*last_build_profile=xxx:VALIDATION.*",
+assert_match(".*last_build_profile=xxx=VALIDATION.*",
              run_alr("config").out)
 
 print('SUCCESS')

--- a/testsuite/tests/build_profile/recursive/test.py
+++ b/testsuite/tests/build_profile/recursive/test.py
@@ -41,7 +41,7 @@ check_profile("development", config_root)
 check_profile("release", config_dep1)
 
 # Verify both overrides when all are using defaults
-run_alr("build-validation")
+run_alr("build", "--profiles=*:validation")
 for crate in crates:
     check_profile("validation", config[crate])
 

--- a/testsuite/tests/build_profile/recursive/test.py
+++ b/testsuite/tests/build_profile/recursive/test.py
@@ -41,11 +41,11 @@ check_profile("development", config_root)
 check_profile("release", config_dep1)
 
 # Verify both overrides when all are using defaults
-run_alr("build", "--profiles=*:validation")
+run_alr("build", "--profiles=*=validation")
 for crate in crates:
     check_profile("validation", config[crate])
 
-run_alr("build", "--profiles=%:validation")
+run_alr("build", "--profiles=%=validation")
 for crate in crates:
     check_profile("validation", config[crate])
 
@@ -55,11 +55,11 @@ with open(alr_manifest(), "at") as manifest:
     manifest.write("[build-profiles]\n"
                    "dep1 = 'release'\n")
 
-run_alr("build", "--profiles=*:validation")
+run_alr("build", "--profiles=*=validation")
 for crate in crates:
     check_profile("validation", config[crate])
 
-run_alr("build", "--profiles=%:validation")
+run_alr("build", "--profiles=%=validation")
 check_profile("validation", config_root)
 check_profile("release", config_dep1)  # Manifest takes precedence in this case
 check_profile("validation", config_dep2)
@@ -69,18 +69,18 @@ check_profile("validation", config_dep2)
 with open(alr_manifest(), "at") as manifest:
     manifest.write("'*' = 'development'\n")
 
-run_alr("build", "--profiles=*:validation")
+run_alr("build", "--profiles=*=validation")
 for crate in crates:
     check_profile("validation", config[crate])
 
-run_alr("build", "--validation", "--profiles=%:validation")
+run_alr("build", "--validation", "--profiles=%=validation")
 check_profile("validation", config_root)   # Root is governed by command line
 check_profile("release", config_dep1)      # Because of explicit crate in manif
 check_profile("development", config_dep2)  # Because of wildcard in manifest
 
 # Check individual overriding, which always prevails
 
-run_alr("build", "--profiles=xxx:release,dep1:validation,dep2:validation")
+run_alr("build", "--profiles=xxx=release,dep1=validation,dep2=validation")
 check_profile("release", config_root)
 check_profile("validation", config_dep1)
 check_profile("validation", config_dep2)

--- a/testsuite/tests/build_profile/recursive/test.py
+++ b/testsuite/tests/build_profile/recursive/test.py
@@ -1,0 +1,81 @@
+"""
+Check build recursive switches --recurse-unset and --recurse-all
+"""
+
+from drivers.alr import run_alr, init_local_crate, alr_pin, alr_manifest
+from drivers.helpers import lines_of, content_of
+
+import os
+
+
+def check_profile(profile: str, file: str):
+    line = f'   Build_Profile : Build_Profile_Kind := "{profile}";\n'
+    assert line in lines_of(file), \
+        f"Unexpected contents: missing line '{line}' in {file}:\n" + \
+        f"{content_of(file)}"
+
+
+# Prepare a crate with a couple of dependencies
+
+init_local_crate()
+init_local_crate("dep1", enter=False)
+init_local_crate("dep2", enter=False)
+
+crates = ["xxx", "dep1", "dep2"]
+
+alr_pin("dep1", path="dep1")
+alr_pin("dep2", path="dep2")
+
+config_root = os.path.join("config", "xxx_config.gpr")
+config_dep1 = os.path.join("dep1", "config", "dep1_config.gpr")
+config_dep2 = os.path.join("dep2", "config", "dep2_config.gpr")
+
+config = dict()
+config["xxx"] = config_root
+config["dep1"] = config_dep1
+config["dep2"] = config_dep2
+
+# Verify default profiles in root and dependency
+run_alr("update")  # Faster than build
+check_profile("development", config_root)
+check_profile("release", config_dep1)
+
+# Verify both overrides when all are using defaults
+run_alr("build", "--validation", "--recurse-all")
+for crate in crates:
+    check_profile("validation", config[crate])
+
+run_alr("build", "--validation", "--recurse-unset")
+for crate in crates:
+    check_profile("validation", config[crate])
+
+# give one profile and rech both overrides
+
+with open(alr_manifest(), "at") as manifest:
+    manifest.write("[build-profiles]\n"
+                   "dep1 = 'release'\n")
+
+run_alr("build", "--validation", "--recurse-all")
+for crate in crates:
+    check_profile("validation", config[crate])
+
+run_alr("build", "--validation", "--recurse-unset")
+check_profile("validation", config_root)
+check_profile("release", config_dep1)  # Manifest takes precedence in this case
+check_profile("validation", config_dep2)
+
+# override all in manifest and check both overrides
+
+with open(alr_manifest(), "at") as manifest:
+    manifest.write("'*' = 'development'\n")
+
+run_alr("build", "--validation", "--recurse-all")
+for crate in crates:
+    check_profile("validation", config[crate])
+
+run_alr("build", "--validation", "--recurse-unset")
+check_profile("validation", config_root)   # Root is governed by command line
+check_profile("release", config_dep1)      # Because of explicit crate in manif
+check_profile("development", config_dep2)  # Because of wildcard in manifest
+
+print('SUCCESS')

--- a/testsuite/tests/build_profile/recursive/test.py
+++ b/testsuite/tests/build_profile/recursive/test.py
@@ -1,5 +1,5 @@
 """
-Check build recursive switches --recurse-unset and --recurse-all
+Check build --profiles switch
 """
 
 from drivers.alr import run_alr, init_local_crate, alr_pin, alr_manifest

--- a/testsuite/tests/build_profile/recursive/test.py
+++ b/testsuite/tests/build_profile/recursive/test.py
@@ -41,11 +41,11 @@ check_profile("development", config_root)
 check_profile("release", config_dep1)
 
 # Verify both overrides when all are using defaults
-run_alr("build", "--validation", "--recurse-all")
+run_alr("build-validation")
 for crate in crates:
     check_profile("validation", config[crate])
 
-run_alr("build", "--validation", "--recurse-unset")
+run_alr("build", "--profiles=%:validation")
 for crate in crates:
     check_profile("validation", config[crate])
 
@@ -55,11 +55,11 @@ with open(alr_manifest(), "at") as manifest:
     manifest.write("[build-profiles]\n"
                    "dep1 = 'release'\n")
 
-run_alr("build", "--validation", "--recurse-all")
+run_alr("build", "--profiles=*:validation")
 for crate in crates:
     check_profile("validation", config[crate])
 
-run_alr("build", "--validation", "--recurse-unset")
+run_alr("build", "--profiles=%:validation")
 check_profile("validation", config_root)
 check_profile("release", config_dep1)  # Manifest takes precedence in this case
 check_profile("validation", config_dep2)
@@ -69,13 +69,20 @@ check_profile("validation", config_dep2)
 with open(alr_manifest(), "at") as manifest:
     manifest.write("'*' = 'development'\n")
 
-run_alr("build", "--validation", "--recurse-all")
+run_alr("build", "--profiles=*:validation")
 for crate in crates:
     check_profile("validation", config[crate])
 
-run_alr("build", "--validation", "--recurse-unset")
+run_alr("build", "--validation", "--profiles=%:validation")
 check_profile("validation", config_root)   # Root is governed by command line
 check_profile("release", config_dep1)      # Because of explicit crate in manif
 check_profile("development", config_dep2)  # Because of wildcard in manifest
+
+# Check individual overriding, which always prevails
+
+run_alr("build", "--profiles=xxx:release,dep1:validation,dep2:validation")
+check_profile("release", config_root)
+check_profile("validation", config_dep1)
+check_profile("validation", config_dep2)
 
 print('SUCCESS')

--- a/testsuite/tests/build_profile/recursive/test.yaml
+++ b/testsuite/tests/build_profile/recursive/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
Two new switches that allow to apply a profile to the complete solution without having to edit the manifest:

- `alr build --validation --recurse-all` # Overrides all crates
- `alr build --validation --recurse-unset` # Overrides only crates without explicit settings in manifests

These require an explicit profile to apply. 

The use case is when you want to e.g. make a one-shot full debug/validation build.