### PR TITLE
Right trim tables

### DIFF
--- a/src/alire/alire-utils-tables.adb
+++ b/src/alire/alire-utils-tables.adb
@@ -1,3 +1,5 @@
+with Ada.Strings.Fixed;
+
 package body Alire.Utils.Tables is
 
    ------------
@@ -20,8 +22,10 @@ package body Alire.Utils.Tables is
    is
 
       procedure Print (Line : String) is
+         use Ada.Strings;
+         Trim : String renames Fixed.Trim (Line, Right);
       begin
-         Trace.Log (Line, Level);
+         Trace.Log (Trim, Level);
       end Print;
 
    begin

--- a/testsuite/tests/get/indirect-link/test.py
+++ b/testsuite/tests/get/indirect-link/test.py
@@ -32,9 +32,9 @@ run_alr('with', 'tier1')
 p = run_alr('with', '--solve')
 assert_match('.*' +
              re.escape('Dependencies (graph):\n'
-                       '   tier1=1.0.0   --> tier2*              \n'
+                       '   tier1=1.0.0   --> tier2*\n'
                        '   xxx=0.1.0-dev --> tier1=1.0.0 (^1.0.0)\n'
-                       '   xxx=0.1.0-dev --> tier2^1.0.0         ') + '.*',
+                       '   xxx=0.1.0-dev --> tier2^1.0.0\n') + '.*',
              p.out, flags=re.S)
 
 

--- a/testsuite/tests/index/external-from-output/test.py
+++ b/testsuite/tests/index/external-from-output/test.py
@@ -18,7 +18,7 @@ assert_eq('Not found: make*\n'
 # External definition
 p = run_alr('show', 'make', '--external')
 assert_eq('Kind       Description    Details            Available\n'
-          'Executable make --version .*Make ([\\d\\.]+).* True     \n',
+          'Executable make --version .*Make ([\\d\\.]+).* True\n',
           p.out)
 
 # External detection
@@ -42,7 +42,7 @@ p = run_alr('show', 'bad_switch', '--external')
 assert_eq('Kind       Description                   '
           'Details            Available\n'
           'Executable make --bad-nonexistent-switch '
-          '.*Make ([\\d\\.]+).* True     \n',
+          '.*Make ([\\d\\.]+).* True\n',
           p.out)
 
 # External detection fails (no release found, but without error)

--- a/testsuite/tests/pin/change-path/test.py
+++ b/testsuite/tests/pin/change-path/test.py
@@ -40,7 +40,7 @@ Dependencies automatically updated as follows:
 
    · yyy 0.1.0-dev (path=../nest2/yyy)
 
-yyy file:../nest2/yyy \n""",
+yyy file:../nest2/yyy\n""",
           p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/pin/conflicting-link/test.py
+++ b/testsuite/tests/pin/conflicting-link/test.py
@@ -26,8 +26,8 @@ alr_pin("zzz", path="../zzz")  # This is the doubly-linked same crate
 
 # Should work properly
 p = run_alr("pin")
-assert_eq('yyy file:../nest/yyy \n'
-          'zzz file:../zzz      \n',
+assert_eq('yyy file:../nest/yyy\n'
+          'zzz file:../zzz\n',
           p.out)
 
 #  Now we will pin a different zzz from xxx,

--- a/testsuite/tests/pin/recursive-local/test.py
+++ b/testsuite/tests/pin/recursive-local/test.py
@@ -24,8 +24,8 @@ alr_pin("yyy", path="../nest/yyy")
 
 # Should work properly
 p = run_alr("pin")
-assert_eq('yyy file:../nest/yyy \n'
-          'zzz file:../zzz      \n',
+assert_eq('yyy file:../nest/yyy\n'
+          'zzz file:../zzz\n',
           p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/pin/recursive-remote/test.py
+++ b/testsuite/tests/pin/recursive-remote/test.py
@@ -42,7 +42,7 @@ s = dir_separator()
 assert_match(re.escape('yyy file:alire/cache/pins/yyy ') +  # local rel path
              '.*' + re.escape(f'{s}nest{s}yyy\n') +         # remote abs url
              re.escape('zzz file:alire/cache/pins/zzz ') +  # local rel path
-             '.*' + re.escape(f'{s}zzz     \n'),            # remote abs url
+             '.*' + re.escape(f'{s}zzz\n'),                 # remote abs url
              p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/pin/without-lockfile/test.py
+++ b/testsuite/tests/pin/without-lockfile/test.py
@@ -25,7 +25,7 @@ os.remove(alr_lockfile())
 
 # Check that the pin is applied on next command run
 p = run_alr("pin")
-assert_eq(f"{fake_dep} file:{fake_dep} \n", p.out)
+assert_eq(f"{fake_dep} file:{fake_dep}\n", p.out)
 
 
 print('SUCCESS')

--- a/testsuite/tests/search/basic/test.py
+++ b/testsuite/tests/search/basic/test.py
@@ -7,8 +7,8 @@ from drivers.asserts import assert_eq
 
 
 def format_line(name, status, version, description, notes):
-    return '{: <9} {: <7} {: <8} {: <54} {: <5}\n'.format(
-        name, status, version, description, notes)
+    return '{: <9} {: <7} {: <8} {: <54} {: <5}'.format(
+        name, status, version, description, notes).rstrip(' ') + '\n'
 
 
 def format_table(*args):

--- a/testsuite/tests/with/pin-transitive/test.py
+++ b/testsuite/tests/with/pin-transitive/test.py
@@ -27,8 +27,8 @@ run_alr("with", "--use=../../direct")
 
 # Verify created pins
 p = run_alr("pin")
-assert_eq("direct   file:../../direct   \n"
-          "indirect file:../../indirect \n",
+assert_eq("direct   file:../../direct\n"
+          "indirect file:../../indirect\n",
           p.out)
 
 # Check pin removal
@@ -38,7 +38,7 @@ os.chdir("../nest/base")
 run_alr("update")
 
 p = run_alr("pin")
-assert_eq("direct file:../../direct \n",
+assert_eq("direct file:../../direct\n",
           p.out)
 
 


### PR DESCRIPTION
Reason for this PR is that `alr search --list` may emit very long lines due to occasional notes which (on my terminal at least) looks like each line is separated by an empty line.
This PR will right trim all `Alire.Utils.Tables.Table`. 