### PR TITLE
Fail tests if complain_on_error=False but no error happens

### DIFF
--- a/testsuite/tests/index/external-from-output/test.py
+++ b/testsuite/tests/index/external-from-output/test.py
@@ -8,8 +8,7 @@ from drivers.asserts import assert_eq, assert_match
 import re
 
 # Hint that an external exists
-p = run_alr('show', 'make',
-            complain_on_error=False, quiet=False)
+p = run_alr('show', 'make', quiet=False)
 assert_eq('Not found: make*\n'
           'There are external definitions for the crate. '
           'Use --external to show them.\n',

--- a/testsuite/tests/publish/check-properties/test.py
+++ b/testsuite/tests/publish/check-properties/test.py
@@ -17,7 +17,7 @@ assert_match(".*Missing required properties: maintainers.*", p.out)
 # Attempt with crate missing optional recommended properties. No quiet or the
 # warning on optional properties is silenced.
 p = run_alr("publish", "my_index/crates/notags.tgz",
-            quiet=False, complain_on_error=False, force=True)
+            quiet=False, force=True)
 assert_match(".*Missing optional recommended properties:"
              " authors, licenses, tags, website.*",
              p.out)

--- a/testsuite/tests/run/defaults/test.py
+++ b/testsuite/tests/run/defaults/test.py
@@ -11,12 +11,10 @@ target = 'noop_1.0.0_filesystem'
 
 
 def check_run(release, match=""):
-    p = run_alr('get', release,
-                complain_on_error=True, quiet=True)
+    p = run_alr('get', release, quiet=True)
     # Enter working copy and try to run default executable
     os.chdir(target)
-    p = run_alr('run',
-                complain_on_error=not match, quiet=not match)
+    p = run_alr('run', quiet=not match)
     # Check output when pattern was given:
     if match:
         assert_match(match, p.out, flags=re.S)

--- a/testsuite/tests/workflows/actions-as-root/test.py
+++ b/testsuite/tests/workflows/actions-as-root/test.py
@@ -47,7 +47,7 @@ os.remove('./test_pre_build')
 os.remove('src/empty.adb')
 
 # Build without error
-run_alr('build', complain_on_error=False)
+run_alr('build')
 
 # pre/post-build expected for successful build
 check_not_expected('./test_post_fetch')


### PR DESCRIPTION
This removes the need to assert that an expected failure indeed happened, and
hardens tests against situations where it's unclear if an error should happen.

A few tests required tweaking, in all cases because `complain_on_error` was wrongly used.