### PR TITLE
Honor the --force option when publishing a crate (#1083)

### DIFF
--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -187,15 +187,9 @@ package body Alire.Publish is
 
       Index_On_Disk.Loading.Load_All (Strict => True).Assert;
       if Index.Exists (Release.Name, Release.Version) then
-         if not Force then
-            Raise_Checked_Error
-               ("Target release " & Release.Milestone.TTY_Image
-                & " already exist in a loaded index");
-         end if;
-         Ada.Text_IO.New_Line;
-         Trace.Warning
+         Recoverable_Error
             ("Target release " & Release.Milestone.TTY_Image
-             & " already exist in a loaded index (ignored)");
+             & " already exist in a loaded index");
       end if;
 
       --  Present release information to user

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -187,9 +187,15 @@ package body Alire.Publish is
 
       Index_On_Disk.Loading.Load_All (Strict => True).Assert;
       if Index.Exists (Release.Name, Release.Version) then
-         Raise_Checked_Error
-           ("Target release " & Release.Milestone.TTY_Image
-            & " already exist in a loaded index");
+         if not Force then
+            Raise_Checked_Error
+               ("Target release " & Release.Milestone.TTY_Image
+                & " already exist in a loaded index");
+         end if;
+         Ada.Text_IO.New_Line;
+         Trace.Warning
+            ("Target release " & Release.Milestone.TTY_Image
+             & " already exist in a loaded index (ignored)");
       end if;
 
       --  Present release information to user


### PR DESCRIPTION
When publishing and checking for existing crate with same version,
if the crate already exist and the force option is used,
emit a warning message and continue.