### PR TITLE
Allow missing configuration values until build

### DIFF
--- a/src/alire/alire-crate_configuration.adb
+++ b/src/alire/alire-crate_configuration.adb
@@ -107,14 +107,14 @@ package body Alire.Crate_Configuration is
                                 Profile : Profile_Kind)
    is
       Key : constant String := Build_Profile_Key (Crate);
-      Val : Config_Setting  := This.Map (+Key);
+      Val : Config_Setting  := This.Var_Map (+Key);
 
       Prev_Profile : constant Profile_Kind := This.Profile_Map (Crate);
    begin
       --  Update config value that holds the profile value
       Val.Value  := TOML.Create_String (To_Lower_Case (Profile'Image));
       Val.Set_By := +"library client";
-      This.Map (+Key) := Val;
+      This.Var_Map (+Key) := Val;
 
       --  Update profile itself
       This.Profile_Map.Include (Crate, Profile);
@@ -347,7 +347,7 @@ package body Alire.Crate_Configuration is
    is
       use Config_Maps;
    begin
-      for C in This.Map.Iterate loop
+      for C in This.Var_Map.Iterate loop
          if (Crate = "" or else Name (C).As_String = Crate)
            and then Element (C).Set_By = Must_Be_Set
          then
@@ -504,10 +504,10 @@ package body Alire.Crate_Configuration is
                        Elt.Type_Def.Element.To_Ada_Declaration (Elt.Value));
       end loop;
 
-      for C in This.Map.Iterate loop
+      for C in This.Var_Map.Iterate loop
          declare
             Elt : constant Config_Maps.Constant_Reference_Type :=
-              This.Map.Constant_Reference (C);
+              This.Var_Map.Constant_Reference (C);
 
             Type_Def : Config_Type_Definition renames Elt.Type_Def.Element;
 
@@ -639,10 +639,10 @@ package body Alire.Crate_Configuration is
                              This.Switches_Map.Element (Crate),
                              Indent => 10);
 
-      for C in This.Map.Iterate loop
+      for C in This.Var_Map.Iterate loop
          declare
             Elt : constant Config_Maps.Constant_Reference_Type :=
-              This.Map.Constant_Reference (C);
+              This.Var_Map.Constant_Reference (C);
 
             Type_Def : Config_Type_Definition renames Elt.Type_Def.Element;
 
@@ -702,10 +702,10 @@ package body Alire.Crate_Configuration is
                        Elt.Type_Def.Element.To_C_Declaration (Elt.Value));
       end loop;
 
-      for C in This.Map.Iterate loop
+      for C in This.Var_Map.Iterate loop
          declare
             Elt : constant Config_Maps.Constant_Reference_Type :=
-              This.Map.Constant_Reference (C);
+              This.Var_Map.Constant_Reference (C);
 
             Type_Def : Config_Type_Definition renames Elt.Type_Def.Element;
 
@@ -752,7 +752,7 @@ package body Alire.Crate_Configuration is
               "' is reserved for Alire internal use");
       end if;
 
-      if This.Map.Contains (Name) then
+      if This.Var_Map.Contains (Name) then
          Raise_Checked_Error
            ("Configuration variable '" & (+Name) & "' already defined");
       end if;
@@ -762,7 +762,7 @@ package body Alire.Crate_Configuration is
       begin
          Setting.Type_Def.Replace_Element (Type_Def);
          Setting.Value := TOML.No_TOML_Value;
-         This.Map.Insert (Name, Setting);
+         This.Var_Map.Insert (Name, Setting);
       end;
    end Add_Definition;
 
@@ -803,14 +803,14 @@ package body Alire.Crate_Configuration is
 
       --  TODO check if setting configuration of a dependency
 
-      if not This.Map.Contains (Name) then
+      if not This.Var_Map.Contains (Name) then
          Raise_Checked_Error
            ("Unknown configuration variable '" & (+Name) & "'");
       end if;
 
       declare
          Ref : constant Config_Maps.Reference_Type :=
-           This.Map.Reference (Name);
+           This.Var_Map.Reference (Name);
       begin
 
          if not Valid (Ref.Type_Def.Element, Val.Value) then
@@ -867,10 +867,10 @@ package body Alire.Crate_Configuration is
    is
       Config_Fault : Boolean := False;
    begin
-      for C in Conf.Map.Iterate loop
+      for C in Conf.Var_Map.Iterate loop
          declare
             Elt : constant Config_Maps.Reference_Type :=
-              Conf.Map.Reference (C);
+              Conf.Var_Map.Reference (C);
 
             Key : constant String := To_String (Config_Maps.Key (C));
          begin

--- a/src/alire/alire-crate_configuration.ads
+++ b/src/alire/alire-crate_configuration.ads
@@ -110,6 +110,8 @@ private
       Hash            => Ada.Strings.Unbounded.Hash,
       Equivalent_Keys => Ada.Strings.Unbounded."=");
 
+   function Name (C : Config_Maps.Cursor) return Crate_Name;
+
    package Profile_Setter_Maps
    is new Ada.Containers.Indefinite_Ordered_Maps
      (Crate_Name, Setters);

--- a/src/alire/alire-crate_configuration.ads
+++ b/src/alire/alire-crate_configuration.ads
@@ -32,6 +32,9 @@ package Alire.Crate_Configuration is
    function Is_Valid (This : Global_Config) return Boolean;
    --  False until Load is called
 
+   procedure Ensure_Complete (This : Global_Config);
+   --  Verify all variables have a value, or report and raise
+
    function Build_Profile (This  : Global_Config;
                            Crate : Crate_Name)
                            return Utils.Switches.Profile_Kind

--- a/src/alire/alire-crate_configuration.ads
+++ b/src/alire/alire-crate_configuration.ads
@@ -121,7 +121,8 @@ private
      (Crate_Name, Alire.Utils.Switches.Switch_List);
 
    type Global_Config is tagged record
-      Map : Config_Maps.Map;
+      Var_Map : Config_Maps.Map;
+      --  Mapping "crate.var" --> setting
 
       Profile_Map  : Profile_Maps.Map;
       --  Mapping crate -> profile, exists for all crates in solution

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -194,6 +194,9 @@ package body Alire.Roots is
          This.Generate_Configuration;
       end if;
 
+      This.Configuration.Ensure_Complete;
+      --  For building the configuration must be complete
+
       if Export_Build_Env then
          This.Export_Build_Environment;
       end if;

--- a/testsuite/tests/config/missing-config-default/test.py
+++ b/testsuite/tests/config/missing-config-default/test.py
@@ -2,36 +2,108 @@
 Retrieve a crate with missing defaults for configuration variables
 """
 
-from drivers.alr import run_alr
+import os
+
+from drivers.alr import run_alr, alr_manifest, alr_touch_manifest, init_local_crate
 from drivers.asserts import assert_match
+from glob import glob
+
+# get/with must succeed, but showing warnings
+# build must fail
 
 
 # Get the "hello=1.0.0", which has missing defaults for configuration variables
-p = run_alr('get', 'hello=1.0.0', complain_on_error=False)
+p = run_alr('get', '--build', 'hello=1.0.0', complain_on_error=False)
 
-assert p.status != 0, "Get should have failed"
+assert p.status != 0, "Get with build should have failed"
+
+assert_match('.*Configuration variables without a default remain unset\n',
+             p.out)
+
+
+# Get the "hello=1.0.1", which has missing defaults for configuration variables
+# in "libhello".
+p = run_alr('get', '--build', 'hello=1.0.1', complain_on_error=False)
+
+assert p.status != 0, "Get with build should have failed"
+
+assert_match('.*Configuration variables without a default remain unset\n',
+             p.out)
+
+# Get without build must succeed with the missing values as warnings
+p = run_alr("get", "hello=1.0.0", quiet=False)
 
 assert_match('.*Configuration variable \'hello.var1\' not set and has no default value.\n'
              '.*Configuration variable \'hello.var2\' not set and has no default value.\n'
              '.*Configuration variable \'hello.var3\' not set and has no default value.\n'
              '.*Configuration variable \'hello.var4\' not set and has no default value.\n'
              '.*Configuration variable \'hello.var5\' not set and has no default value.\n'
-             '.*Configuration failed\n',
+             '.*Configuration variable \'libhello.var1\' not set and has no default value.\n'
+             '.*Configuration variable \'libhello.var2\' not set and has no default value.\n'
+             '.*Configuration variable \'libhello.var3\' not set and has no default value.\n'
+             '.*Configuration variable \'libhello.var4\' not set and has no default value.\n'
+             '.*Configuration variable \'libhello.var5\' not set and has no default value.\n'
+             '\n'
+             'hello=1.0.0 successfully retrieved.',
              p.out)
 
+# Attempting to build now should fail
+os.chdir(glob("hello_1.0.0_*")[0])
+p = run_alr("build", complain_on_error=False)
+assert p.status != 0, "Build should have failed"
+assert_match('.*Configuration variables without a default remain unset\n',
+             p.out)
 
-# Get the "hello=1.0.1", which has missing defaults for configuration variables
-# in "libhello".
-p = run_alr('get', 'hello=1.0.1', complain_on_error=False)
+# Verify that providing the values in the manifest allows the build to work
+with open(alr_manifest(), "at") as manifest:
+    manifest.write("""
+[configuration.values]
+hello.var1 = true
+hello.var2 = "string"
+hello.var3 = "A"
+hello.var4 = 1
+hello.var5 = 1.0
+""")
 
-assert p.status != 0, "Get should have failed"
+# Ensure the edition is noticed
+alr_touch_manifest()
 
+# Configuration is still incomplete as the libhello vars are unset
+p = run_alr("build", complain_on_error=False)
+assert p.status != 0, "Build should have failed"
+assert_match('.*Configuration variables without a default remain unset\n',
+             p.out)
+
+# Provide values for libhello
+with open(alr_manifest(), "at") as manifest:
+    manifest.write("""
+libhello.var1 = true
+libhello.var2 = "string"
+libhello.var3 = "A"
+libhello.var4 = 1
+libhello.var5 = 1.0
+""")
+
+# Ensure the edition is noticed
+alr_touch_manifest()
+
+# It should succeed now (it fails, because there are no actual project/sources)
+p = run_alr("build", complain_on_error=False)
+assert p.status != 0, "Build should have failed"
+assert_match('.*gprbuild(.exe)?: project file .*hello.gpr" not found.*', p.out)
+
+
+# New test from scratch, one can "with" a library with values without defaults
+init_local_crate()
+run_alr("with", "libhello")  # Shouldn't fail
+p = run_alr("build", complain_on_error=False, quiet=False)
+assert p.status != 0, "Build should have failed"
 assert_match('.*Configuration variable \'libhello.var1\' not set and has no default value.\n'
              '.*Configuration variable \'libhello.var2\' not set and has no default value.\n'
              '.*Configuration variable \'libhello.var3\' not set and has no default value.\n'
              '.*Configuration variable \'libhello.var4\' not set and has no default value.\n'
              '.*Configuration variable \'libhello.var5\' not set and has no default value.\n'
-             '.*Configuration failed\n',
+             '.*Configuration variables without a default remain unset\n',
              p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/config/missing-config-default/test.py
+++ b/testsuite/tests/config/missing-config-default/test.py
@@ -43,6 +43,8 @@ assert_match('.*Configuration variable \'hello.var1\' not set and has no default
              '.*Configuration variable \'libhello.var3\' not set and has no default value.\n'
              '.*Configuration variable \'libhello.var4\' not set and has no default value.\n'
              '.*Configuration variable \'libhello.var5\' not set and has no default value.\n'
+             '.*Skipping generation of incomplete configuration files for crate hello\n'
+             '.*Skipping generation of incomplete configuration files for crate libhello\n'
              '\n'
              'hello=1.0.0 successfully retrieved.',
              p.out)


### PR DESCRIPTION
This way we can normally get/without crates without defaults, but at the time of building the values must be set.

Fixes #1125