### PR TITLE
Add support for FreeBSD (#22)

### DIFF
--- a/alire.gpr
+++ b/alire.gpr
@@ -25,6 +25,7 @@ library project Alire is
    case Alire_Common.Host_Os is
       when "windows" => Src_Dirs := Src_Dirs & ("src/alire/os_windows");
       when "osx"     => Src_Dirs := Src_Dirs & ("src/alire/os_macos");
+      when "freebsd" => Src_Dirs := Src_Dirs & ("src/alire/os_freebsd");
       when others    => Src_Dirs := Src_Dirs & ("src/alire/os_linux");
    end case;
 
@@ -36,6 +37,9 @@ library project Alire is
          when "osx"     =>
             for body ("Alire.Platforms.Current") use "alire-platforms-current__macos.adb";
             for body ("Alire.Platforms.Folders") use "alire-platforms-folders__macos.adb";
+         when "freebsd" =>
+            for body ("Alire.Platforms.Current") use "alire-platforms-current__freebsd.adb";
+            for body ("Alire.Platforms.Folders") use "alire-platforms-folders__freebsd.adb";
          when others    =>
             for body ("Alire.Platforms.Current") use "alire-platforms-current__linux.adb";
             for body ("Alire.Platforms.Folders") use "alire-platforms-folders__linux.adb";

--- a/alr_env.gpr
+++ b/alr_env.gpr
@@ -44,6 +44,9 @@ aggregate project Alr_Env is
       when "macOS" | "macos" | "OSX" | "osx" =>
          for External ("ALIRE_OS") use "osx";
          for External ("GNATCOLL_OS") use "osx";
+      when "freebsd" =>
+         for External ("ALIRE_OS") use "freebsd";
+         for External ("GNATCOLL_OS") use "unix";
       when others =>
          for External ("ALIRE_OS") use "unix";
          for External ("GNATCOLL_OS") use "unix";

--- a/src/alire/alire-platforms.ads
+++ b/src/alire/alire-platforms.ads
@@ -3,8 +3,8 @@ package Alire.Platforms with Preelaborate is
    --  Platform information necessary for some releases
 
    type Extended_Architectures is
-     (ARM64, -- Equivalent to AARCH64
-      AMD64, -- Equivalent to X86_64 (FreeBSD)
+     (AMD64, -- Equivalent to X86_64 (FreeBSD)
+      ARM64, -- Equivalent to AARCH64
       End_Of_Duplicates,
       --  Up to this point, these are architectures that we want to rename to
       --  some of the following because they are equivalent.
@@ -20,13 +20,14 @@ package Alire.Platforms with Preelaborate is
      Extended_Architectures'Succ (End_Of_Duplicates) .. Architecture_Unknown;
    --  See e.g. https://stackoverflow.com/a/45125525/761390
 
-   type Operating_Systems is (Linux,
+   type Operating_Systems is (FreeBSD,
+                              Linux,
                               MacOS,
-                              FreeBSD,
                               Windows,
                               OS_Unknown);
    subtype Known_Operating_Systems is
-     Operating_Systems range Linux .. Windows;
+     Operating_Systems range
+       Operating_Systems'First .. Operating_Systems'Pred (OS_Unknown);
 
    type Targets is (Native,
                     Unknown_Cross_Target);
@@ -74,11 +75,13 @@ package Alire.Platforms with Preelaborate is
 
 private
 
+   --  Should be in sync with testsuite/drivers/helpers.py#L106
+
    function Arch_Mapping (Arch : Extended_Architectures) return Architectures
    is (case Arch is
+          when AMD64         => X86_64,
           when ARM64         => AARCH64,
           when Architectures => Arch,
-          when AMD64         => X86_64,
           when others        =>
              raise Program_Error
                with "Mapping missing for given architecture: " & Arch'Image);

--- a/src/alire/alire-platforms.ads
+++ b/src/alire/alire-platforms.ads
@@ -4,6 +4,7 @@ package Alire.Platforms with Preelaborate is
 
    type Extended_Architectures is
      (ARM64, -- Equivalent to AARCH64
+      AMD64, -- Equivalent to X86_64 (FreeBSD)
       End_Of_Duplicates,
       --  Up to this point, these are architectures that we want to rename to
       --  some of the following because they are equivalent.
@@ -21,6 +22,7 @@ package Alire.Platforms with Preelaborate is
 
    type Operating_Systems is (Linux,
                               MacOS,
+                              FreeBSD,
                               Windows,
                               OS_Unknown);
    subtype Known_Operating_Systems is
@@ -76,6 +78,7 @@ private
    is (case Arch is
           when ARM64         => AARCH64,
           when Architectures => Arch,
+          when AMD64         => X86_64,
           when others        =>
              raise Program_Error
                with "Mapping missing for given architecture: " & Arch'Image);

--- a/src/alire/os_freebsd/alire-check_absolute_path.adb
+++ b/src/alire/os_freebsd/alire-check_absolute_path.adb
@@ -1,0 +1,7 @@
+separate (Alire)
+function Check_Absolute_Path (Path : Any_Path) return Boolean is
+begin
+   return (Path'Length >= 1
+            and then
+           Path (Path'First) = GNAT.OS_Lib.Directory_Separator);
+end Check_Absolute_Path;

--- a/src/alire/os_freebsd/alire-platforms-current__freebsd.adb
+++ b/src/alire/os_freebsd/alire-platforms-current__freebsd.adb
@@ -1,0 +1,34 @@
+
+package body Alire.Platforms.Current is
+
+   --  FreeBSD implementation (very close to Linux)
+
+   ---------------------------
+   -- Detected_Distribution --
+   ---------------------------
+
+   function Detected_Distribution return Platforms.Distributions is
+      (Platforms.Distro_Unknown);
+
+   -----------------------
+   -- Distribution_Root --
+   -----------------------
+
+   function Distribution_Root return Absolute_Path
+   is ("/");
+
+   ----------------------
+   -- Load_Environment --
+   ----------------------
+
+   procedure Load_Environment (Ctx : in out Alire.Environment.Context)
+   is null;
+
+   ----------------------
+   -- Operating_System --
+   ----------------------
+
+   function Operating_System return Alire.Platforms.Operating_Systems
+   is (Alire.Platforms.FreeBSD);
+
+end Alire.Platforms.Current;

--- a/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
+++ b/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
@@ -1,0 +1,19 @@
+with Alire.Platforms.Common;
+
+package body Alire.Platforms.Folders is
+
+   --  Linux implementation
+
+   -----------
+   -- Cache --
+   -----------
+
+   function Cache return String is (Common.XDG_Config_Folder);
+
+   -----------
+   -- Config--
+   -----------
+
+   function Config return String is (Common.XDG_Config_Folder);
+
+end Alire.Platforms.Folders;


### PR DESCRIPTION
* update GNAT project to recognize -XOS=freebsd and configure accordingly
* add FreeBSD as a valid operating system
* add AMD64 as an alias for X86_64 because uname -m returns amd64 on FreeBSD
* add platform specific implementation for FreeBSD

To build on FreeBSD, we should use

gprbuild -j0 -P alr_env -XOS=freebsd