### PR TITLE
Reason for missing releases in solution

### DIFF
--- a/src/alire/alire-dependencies-states.ads
+++ b/src/alire/alire-dependencies-states.ads
@@ -15,6 +15,11 @@ package Alire.Dependencies.States is
                          Linked,  -- Supplied for any version by a local dir
                          Solved); -- Solved with an index release/detected hint
 
+   type Missed_Reasons is (Skipped,      -- Left out on purpose during solving
+                           Conflict,     -- Conflicting dependents
+                           Unindexed,    -- Crate doesn't exist
+                           Unavailable); -- No version fulfils the dependency
+
    type Transitivities is (Unknown,   -- Needed by limitations in the solver
                            Direct,    -- A dependency of the root release
                            Indirect); -- A dependency introduced transitively
@@ -45,7 +50,8 @@ package Alire.Dependencies.States is
                      return State;
    --  Returns a copy of Base with additional anded versions
 
-   function Missing (Base : State) return State;
+   function Missing (Base   : State;
+                     Reason : Missed_Reasons) return State;
    --  Change fulfilment to Missed in copy of Base
 
    function Pinning (Base : State;
@@ -110,6 +116,9 @@ package Alire.Dependencies.States is
 
    function Fulfilment (This : State) return Fulfillments;
 
+   function Reason (This : State) return Missed_Reasons
+     with Pre => This.Fulfilment = Missed;
+
    function Link (This : State) return Softlink
      with Pre => This.Is_Linked;
 
@@ -146,6 +155,8 @@ package Alire.Dependencies.States is
    overriding function To_TOML (This : State) return TOML.TOML_Value;
 
 private
+
+   function L (S : String) return String renames AAA.Strings.To_Lower_Case;
 
    use type Semantic_Versioning.Extended.Version_Set;
 
@@ -214,6 +225,8 @@ private
          when Solved =>
             Release : Stored_Release; -- This is always valid
             Shared  : Boolean;        -- The release is from shared install
+         when Missed =>
+            Reason  : Missed_Reasons := Skipped; -- Until solving is attempted
          when others => null;
       end case;
    end record;
@@ -289,6 +302,9 @@ private
           then This.Transitivity'Img & ","
           else "")
        & AAA.Strings.To_Lower_Case (This.Fulfilled.Fulfillment'Img)
+       & (if This.Fulfilled.Fulfillment = Missed
+          then ":" & L (This.Fulfilled.Reason'Image)
+          else "")
        & (if This.Fulfilled.Fulfillment = Linked
           then "," & This.Fulfilled.Target.Element.Image (User => True)
                    & (if not This.Fulfilled.Target.Element.Is_Broken
@@ -405,10 +421,12 @@ private
    -- Missing --
    -------------
 
-   function Missing (Base : State) return State
+   function Missing (Base   : State;
+                     Reason : Missed_Reasons) return State
    is (Base.As_Dependency with
        Name_Len     => Base.Name_Len,
-       Fulfilled    => (Fulfillment => Missed),
+       Fulfilled    => (Fulfillment => Missed,
+                        Reason      => Reason),
        Pinning      => Base.Pinning,
        Transitivity => Base.Transitivity);
 
@@ -480,6 +498,13 @@ private
                         Version => Version),
        Transitivity => Base.Transitivity);
 
+   ------------
+   -- Reason --
+   ------------
+
+   function Reason (This : State) return Missed_Reasons
+   is (This.Fulfilled.Reason);
+
    -------------
    -- Release --
    -------------
@@ -541,7 +566,9 @@ private
           else "")
        & AAA.Strings.To_Lower_Case
          (case This.Fulfilled.Fulfillment is
-             when Missed => TTY.Error (This.Fulfilled.Fulfillment'Img),
+             when Missed =>
+                TTY.Error (This.Fulfilled.Fulfillment'Img) & ":"
+                & TTY.Warn (L (This.Fulfilled.Reason'Image)),
              when Hinted => TTY.Warn (This.Fulfilled.Fulfillment'Img),
              when others => This.Fulfilled.Fulfillment'Img)
        & (if This.Fulfilled.Fulfillment = Linked
@@ -569,7 +596,8 @@ private
    function Unlinking (Base : State) return State
    is (Base.As_Dependency with
        Name_Len     => Base.Name_Len,
-       Fulfilled    => (Fulfillment => Missed),
+       Fulfilled    => (Fulfillment => Missed,
+                        Reason      => Skipped),
        Pinning      => Base.Pinning,
        Transitivity => Base.Transitivity);
 

--- a/src/alire/alire-dependencies-states.ads
+++ b/src/alire/alire-dependencies-states.ads
@@ -20,7 +20,7 @@ package Alire.Dependencies.States is
                            --  Not trivial to distinguish both with the current
                            --  solver so no explicit Forbidden reason for now.
                            Conflict,     -- Conflicting dependents
-                           Unindexed,    -- Crate doesn't exist
+                           Unknown,      -- Crate isn't in any index
                            Unavailable); -- No version fulfils the dependency
 
    type Transitivities is (Unknown,   -- Needed by limitations in the solver

--- a/src/alire/alire-dependencies-states.ads
+++ b/src/alire/alire-dependencies-states.ads
@@ -15,7 +15,10 @@ package Alire.Dependencies.States is
                          Linked,  -- Supplied for any version by a local dir
                          Solved); -- Solved with an index release/detected hint
 
-   type Missed_Reasons is (Skipped,      -- Left out on purpose during solving
+   type Missed_Reasons is (Skipped,      -- Left out on purpose during solving.
+                           --  Also when only forbidden crates fulfil some dep.
+                           --  Not trivial to distinguish both with the current
+                           --  solver so no explicit Forbidden reason for now.
                            Conflict,     -- Conflicting dependents
                            Unindexed,    -- Crate doesn't exist
                            Unavailable); -- No version fulfils the dependency

--- a/src/alire/alire-roots-editable.adb
+++ b/src/alire/alire-roots-editable.adb
@@ -140,7 +140,8 @@ package body Alire.Roots.Editable is
          Alire.Manifest.Append (Crate_File (This.Edit), Dep);
          This.Reload_Manifest;
 
-         This.Edit.Set (This.Solution.Missing (Dep));
+         This.Edit.Set (This.Solution.Missing (Dep,
+                                               Dependencies.States.Skipped));
       end;
    end Add_Dependency;
 

--- a/src/alire/alire-solutions-diffs.adb
+++ b/src/alire/alire-solutions-diffs.adb
@@ -144,6 +144,7 @@ package body Alire.Solutions.Diffs is
              and then Has_Latter and then Latter.Fulfilment in Fulfilment);
 
          use type Alire.User_Pins.Pin;
+
       begin
          --  New hint
          if Gains_State (Hinted) then
@@ -159,7 +160,9 @@ package body Alire.Solutions.Diffs is
 
          --  New unsolvable
          elsif Gains_State (Missed) then
-            Add_Change (Chg, Icon (Missing), TTY.Error ("missing"));
+            Add_Change (Chg, Icon (Missing),
+                        TTY.Error ("missing") & ":"
+                        & TTY.Warn (To_Lower_Case (Latter.Reason'Image)));
 
          --  From hint to proper release
          elsif Has_Former and then Former.Is_Hinted and then

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -404,7 +404,6 @@ package body Alire.Solutions is
        --  The candidate release forbids something in the solution
           (for some Dep of Release.Forbidden (Env) =>
                (for some Rel of This.Releases => Rel.Satisfies (Dep.Value))));
-      pragma Warnings (On);
    end Forbids;
 
    ---------------

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -21,6 +21,7 @@ package body Alire.Solutions is
 
    use type Ada.Containers.Count_Type;
    use type Semantic_Versioning.Version;
+   use all type States.Missed_Reasons;
 
    ----------------------
    -- All_Dependencies --
@@ -175,28 +176,32 @@ package body Alire.Solutions is
    -------------
 
    function Missing (This : Solution;
-                     Dep  : Dependencies.Dependency)
+                     Dep    : Dependencies.Dependency;
+                     Reason : States.Missed_Reasons)
                      return Solution
    is (if This.Depends_On (Dep.Crate)
        then (Solved       => True,
              Dependencies =>
-                This.Dependencies.Including (This.State (Dep.Crate).Missing))
+                This.Dependencies.Including
+                  (This.State (Dep.Crate).Missing (Reason)))
        else (Solved       => True,
              Dependencies =>
-                This.Dependencies.Including (States.New_State (Dep).Missing)));
+                This.Dependencies.Including
+                  (States.New_State (Dep).Missing (Reason))));
 
    -------------
    -- Missing --
    -------------
 
    function Missing (This  : Solution;
-                     Crate : Crate_Name)
+                     Crate  : Crate_Name;
+                     Reason : States.Missed_Reasons)
                      return Solution
    is (if This.Dependencies.Contains (Crate)
        then (Solved       => True,
              Dependencies =>
                 This.Dependencies.Including
-               (This.Dependencies (Crate).Missing))
+                  (This.Dependencies (Crate).Missing (Reason)))
        else This);
 
    -------------
@@ -228,7 +233,7 @@ package body Alire.Solutions is
    function Resetting (This  : Solution;
                        Crate : Crate_Name)
                        return Solution
-   is (This.Missing (Crate).User_Unpinning (Crate));
+   is (This.Missing (Crate, Skipped).User_Unpinning (Crate));
 
    -------------
    -- Setting --
@@ -282,7 +287,9 @@ package body Alire.Solutions is
        then (Solved       => True,
              Dependencies =>
                 This.Dependencies.Including
-               (This.Dependencies (Crate).Unlinking.Unpinning.Missing))
+               (This.Dependencies (Crate).Unlinking
+                                         .Unpinning
+                                         .Missing (Skipped)))
        else This);
 
    --------------------
@@ -445,7 +452,10 @@ package body Alire.Solutions is
          elsif Result.State (Dep_Name).Is_Hinted then
             Result := Result.Hinting (Result.State (Dep_Name).As_Dependency);
          else
-            Result := Result.Missing (Result.State (Dep_Name).As_Dependency);
+            Result := Result.Missing
+              (Result.State (Dep_Name).As_Dependency, Conflict);
+            --  Conflict because there was a pre-existing dependency that the
+            --  release is unable to fulfil.
          end if;
 
          --  In addition, mark as solved other deps satisfied via provides

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -121,13 +121,15 @@ package Alire.Solutions is
      with Pre => This.Depends_On (Crate);
    --  Fulfill a dependency with a link pin
 
-   function Missing (This : Solution;
-                     Dep  : Dependencies.Dependency)
+   function Missing (This   : Solution;
+                     Dep    : Dependencies.Dependency;
+                     Reason : States.Missed_Reasons)
                      return Solution;
    --  Add/merge dependency as missing in solution
 
-   function Missing (This  : Solution;
-                     Crate : Crate_Name)
+   function Missing (This   : Solution;
+                     Crate  : Crate_Name;
+                     Reason : States.Missed_Reasons)
                      return Solution;
    --  Fulfill an existing dependency as missing, or do nothing otherwise
 

--- a/src/alire/alire-solver.adb
+++ b/src/alire/alire-solver.adb
@@ -1031,7 +1031,7 @@ package body Alire.Solver is
                   & " when the search tree was "
                   & Image_One_Line (State));
 
-               Expand_Missing (Unindexed);
+               Expand_Missing (Unknown);
 
             end if;
          end Expand_Value;

--- a/testsuite/tests/pin/version/test.py
+++ b/testsuite/tests/pin/version/test.py
@@ -37,7 +37,7 @@ Dependencies (direct):
 Pins (direct):
    hello = { version='7.7.7' }
 Dependencies (external):
-   hello=7.7.7 (direct,missed,pin=7.7.7) (pinned)
+   hello=7.7.7 (direct,missed:unavailable,pin=7.7.7) (pinned)
 Dependencies (graph):
    xxx=0.1.0-dev --> hello*
 """, p.out)

--- a/testsuite/tests/solver/forbids-replace/test.py
+++ b/testsuite/tests/solver/forbids-replace/test.py
@@ -26,7 +26,7 @@ alr_with("crate_real")
 # need eventually a way to disable equivalences (via pins, or solver config).
 match_solution("crate_real=1.0.0 (origin: filesystem)", escape=True)
 
-# Let's add the drop-in equivalent crate that provides+forbids crate_lone
+# Let's add the drop-in equivalent crate that provides+forbids crate_real
 alr_with("crate_subst")
 match_solution("crate_real=1.0.0 (crate_subst) (origin: filesystem)",
                escape=True)  # This is the substituted release

--- a/testsuite/tests/solver/forbids/test.py
+++ b/testsuite/tests/solver/forbids/test.py
@@ -20,7 +20,7 @@ init_local_crate("conflict_lone")
 alr_with("crate_conflict")
 alr_with("crate_lone")
 match_solution("crate_(conflict|lone)=.* \(origin:.*\)")   # has origin: solved
-match_solution("crate_(conflict|lone)\* \(direct,missed\)")
+match_solution("crate_(conflict|lone)\* \(direct,missed:skipped\)")
 # Because of load/solving details, we do not know which of the two crates is
 # going to be missed/accepted in the solution, so we check there is one of each
 
@@ -28,6 +28,6 @@ init_local_crate("conflict_virtual")
 alr_with("crate_conflict")
 alr_with("crate_virtual")
 match_solution("crate_(conflict|virtual)=.* \(origin:.*\)")
-match_solution("crate_(conflict|virtual)\* \(direct,missed\)")
+match_solution("crate_(conflict|virtual)\* \(direct,missed:skipped\)")
 
 print('SUCCESS')

--- a/testsuite/tests/solver/missing-reasons/test.py
+++ b/testsuite/tests/solver/missing-reasons/test.py
@@ -27,7 +27,7 @@ match_solution(
     """Dependencies (external):
    hello(=1.0.1) & (=1.0.0) (direct,missed:conflict)
    libhello=777 (direct,missed:unavailable)
-   unobtanium* (direct,missed:unindexed)""",
+   unobtanium* (direct,missed:unknown)""",
     escape=True)
 
 print('SUCCESS')

--- a/testsuite/tests/solver/missing-reasons/test.py
+++ b/testsuite/tests/solver/missing-reasons/test.py
@@ -1,0 +1,33 @@
+"""
+Test missing reasons in solutions
+"""
+
+import os
+
+from drivers.alr import run_alr, init_local_crate, alr_with, alr_pin
+from drivers.asserts import match_solution, assert_eq
+
+# Conflict between hello versions, nonexistent libhello, and nonexistent crate
+
+# Root crate
+init_local_crate()
+
+# Dependency to force conflict on hello
+init_local_crate("dep")
+alr_with("hello=1.0.0")
+os.chdir("..")
+
+alr_with("hello=1.0.1")   # Conflict with dep -> hello=1.0.0
+alr_with("libhello=777")  # Version not in index
+alr_with("unobtanium")    # Unindexed crate
+
+alr_pin("dep", path="dep")  # Establish the conflict with this local dep
+
+match_solution(
+    """Dependencies (external):
+   hello(=1.0.1) & (=1.0.0) (direct,missed:conflict)
+   libhello=777 (direct,missed:unavailable)
+   unobtanium* (direct,missed:unindexed)""",
+    escape=True)
+
+print('SUCCESS')

--- a/testsuite/tests/solver/missing-reasons/test.yaml
+++ b/testsuite/tests/solver/missing-reasons/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+  solver_index: {}

--- a/testsuite/tests/update/missing-deps/test.py
+++ b/testsuite/tests/update/missing-deps/test.py
@@ -26,7 +26,8 @@ p = run_alr('with', '--solve')
 assert_match(
     '.*Dependencies \(external\):\n'
     '   ' +
-    re.escape('libhello(=3.0.0) & (^2.0.0) (direct,missed,pin=3.0.0)') + '.*',
+    re.escape('libhello(=3.0.0) & (^2.0.0) '
+              '(direct,missed:conflict,pin=3.0.0)') + '.*',
     p.out, flags=re.S)
 
 

--- a/testsuite/tests/with/changes-info/test.py
+++ b/testsuite/tests/with/changes-info/test.py
@@ -37,7 +37,7 @@ assert_match(".*" +
 Changes to dependency solution:
 
    New solution is incomplete.
-   +! unobtanium * (new,missing:unindexed)""") + ".*",
+   +! unobtanium * (new,missing:unknown)""") + ".*",
              p.out, flags=re.S)
 
 ###############################################################################

--- a/testsuite/tests/with/changes-info/test.py
+++ b/testsuite/tests/with/changes-info/test.py
@@ -37,7 +37,7 @@ assert_match(".*" +
 Changes to dependency solution:
 
    New solution is incomplete.
-   +! unobtanium * (new,missing)""") + ".*",
+   +! unobtanium * (new,missing:unindexed)""") + ".*",
              p.out, flags=re.S)
 
 ###############################################################################

--- a/testsuite/tests/with/tree-switch/test.py
+++ b/testsuite/tests/with/tree-switch/test.py
@@ -33,7 +33,7 @@ assert_match(re.escape('''xxx=0.1.0-dev
 |   +-- libhello=1.0.1 (^1.0)
 +-- superhello=1.0.0 (^1.0.0)
 |   +-- libhello=1.0.1 (~1.0)
-+-- unobtanium* (direct,missed) (*)
++-- unobtanium* (direct,missed:unindexed) (*)
 +-- wip* (direct,linked,path=''') + '.*' + re.escape(') (*)'),
              p.out, flags=re.S)
 

--- a/testsuite/tests/with/tree-switch/test.py
+++ b/testsuite/tests/with/tree-switch/test.py
@@ -33,7 +33,7 @@ assert_match(re.escape('''xxx=0.1.0-dev
 |   +-- libhello=1.0.1 (^1.0)
 +-- superhello=1.0.0 (^1.0.0)
 |   +-- libhello=1.0.1 (~1.0)
-+-- unobtanium* (direct,missed:unindexed) (*)
++-- unobtanium* (direct,missed:unknown) (*)
 +-- wip* (direct,linked,path=''') + '.*' + re.escape(') (*)'),
              p.out, flags=re.S)
 


### PR DESCRIPTION
This is an internal improvement to the solver so now when a dependency can't be solved it will give the reason (via an extra `:reason` part after the usual `missed`). For example, in the output of `alr with --solve`:

```
Dependencies (external):
   hello(=1.0) & (=1.0.1) (direct,missed:conflict)
   libhello^777 (direct,missed:unavailable)
   unobtanium* (direct,missed:unindexed)
Dependencies (graph):
   some_dep=0.1.0-dev --> hello=1.0.1 
   xxx=0.1.0-dev      --> hello=1.0    
   xxx=0.1.0-dev      --> libhello^777
   xxx=0.1.0-dev      --> unobtanium*
```

- Unindexed: the crate doesn't exist at all in our indexes
- Unavailable: the requested version does not exist (but the crate does)
- Conflict: two dependencies on the same crate cannot be reconciled. This can be further diagnosed in the graph portion of the solution (no change on the info shown there). 