### PR TITLE
Allow alire to access indexes using ssh

### DIFF
--- a/src/alire/alire-index_on_disk-git.ads
+++ b/src/alire/alire-index_on_disk-git.ads
@@ -8,7 +8,8 @@ package Alire.Index_On_Disk.Git is
    function New_Handler (Origin : URL;
                          Name   : Restricted_Name;
                          Parent : Any_Path) return Index with
-     Pre => AAA.Strings.Has_Prefix (Origin, "git+");
+     Pre => AAA.Strings.Has_Prefix (Origin, "git+") or
+            AAA.Strings.Has_Prefix (Origin, "git@");
 
    overriding
    function Add (This : Index) return Outcome;

--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -217,7 +217,8 @@ package body Alire.Index_On_Disk is
          return Process_Local_Index
            (Origin (Origin'First + File_Prefix'Length ..  Origin'Last));
       elsif Origin (Origin'First) = '/'
-            or else not AAA.Strings.Contains (Origin, "+")
+        or else not (AAA.Strings.Contains (Origin, "@")
+                     or AAA.Strings.Contains (Origin, "+"))
       then
          return Process_Local_Index (Origin);
       end if;

--- a/src/alire/alire-origins.adb
+++ b/src/alire/alire-origins.adb
@@ -396,14 +396,11 @@ package body Alire.Origins is
       use AAA.Strings;
       use all type URI.Schemes;
       Scheme      : constant URI.Schemes := URI.Scheme (URL);
-      Transformed : constant Alire.URL := VCSs.Git.Transform_To_Public (URL);
       VCS_URL : constant String :=
                   (if Contains (URL, "file:") then
                       Tail (URL, ':') -- Remove file: that confuses git
-                   elsif Has_Prefix (URL, "git@") and then
-                      Transformed /= URL -- known and transformable
-                   then
-                      Transformed
+                   elsif Scheme = URI.Pure_Git then
+                      URL
                    elsif Scheme in URI.VCS_Schemes then
                       Tail (URL, '+') -- remove prefix vcs+
                    elsif Scheme in URI.HTTP then -- A plain URL... check VCS
@@ -419,15 +416,7 @@ package body Alire.Origins is
 
    begin
       case Scheme is
-         when Pure_Git =>
-            if Transformed /= URL then
-               return New_VCS (Transformed, Commit);
-            else
-               Raise_Checked_Error
-                 ("Attempting to use a private git@ URL with an unknown host: "
-                  & Utils.TTY.URL (URL));
-            end if;
-         when Git | HTTP =>
+         when Pure_Git | Git | HTTP =>
             if Commit'Length /= Git_Commit'Length then
                Raise_Checked_Error
                  ("invalid git commit id, " &

--- a/src/alire/alire-vcss.adb
+++ b/src/alire/alire-vcss.adb
@@ -35,7 +35,8 @@ package body Alire.VCSs is
    ----------
 
    function Kind (Origin : URL) return Kinds is
-     (if Has_Prefix (Origin, "git+") then VCS_Git
+     (if Has_Prefix (Origin, "git+") or Has_Prefix (Origin, "git@")
+      then VCS_Git
       else VCS_Unknown);
 
    ----------


### PR DESCRIPTION
Currently to add a remote index alire expects the URL that starts `git+`. SSH urls will normally start `git@` instead. By changing a few checks, alire is able to access an index via ssh.

This is useful for if you want to host a non public index, but don't want to enter a username and password to be able to access the index (which is not best practice security wise).