### PR TITLE
Add FreeBSD as a known OS

### DIFF
--- a/src/alire/alire-platforms.ads
+++ b/src/alire/alire-platforms.ads
@@ -19,12 +19,14 @@ package Alire.Platforms with Preelaborate is
      Extended_Architectures'Succ (End_Of_Duplicates) .. Architecture_Unknown;
    --  See e.g. https://stackoverflow.com/a/45125525/761390
 
-   type Operating_Systems is (Linux,
+   type Operating_Systems is (FreeBSD,
+                              Linux,
                               MacOS,
                               Windows,
                               OS_Unknown);
    subtype Known_Operating_Systems is
-     Operating_Systems range Linux .. Windows;
+     Operating_Systems range
+       Operating_Systems'First .. Operating_Systems'Pred (OS_Unknown);
 
    type Targets is (Native,
                     Unknown_Cross_Target);


### PR DESCRIPTION
Since it seems `alr` is working on it with the new gcc, and in preparation for future contributions (https://github.com/alire-project/alire/issues/22#issuecomment-1207224025)

This is the bare minimum to be able to use it in manifests. We still don't have OS-specific files to make the detection.