### PR TITLE
alr-commands-init.adb: make alr init interactive

### DIFF
--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -189,6 +189,7 @@ package body Alire.Utils is
 
    function Is_Valid_Tag (Tag : String) return Boolean is
      ((for all C of Tag => C in '0' .. '9' | 'a' .. 'z' | '-')
+      and then Tag'Length in 1 .. Max_Tag_Length
       and then Tag (Tag'First) /= '-'
       and then Tag (Tag'Last) /= '-'
       and then not AAA.Strings.Contains (Tag, "--"));


### PR DESCRIPTION
Alr init will now queries the user for information such as license, description, tags, etc.

Non-interactive usage is still possible using existing switches.