### PR TITLE
Allow package removal by `apt` with --force

### DIFF
--- a/src/alire/alire-origins-deployers-system-apt.adb
+++ b/src/alire/alire-origins-deployers-system-apt.adb
@@ -91,11 +91,16 @@ package body Alire.Origins.Deployers.System.Apt is
    overriding
    function Install (This : Deployer) return Outcome is
    begin
+      if Force then
+         Put_Warning (TTY.Terminal ("--force") & " in effect, removal of "
+                      & "system packages by apt is allowed");
+      end if;
+
       Subprocess.Checked_Spawn
         ("sudo", Empty_Vector &
            "apt-get" &
            "install" &
-           "--no-remove" &
+           (if Force then Empty_Vector else To_Vector ("--no-remove")) &
            "-q" &
            "-q" &
            "-y" &

--- a/src/alire/alire-origins-deployers.adb
+++ b/src/alire/alire-origins-deployers.adb
@@ -143,11 +143,14 @@ package body Alire.Origins.Deployers is
    exception
       when E : others =>
          Log_Exception (E);
-         if Ada.Directories.Exists (Folder) then
+         if Folder /= "" and then Ada.Directories.Exists (Folder) then
             Ada.Directories.Delete_Tree (Folder);
          end if;
          return Outcome_Failure ("Deployment of " & From.Image
-                                 & " to " & Folder & " failed");
+                                 & (if From.Is_System
+                                    then " from system packages"
+                                    else " to " & Folder)
+                                 & " failed");
    end Deploy_Steps;
 
    ------------

--- a/src/alire/alire-version.ads
+++ b/src/alire/alire-version.ads
@@ -3,6 +3,7 @@ package Alire.Version with Preelaborate is
    --  Remember to update Alire.Index branch if needed too
 
    Current : constant String := "1.3-dev";
+   --  1.2.1:     build switches fix and other minor assorted fixes
    --  1.2.0:     rpm speed-up, silence propagation warning, early switch parse
    --  1.2.0-rc1: release candidate for 1.2
    --  1.1.2:     latest msys2 and ensure it's fully updated

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -251,8 +251,7 @@ package body Alr.Commands.Test is
                   Output.Append_Line ("Spawning: " & Dkr_Custom_Cmd.Flatten);
                   Exit_Code := Unchecked_Spawn_And_Capture
                     (Dkr_Custom_Cmd.First_Element,
-                     Dkr_Custom_Cmd.Tail
-                     & Custom_Alr & "get" & R.Milestone.Image,
+                     Dkr_Custom_Cmd.Tail,
                      Output,
                      Err_To_Out => True);
                else

--- a/testsuite/drivers/asserts.py
+++ b/testsuite/drivers/asserts.py
@@ -7,6 +7,7 @@ import re
 import difflib
 
 from drivers.alr import run_alr
+from drivers.helpers import contents
 
 def indent(text, prefix='  '):
     """
@@ -37,6 +38,15 @@ def assert_eq(expected, actual, label=None):
                 'But got:',
                 indent(str(actual))]
         assert False, '\n'.join(text) + diff
+
+
+def assert_contents(dir: str, expected: list[str], regex: str = ""):
+    """
+    Check that entries in dir filtered by regex match the list in contents
+    """
+    real = contents(dir, regex)
+    assert real == expected, \
+        f"Wanted contents: {expected}\nBut got: {real}\n"
 
 
 def assert_match(expected_re, actual, label=None, flags=re.S):

--- a/testsuite/drivers/asserts.py
+++ b/testsuite/drivers/asserts.py
@@ -40,7 +40,7 @@ def assert_eq(expected, actual, label=None):
         assert False, '\n'.join(text) + diff
 
 
-def assert_contents(dir: str, expected: list[str], regex: str = ""):
+def assert_contents(dir: str, expected, regex: str = ""):
     """
     Check that entries in dir filtered by regex match the list in contents
     """

--- a/testsuite/tests/test/default-test/test.py
+++ b/testsuite/tests/test/default-test/test.py
@@ -1,0 +1,25 @@
+"""
+Check that the default "get & build" test for `alr test` works
+"""
+
+import re
+import os
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+from drivers.helpers import content_of
+from glob import glob
+
+# Enter an empty folder
+os.mkdir("t")
+os.chdir("t")
+
+run_alr("test", "hello")  # Should not err
+
+# Check test outcome
+assert_match(".*" +
+             re.escape("pass:hello=1.0.0") + ".*" +
+             re.escape("pass:hello=1.0.1") + ".*",
+             content_of(glob("*.txt")[0]))
+
+print('SUCCESS')

--- a/testsuite/tests/test/default-test/test.yaml
+++ b/testsuite/tests/test/default-test/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
Also related changes to pass `--force` during `alr test` and a new extra test for the default `alr test` behavior.