### PR TITLE
Remove too strict check for root manifest reload

### DIFF
--- a/src/alire/alire-roots-editable.adb
+++ b/src/alire/alire-roots-editable.adb
@@ -239,6 +239,14 @@ package body Alire.Roots.Editable is
       is (Directories.Find_Relative_Path_To (Path) = "..");
 
    begin
+      --  When adding a pin from a folder other than the root, notify about it.
+      --  It's likely that the user is confusing about what is going on.
+      if Directories.Current /= +This.Orig.Path then
+         Put_Warning ("Adding pin to " & TTY.URL (Path)
+                      & " in crate " & Utils.TTY.Name (This.Orig.Name)
+                      & " rooted at " & TTY.URL (+This.Orig.Path));
+      end if;
+
       if Crate.Is_Empty and then not Pin_Root.Is_Valid then
          Raise_Checked_Error
            ("No crate name given and link target is not an Alire crate:"

--- a/src/alire/alire-roots-editable.adb
+++ b/src/alire/alire-roots-editable.adb
@@ -240,7 +240,7 @@ package body Alire.Roots.Editable is
 
    begin
       --  When adding a pin from a folder other than the root, notify about it.
-      --  It's likely that the user is confusing about what is going on.
+      --  It's likely that the user is confused about what is going on.
       if Directories.Current /= +This.Orig.Path then
          Put_Warning ("Adding pin to " & TTY.URL (Path)
                       & " in crate " & Utils.TTY.Name (This.Orig.Name)

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -1,5 +1,4 @@
 private with AAA.Caches.Files;
-with Ada.Directories;
 private with Ada.Finalization;
 
 with AAA.Strings;
@@ -200,8 +199,7 @@ package Alire.Roots is
    procedure Write_Manifest (This : Root);
    --  Generates the crate.toml manifest at the appropriate location for Root
 
-   procedure Reload_Manifest (This : in out Root)
-     with Pre => This.Path = Ada.Directories.Current_Directory;
+   procedure Reload_Manifest (This : in out Root);
    --  If changes have been done to the manifest, either via the dependency/pin
    --  modification procedures, or somehow outside alire after This was
    --  created, we need to reload the manifest. The solution remains

--- a/testsuite/tests/pin/from-subdir/test.py
+++ b/testsuite/tests/pin/from-subdir/test.py
@@ -1,0 +1,32 @@
+"""
+Verify that requesting a pin from a dir which is not the root still works, but
+the user gets a warning about it.
+"""
+
+import os, re
+
+from drivers.alr import run_alr, init_local_crate
+from drivers.asserts import assert_eq, assert_match
+from drivers.helpers import dir_separator
+
+# Create top crate
+init_local_crate()
+
+# Create nested crate
+init_local_crate("child")
+
+# Enter a subdir of the nested crate
+os.mkdir("sub")
+os.chdir("sub")
+
+s = re.escape(dir_separator())
+
+# Add the pin for the parent crate from the subdir of the child
+p = run_alr("with", "xxx", f"--use=..{s}..", quiet=False)
+
+# Check the warning
+assert_match(f".*Adding pin to .*pin__from-subdir{s}xxx in crate child rooted"
+             f" at .*{s}pin__from-subdir{s}xxx{s}child",
+             p.out)
+
+print('SUCCESS')

--- a/testsuite/tests/pin/from-subdir/test.yaml
+++ b/testsuite/tests/pin/from-subdir/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
Since we are using absolute paths all around, that check is no longer necessary.

Add a test for the situation that triggered the bug, which was expected to work.

Fixes #1153 