### PR TITLE
workaround for gnatcoll-core#64 / gnatstudio#128

### DIFF
--- a/src/alire/alire-crate_configuration.adb
+++ b/src/alire/alire-crate_configuration.adb
@@ -531,8 +531,12 @@ package body Alire.Crate_Configuration is
                        Elt.Type_Def.Element.To_GPR_Declaration (Elt.Value));
       end loop;
 
-      TIO.Put_Line (File, "   Ada_Compiler_Switches := " &
-                      "External_As_List (""ADAFLAGS"", "" "") &");
+      TIO.Put_Line (File,
+         "   Ada_Compiler_Switches := External_As_List (""ADAFLAGS"", "" "");"
+         );
+
+      TIO.Put_Line (File,
+         "   Ada_Compiler_Switches := Ada_Compiler_Switches &");
 
       Pretty_Print_Switches (File,
                              This.Switches_Map.Element (Crate),


### PR DESCRIPTION
This is a workaround for issue [AdaCore/gnatstudio#128](https://github.com/AdaCore/gnatstudio/issues/128) and [AdaCore/gnatcoll-core#64](https://github.com/AdaCore/gnatcoll-core/issues/64) where GNAT Studio fails to open recently-updated or newly-created alire files.

The issue was fixed in [AdaCore/gnatcoll-core@0553172](https://github.com/AdaCore/gnatcoll-core/commit/0553172078189cdbc381f66a510880290f876c3e) so if alire will be using that version of gnatcoll in their upcoming release, feel free to reject this PR.  Otherwise, this does seem to fix the problem in a less drastic way than was suggested in gnatstudio#128 by breaking out the Ada_Compiler_Switches assignment into two statements.  So `config/<crate>_config.gpr` from e.g.

```Ada
   Ada_Compiler_Switches := External_As_List ("ADAFLAGS", " ") &
          (
           . . .
          );
```
To e.g.

```Ada
   Ada_Compiler_Switches := External_As_List ("ADAFLAGS", " ");
   Ada_Compiler_Switches := Ada_Compiler_Switches &
          (
            . . .
          );
```

P.S. I am new to github, and this is my very first actual PR, so I apologize in advance if I did it incorrectly!