### PR TITLE
Fixes for external detection in Fedora

### DIFF
--- a/src/alire/alire-origins-deployers-system-apt.adb
+++ b/src/alire/alire-origins-deployers-system-apt.adb
@@ -3,8 +3,6 @@ with AAA.Strings; use AAA.Strings;
 with Alire.OS_Lib.Subprocess;
 with Alire.Errors;
 
-with GNAT.Regpat;
-
 package body Alire.Origins.Deployers.System.Apt is
 
    package Subprocess renames Alire.OS_Lib.Subprocess;
@@ -59,27 +57,25 @@ package body Alire.Origins.Deployers.System.Apt is
                        Valid_Exit_Codes => (0, 100), -- Returned when not found
                        Err_To_Out       => True);
 
-      use GNAT.Regpat;
-      Matches : Match_Array (1 .. 1);
    begin
       for Line of Output loop
          if Contains (Line, "Version:") then
             Trace.Debug ("Extracting native version from apt output: " & Line);
-            Match (Regexp, Line, Matches);
-            if Matches (1) /= No_Match then
-               Trace.Debug ("Candidate version string: "
-                            & Line (Matches (1).First .. Matches (1).Last));
-               return
-                 Version_Outcomes.New_Result
-                   (Semantic_Versioning.Parse
-                      (Line (Matches (1).First .. Matches (1).Last),
-                       Relaxed => True)); -- Relaxed because some Debian
-                                          --  versions have extra version pts,
-                                          --  e.g. 1.2.3.4
-            else
-               Trace.Debug
-                 ("Unexpected version format, could not identify version");
-            end if;
+            declare
+               Match : constant String := Utils.First_Match (Regexp, Line);
+            begin
+               if Match /= "" then
+                  Trace.Debug ("Candidate version string: " & Match);
+                  return
+                    Version_Outcomes.New_Result
+                      (Semantic_Versioning.Parse (Match, Relaxed => True));
+                  --  Relaxed because some Debian versions have extra version
+                  --  pts, e.g. 1.2.3.4
+               else
+                  Trace.Debug
+                    ("Unexpected version format, could not identify version");
+               end if;
+            end;
          end if;
       end loop;
 

--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -127,6 +127,43 @@ package body Alire.Utils is
       end return;
    end Count_True;
 
+   -----------------
+   -- First_Match --
+   -----------------
+
+   function First_Match (Regex : String; Text : String) return String is
+
+      -----------------------
+      -- Count_Parentheses --
+      -----------------------
+
+      function Count_Parentheses return Positive is
+         Count : Natural := 0;
+      begin
+         for Char of Regex loop
+            if Char = '(' then
+               Count := Count + 1;
+            end if;
+         end loop;
+         return Count;
+      end Count_Parentheses;
+
+      use GNAT.Regpat;
+      Matches : Match_Array (1 .. Count_Parentheses);
+      --  This is a safe estimation, as some '(' may not be part of a capture
+
+   begin
+      Match (Regex, Text, Matches);
+
+      for I in Matches'Range loop
+         if Matches (I) /= No_Match then
+            return Text (Matches (I).First .. Matches (I).Last);
+         end if;
+      end loop;
+
+      return "";
+   end First_Match;
+
    -------------------------------
    -- Is_Valid_Full_Person_Name --
    -------------------------------

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -79,6 +79,14 @@ package Alire.Utils with Preelaborate is
    --  Flatten String keys of Indefinite_Ordered_Maps into string
    --  representation.
 
+   function First_Match (Regex : String; Text : String) return String
+     with Pre => (for some Char of Regex => Char = '(');
+   --  Wrapper on GNAT.Regpat. It returns the first match found, which is not
+   --  necessarily the first parenthesized expression. E.g., in a pattern like:
+   --  (abc)|(efg), it will return the "efg" match, even if to GNAT.Regpat that
+   --  is the second matching expression. In case of no match, it will return
+   --  an empty string. At least one capture must be attempted in the Regex.
+
 private
 
    function Quote (S : String) return String


### PR DESCRIPTION
Ignore package name casing and fix regular expression.

Also some refactoring to ensure all distro-specific detectors are using the same regex logic.