### PR TITLE
Support openSUSE and SUSE distributions

### DIFF
--- a/src/alire/alire-origins-deployers-system-zypper.adb
+++ b/src/alire/alire-origins-deployers-system-zypper.adb
@@ -1,0 +1,117 @@
+with AAA.Strings; use AAA.Strings;
+
+with Alire.OS_Lib.Subprocess;
+with Alire.Errors;
+
+package body Alire.Origins.Deployers.System.Zypper is
+
+   package Subprocess renames Alire.OS_Lib.Subprocess;
+
+   -----------------------
+   -- Already_Installed --
+   -----------------------
+
+   overriding function Already_Installed (This : Deployer) return Boolean
+   is
+      Output : constant AAA.Strings.Vector :=
+                 Subprocess.Checked_Spawn_And_Capture
+                   ("zypper",
+                    Empty_Vector &
+                       "--no-refresh" &
+                       "--xmlout" &
+                       "--quiet" &
+                       "search" &
+                       "--match-exact" &
+                       "--installed-only" &
+                       "--type" &
+                       "package" &
+                       This.Base.Package_Name,
+                    Valid_Exit_Codes => (0, 104), -- returned when not found
+                    Err_To_Out       => True);
+   begin
+      for Line of Output loop
+         if Has_Prefix (Line, "<solvable status=""installed""") then
+            return True;
+         end if;
+      end loop;
+
+      return False;
+   end Already_Installed;
+
+   ------------
+   -- Detect --
+   ------------
+
+   overriding
+   function Detect (This : Deployer) return Version_Outcomes.Outcome
+   is
+      Regexp : constant String :=
+                 "edition=""([\d.]+)";
+
+      Output : constant AAA.Strings.Vector :=
+                 Subprocess.Checked_Spawn_And_Capture
+                   ("zypper",
+                    Empty_Vector &
+                       "--no-refresh" &
+                       "--xmlout" &
+                       "--quiet" &
+                       "search" &
+                       "--match-exact" &
+                       "--details" &
+                       "--type" &
+                       "package" &
+                       This.Base.Package_Name,
+                    Valid_Exit_Codes => (0, 104), -- returned when not found
+                    Err_To_Out => True);
+
+   begin
+      for Line of Output loop
+         if Has_Prefix (Line, "<solvable ") then
+            Trace.Debug ("Extracting native version from zypper output: " &
+                         Line);
+            declare
+               Match : constant String := Utils.First_Match (Regexp, Line);
+            begin
+               if Match /= "" then
+                  Trace.Debug ("Candidate version string: " & Match);
+                  return
+                    Version_Outcomes.New_Result
+                      (Semantic_Versioning.Parse (Match, Relaxed => True));
+               else
+                  Trace.Debug
+                    ("Unexpected version format, could not identify version");
+               end if;
+            end;
+         end if;
+      end loop;
+
+      Trace.Debug ("System deployer could not detect: " & This.Base.Image);
+      return Version_Outcomes.Outcome_Failure ("could not be detected",
+                                               Report => False);
+   end Detect;
+
+   -------------
+   -- Install --
+   -------------
+
+   overriding
+   function Install (This : Deployer) return Outcome is
+   begin
+      Subprocess.Checked_Spawn
+        ("sudo", Empty_Vector &
+           "zypper" &
+           "--no-refresh" &
+           "--non-interactive" &
+           "--quiet" &
+           "install" &
+           "--name" &
+           "--auto-agree-with-licenses" &
+           This.Base.Package_Name);
+
+      return Outcome_Success;
+   exception
+      when E : others =>
+         return Alire.Errors.Get (E);
+   end Install;
+
+end Alire.Origins.Deployers.System.Zypper;

--- a/src/alire/alire-origins-deployers-system-zypper.ads
+++ b/src/alire/alire-origins-deployers-system-zypper.ads
@@ -1,0 +1,15 @@
+package Alire.Origins.Deployers.System.Zypper is
+
+   type Deployer is new Deployers.System.Deployer with null record;
+
+   overriding
+   function Already_Installed (This : Deployer) return Boolean;
+
+   overriding
+   function Detect (This : Deployer)
+                    return Version_Outcomes.Outcome;
+
+   overriding
+   function Install (This : Deployer) return Outcome;
+
+end Alire.Origins.Deployers.System.Zypper;

--- a/src/alire/alire-origins-deployers-system.adb
+++ b/src/alire/alire-origins-deployers-system.adb
@@ -1,6 +1,7 @@
 with Alire.Origins.Deployers.System.Apt;
 with Alire.Origins.Deployers.System.Pacman;
 with Alire.Origins.Deployers.System.RPM_Wrappers;
+with Alire.Origins.Deployers.System.Zypper;
 with Alire.Platforms.Current;
 
 with CLIC.User_Input;
@@ -100,7 +101,10 @@ package body Alire.Origins.Deployers.System is
             System.RPM_Wrappers.Deployer'(Deployers.Deployer'(Base => From)
                                           with Wrapper =>
                                              System.RPM_Wrappers.Dnf,
-                                          others       => <>));
+                                          others       => <>),
+         when Platforms.Zypper =>
+            System.Zypper.Deployer'(Deployers.Deployer'(Base => From)
+                                    with others => <>));
       --  NOTE: add here other native package managers as they get
       --  implemented.
 

--- a/src/alire/alire-platforms.ads
+++ b/src/alire/alire-platforms.ads
@@ -54,6 +54,7 @@ package Alire.Platforms with Preelaborate is
                              Pacman,
                              Yum,
                              Dnf,
+                             Zypper,
                              Packager_Unknown);
 
    Distro_Manager : constant array (Distributions) of Package_Managers :=

--- a/src/alire/alire-platforms.ads
+++ b/src/alire/alire-platforms.ads
@@ -40,6 +40,7 @@ package Alire.Platforms with Preelaborate is
                           Rhel, -- RedHat Enterprise Linux
                           Centos,
                           Fedora,
+                          Suse,
                           Distro_Unknown);
 
    subtype Known_Distributions is
@@ -62,6 +63,7 @@ package Alire.Platforms with Preelaborate is
       Msys2 | Arch    => Pacman,
       Rhel            => Yum,
       Centos | Fedora => Dnf,
+      Suse            => Zypper,
       Distro_Unknown  => Packager_Unknown);
 
    type Toolchains is (System,

--- a/src/alire/alire-utils-tools.adb
+++ b/src/alire/alire-utils-tools.adb
@@ -56,12 +56,13 @@ package body Alire.Utils.Tools is
             --  Cannot have package for an unknown distribution
             return "";
 
-         when Msys2 | Debian | Ubuntu | Arch | Centos | Fedora | Rhel =>
+         when Msys2 | Debian | Ubuntu | Arch | Centos | Fedora | Rhel | Suse =>
             return (case Tool is
                        when Easy_Graph =>
                       (if Distribution = Centos or else
                        Distribution = Fedora or else
-                       Distribution = Rhel
+                       Distribution = Rhel or else
+                       Distribution = Suse
                        then "perl-Graph-Easy"
                        elsif Distribution /= Msys2 and Distribution /= Arch
                        then "libgraph-easy-perl"


### PR DESCRIPTION
The openSUSE and SUSE distribution use the zypper package manager. Support for zypper is included in this pull request.