### PR TITLE
Improve user experience with better manifest errors messages

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: CI on macOS
 
-    runs-on: macos-latest
+    runs-on: macos-10.15
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci-toolchain.yml
+++ b/.github/workflows/ci-toolchain.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: 
-          - macos-latest
+          - macos-10.15
           - ubuntu-latest
           - windows-latest
 

--- a/scripts/ci-github.sh
+++ b/scripts/ci-github.sh
@@ -41,6 +41,9 @@ if [ "${INDEX:-}" != "" ]; then
     alr index --name default --add "$INDEX"
 fi
 
+# Fix GNAT version to check error on macOS
+alr toolchain --select gnat_native=12.1.2 gprbuild=22.0.1
+
 echo ALR SEARCH:
 # List releases for the record
 alr -q -d search --list --external

--- a/scripts/ci-github.sh
+++ b/scripts/ci-github.sh
@@ -41,9 +41,6 @@ if [ "${INDEX:-}" != "" ]; then
     alr index --name default --add "$INDEX"
 fi
 
-# Fix GNAT version to check error on macOS
-alr toolchain --select gnat_native=12.1.2 gprbuild=22.0.1
-
 echo ALR SEARCH:
 # List releases for the record
 alr -q -d search --list --external

--- a/src/alire/alire-conditional_trees-toml_load.adb
+++ b/src/alire/alire-conditional_trees-toml_load.adb
@@ -67,11 +67,13 @@ package body Alire.Conditional_Trees.TOML_Load is
                      then
                         if Strict then
                            Case_Table.Recoverable_Error
-                             ("invalid enumeration value: " & Item_Key);
+                             ("invalid enumeration value: '" & Item_Key &
+                                "'." & Map.Base.Suggestion (Item_Key));
                         else
                            Trace.Debug
                              (Errors.Stack
-                                ("unknown enumeration value: " & Item_Key));
+                                ("unknown enumeration value: " & Item_Key &
+                                   "'." & Map.Base.Suggestion (Item_Key)));
                         end if;
                      end if;
                   end loop;

--- a/src/alire/alire-expressions-enums.adb
+++ b/src/alire/alire-expressions-enums.adb
@@ -10,6 +10,14 @@ package body Alire.Expressions.Enums is
    function Is_Valid (This : Enum_Values; Image : String) return Boolean
    is (This.Values.Contains (TOML_Adapters.Tomify (Image)));
 
+   overriding
+   function Possible_Values (This : Enum_Values) return AAA.Strings.Vector is
+      Result : AAA.Strings.Vector;
+   begin
+      Result.Prepend (This.Values);
+      return Result;
+   end Possible_Values;
+
 begin
    declare
       Values : Enum_Values;

--- a/src/alire/alire-expressions.adb
+++ b/src/alire/alire-expressions.adb
@@ -3,6 +3,7 @@ with Ada.Containers.Indefinite_Ordered_Maps;
 with Alire.Errors;
 with Alire.TOML_Adapters;
 with Alire.Utils;
+with Alire.Utils.Did_You_Mean;
 
 package body Alire.Expressions is
 
@@ -42,6 +43,16 @@ package body Alire.Expressions is
          Errors.Set ("Expression variable '" & Key (This) & "' is unknown (" &
              Key_Variables_Image (Variables) & ")")
        else Variable_Values (Key (This)).Is_Valid (Value));
+
+   ----------------
+   -- Suggestion --
+   ----------------
+
+   function Suggestion (This : Variable; Value : String) return String is
+   begin
+      return Utils.Did_You_Mean.Suggestion
+        (Value, Variable_Values (Key (This)).Possible_Values);
+   end Suggestion;
 
    -----------------------
    -- Register_Variable --

--- a/src/alire/alire-expressions.ads
+++ b/src/alire/alire-expressions.ads
@@ -21,6 +21,9 @@ package Alire.Expressions with Preelaborate is
    function Is_Valid (This : Variable; Value : String) return Boolean;
    --  Says if Value is among the values in This
 
+   function Suggestion (This : Variable; Value : String) return String;
+   --  Return a " Did you mean?" message for a given invalid value
+
    function Key (This : Variable) return String;
    --  The key that is used in TOML files for this variable
 
@@ -57,6 +60,8 @@ private
 
    function Is_Valid (V : Values; Image : String) return Boolean is abstract;
    --  Say if a value, given as its string image, matches a value of a type
+
+   function Possible_Values (V : Values) return AAA.Strings.Vector is abstract;
 
    procedure Register (Var_Key    : String;
                        Var_Name   : String;

--- a/src/alire/alire-properties-actions-runners.adb
+++ b/src/alire/alire-properties-actions-runners.adb
@@ -1,4 +1,5 @@
 with AAA.Enum_Tools;
+with Alire.Utils.Did_You_Mean;
 
 package body Alire.Properties.Actions.Runners is
 
@@ -61,6 +62,11 @@ package body Alire.Properties.Actions.Runners is
          Moment   : Moments;
 
          function Is_Valid is new AAA.Enum_Tools.Is_Valid (Moments);
+
+         function Suggestion
+         is new Utils.Did_You_Mean.Enum_Suggestion
+           (Moments, Utils.Did_You_Mean.Tomify);
+
       begin
          if not From.Pop (TOML_Keys.Action_Type, Kind) then
             From.Checked_Error ("action type missing");
@@ -81,7 +87,8 @@ package body Alire.Properties.Actions.Runners is
          end if;
 
          if not Is_Valid (TOML_Adapters.Adafy (Kind.As_String)) then
-            From.Checked_Error ("action type is invalid: " & Kind.As_String);
+            From.Checked_Error ("action type is invalid: '" & Kind.As_String &
+                               "'." & Suggestion (Kind.As_String));
          else
             Moment := Moments'Value (TOML_Adapters.Adafy (Kind.As_String));
          end if;

--- a/src/alire/alire-properties-build_switches.adb
+++ b/src/alire/alire-properties-build_switches.adb
@@ -1,7 +1,64 @@
 with Alire.TOML_Keys;
 with TOML; use TOML;
 
+with Alire.Utils.Did_You_Mean;
+
 package body Alire.Properties.Build_Switches is
+
+   function Profile_Suggestion
+   is new Utils.Did_You_Mean.Enum_Suggestion
+     (Profile_Kind, Utils.Did_You_Mean.Lower_Case);
+
+   function Switches_Categories_Suggestion
+   is new Utils.Did_You_Mean.Enum_Suggestion
+     (Switches_Categories, Utils.Did_You_Mean.Lower_Case);
+
+   function Optimization_Suggestion
+   is new Utils.Did_You_Mean.Enum_Suggestion
+     (Optimization_Kind, Utils.Did_You_Mean.Lower_Case);
+
+   function Debug_Info_Suggestion
+   is new Utils.Did_You_Mean.Enum_Suggestion
+     (Debug_Info_Kind, Utils.Did_You_Mean.Lower_Case);
+
+   function Runtime_Checks_Suggestion
+   is new Utils.Did_You_Mean.Enum_Suggestion
+     (Runtime_Checks_Kind, Utils.Did_You_Mean.Lower_Case);
+
+   function Compile_Checks_Suggestion
+   is new Utils.Did_You_Mean.Enum_Suggestion
+     (Compile_Checks_Kind, Utils.Did_You_Mean.Lower_Case);
+
+   function Contracts_Suggestion
+   is new Utils.Did_You_Mean.Enum_Suggestion
+     (Contracts_Kind, Utils.Did_You_Mean.Lower_Case);
+
+   function Style_Checks_Suggestion
+   is new Utils.Did_You_Mean.Enum_Suggestion
+     (Style_Checks_Kind, Utils.Did_You_Mean.Lower_Case);
+
+   function Ada_Version_Suggestion
+   is new Utils.Did_You_Mean.Enum_Suggestion
+     (Ada_Version_Kind, Utils.Did_You_Mean.Lower_Case);
+
+   -----------------------
+   -- Switch_Suggestion --
+   -----------------------
+
+   function Switch_Suggestion (Str : String; Cat : Switches_Categories)
+                               return String
+   is
+   begin
+      case Cat is
+         when Optimization => return Optimization_Suggestion (Str);
+         when Debug_Info => return Debug_Info_Suggestion (Str);
+         when Contracts => return Contracts_Suggestion (Str);
+         when Compile_Checks => return Compile_Checks_Suggestion (Str);
+         when Runtime_Checks => return Runtime_Checks_Suggestion (Str);
+         when Style_Checks => return Style_Checks_Suggestion (Str);
+         when Ada_Version => return Ada_Version_Suggestion (Str);
+      end case;
+   end Switch_Suggestion;
 
    --------------
    -- Modifier --
@@ -62,19 +119,19 @@ package body Alire.Properties.Build_Switches is
 
          case Cat is
          when Optimization =>
-            Result.Optimization := (Custom, List);
+            Result.Optimization := (Custom => True, List => List);
          when Debug_Info =>
-            Result.Debug_Info := (Custom, List);
+            Result.Debug_Info := (Custom => True, List => List);
          when Compile_Checks =>
-            Result.Compile_Checks := (Custom, List);
+            Result.Compile_Checks := (Custom => True, List => List);
          when Runtime_Checks =>
-            Result.Runtime_Checks := (Custom, List);
+            Result.Runtime_Checks := (Custom => True, List => List);
          when Contracts =>
-            Result.Contracts := (Custom, List);
+            Result.Contracts := (Custom => True, List => List);
          when Style_Checks =>
-            Result.Style_Checks := (Custom, List);
+            Result.Style_Checks := (Custom => True, List => List);
          when Ada_Version =>
-            Result.Ada_Version := (Custom, List);
+            Result.Ada_Version := (Custom => True, List => List);
          end case;
 
       elsif T.Kind = TOML_String then
@@ -86,12 +143,7 @@ package body Alire.Properties.Build_Switches is
                   K : constant Optimization_Kind :=
                     Optimization_Kind'Value (T.As_String);
                begin
-                  Result.Optimization :=
-                    (case K is
-                        when Performance => (Kind => Performance),
-                        when Size        => (Kind => Size),
-                        when Debug       => (Kind => Debug),
-                        when Custom      => raise Constraint_Error);
+                  Result.Optimization := (Custom => False, Value => K);
                end;
 
             when Debug_Info =>
@@ -99,11 +151,7 @@ package body Alire.Properties.Build_Switches is
                   K : constant Debug_Info_Kind :=
                     Debug_Info_Kind'Value (T.As_String);
                begin
-                  Result.Debug_Info :=
-                    (case K is
-                        when No     => (Kind => No),
-                        when Yes    => (Kind => Yes),
-                        when Custom => raise Constraint_Error);
+                  Result.Debug_Info := (Custom => False, Value => K);
                end;
 
             when Runtime_Checks =>
@@ -111,13 +159,7 @@ package body Alire.Properties.Build_Switches is
                   K : constant Runtime_Checks_Kind :=
                     Runtime_Checks_Kind'Value (T.As_String);
                begin
-                  Result.Runtime_Checks :=
-                    (case K is
-                        when None       => (Kind => None),
-                        when Default    => (Kind => Default),
-                        when Overflow   => (Kind => Overflow),
-                        when Everything => (Kind => Everything),
-                        when Custom  => raise Constraint_Error);
+                  Result.Runtime_Checks := (Custom => False, Value => K);
                end;
 
                when Compile_Checks =>
@@ -125,12 +167,7 @@ package body Alire.Properties.Build_Switches is
                   K : constant Compile_Checks_Kind :=
                     Compile_Checks_Kind'Value (T.As_String);
                begin
-                  Result.Compile_Checks :=
-                    (case K is
-                        when None     => (Kind => None),
-                        when Warnings => (Kind => Warnings),
-                        when Errors   => (Kind => Errors),
-                        when Custom   => raise Constraint_Error);
+                  Result.Compile_Checks := (Custom => False, Value => K);
                end;
 
                when Contracts =>
@@ -138,11 +175,7 @@ package body Alire.Properties.Build_Switches is
                   K : constant Contracts_Kind :=
                     Contracts_Kind'Value (T.As_String);
                begin
-                  Result.Contracts :=
-                    (case K is
-                        when No     => (Kind => No),
-                        when Yes    => (Kind => Yes),
-                        when Custom => raise Constraint_Error);
+                  Result.Contracts := (Custom => False, Value => K);
                end;
 
             when Style_Checks =>
@@ -150,11 +183,7 @@ package body Alire.Properties.Build_Switches is
                   K : constant Style_Checks_Kind :=
                     Style_Checks_Kind'Value (T.As_String);
                begin
-                  Result.Style_Checks :=
-                    (case K is
-                        when No     => (Kind => No),
-                        when Yes    => (Kind => Yes),
-                        when Custom => raise Constraint_Error);
+                  Result.Style_Checks := (Custom => False, Value => K);
                end;
 
             when Ada_Version =>
@@ -162,16 +191,7 @@ package body Alire.Properties.Build_Switches is
                   K : constant Ada_Version_Kind :=
                     Ada_Version_Kind'Value (T.As_String);
                begin
-                  Result.Ada_Version :=
-                    (case K is
-                        when Compiler_Default => (Kind => Compiler_Default),
-                        when Ada83            => (Kind => Ada83),
-                        when Ada95            => (Kind => Ada95),
-                        when Ada05            => (Kind => Ada05),
-                        when Ada12            => (Kind => Ada12),
-                        when Ada2022          => (Kind => Ada2022),
-                        when GNAT_Extensions  => (Kind => GNAT_Extensions),
-                        when Custom           => raise Constraint_Error);
+                  Result.Ada_Version := (Custom => False, Value => K);
                end;
 
             end case;
@@ -179,7 +199,8 @@ package body Alire.Properties.Build_Switches is
             when Constraint_Error =>
                From.Checked_Error
                  ("Invalid switch selector '" & T.As_String &
-                    "' for category '" & Cat'Img & "'");
+                    "' for category '" & Cat'Img & "'." &
+                    Switch_Suggestion (T.As_String, Cat));
          end;
 
       else
@@ -214,7 +235,8 @@ package body Alire.Properties.Build_Switches is
          exception
             when Constraint_Error =>
                From.Checked_Error
-                 ("Invalid switch category: '" & (+Key) & "'");
+                 ("Invalid switch category: '" & (+Key) & "'."
+                  & Switches_Categories_Suggestion (+Key));
          end;
       end loop;
 
@@ -295,7 +317,8 @@ package body Alire.Properties.Build_Switches is
             exception
                when Constraint_Error =>
                   From.Checked_Error
-                    ("Invalid profile name: '" & (+Key) & "'");
+                    ("Invalid profile name: '" & (+Key) & "'." &
+                       Profile_Suggestion (+Key));
             end;
          end if;
       end loop;

--- a/src/alire/alire-properties-environment.adb
+++ b/src/alire/alire-properties-environment.adb
@@ -1,6 +1,11 @@
 with Alire.TOML_Keys;
+with Alire.Utils.Did_You_Mean;
 
 package body Alire.Properties.Environment is
+
+   function Actions_Suggestion
+   is new Utils.Did_You_Mean.Enum_Suggestion
+     (Actions, Utils.Did_You_Mean.Lower_Case);
 
    ------------
    -- Action --
@@ -100,7 +105,8 @@ package body Alire.Properties.Environment is
                   when Constraint_Error => -- because Action is invalid
                      From.Checked_Error
                        (": " & (+Var.Name)
-                        & "invalid action: " & Action_Image);
+                        & " invalid action: '" & Action_Image & "'." &
+                          Actions_Suggestion (Action_Image));
                end;
 
                --  Value (already type checked in previous pop)

--- a/src/alire/alire-properties-from_toml.adb
+++ b/src/alire/alire-properties-from_toml.adb
@@ -1,6 +1,11 @@
 with AAA.Enum_Tools;
+with Alire.Utils.Did_You_Mean;
 
 package body Alire.Properties.From_TOML is
+
+   function Property_Keys_Suggestion
+   is new Utils.Did_You_Mean.Enum_Suggestion
+     (Property_Keys, Utils.Did_You_Mean.Tomify);
 
    ------------
    -- Loader --
@@ -88,7 +93,9 @@ package body Alire.Properties.From_TOML is
                      end if;
 
                   else
-                     From.Recoverable_Error ("invalid property: " & Key);
+                     From.Recoverable_Error
+                       ("invalid property: '" & Key &
+                          "'." & Property_Keys_Suggestion (Key));
                   end if;
 
                   exit Process_Property;

--- a/src/alire/alire-properties-labeled.adb
+++ b/src/alire/alire-properties-labeled.adb
@@ -1,3 +1,5 @@
+with Alire.Utils.Did_You_Mean;
+
 package body Alire.Properties.Labeled is
 
    ------------
@@ -47,7 +49,18 @@ package body Alire.Properties.Labeled is
                return L;
             end if;
          end loop;
-         From.Checked_Error ("Key is not a valid property: " & K);
+
+         declare
+            Possible_Values : AAA.Strings.Vector;
+         begin
+            for L in Labels loop
+               Possible_Values.Append (Labeled.Key (L));
+            end loop;
+
+            From.Checked_Error ("Key is not a valid property: " & K & "'" &
+                                  Utils.Did_You_Mean.Suggestion
+                                  (K, Possible_Values));
+         end;
       end Key_To_Label;
 
       --  For conditional loading, we use specific conditional loaders that

--- a/src/alire/alire-utils-did_you_mean.adb
+++ b/src/alire/alire-utils-did_you_mean.adb
@@ -1,0 +1,93 @@
+with Alire.TOML_Adapters;
+
+package body Alire.Utils.Did_You_Mean with Preelaborate is
+
+   -------------------------------
+   -- Levenshtein_Edit_Distance --
+   -------------------------------
+
+   function Levenshtein_Edit_Distance (S, T : String) return Natural is
+      D : array (0 .. S'Last, 0 .. T'Last) of Natural;
+   begin
+      for I in D'Range (1) loop
+         D (I, 0) := I;
+      end loop;
+
+      for J in D'Range (2) loop
+         D (0, J) := J;
+      end loop;
+
+      for I in S'Range loop
+         for J in T'Range loop
+            declare
+               Cost : constant Natural :=
+                 (if S (I) = T (J)
+                  then 0
+                  else 1);
+
+               A : constant Natural := D (I - 1, J) + 1;
+               B : constant Natural := D (I, J - 1) + 1;
+               C : constant Natural := D (I - 1, J - 1) + Cost;
+            begin
+
+               D (I, J) := Natural'Min (Natural'Min (A, B), C);
+            end;
+         end loop;
+      end loop;
+
+      return D (D'Last (1), D'Last (2));
+   end Levenshtein_Edit_Distance;
+
+   ----------------
+   -- Suggestion --
+   ----------------
+
+   function Suggestion (Input           : String;
+                        Possible_Values : AAA.Strings.Vector)
+                        return String
+   is
+      Min_Dist : Natural := Natural'Last;
+      Dist : Natural;
+      Closest : Positive := Possible_Values.First_Index;
+   begin
+      for Index in Possible_Values.First_Index .. Possible_Values.Last_Index
+      loop
+         Dist := Levenshtein_Edit_Distance (Input, Possible_Values (Index));
+         if Dist < Min_Dist then
+            Min_Dist := Dist;
+            Closest := Index;
+         end if;
+      end loop;
+
+      declare
+         Relevant : constant Boolean := Min_Dist < Input'Length / 2;
+         --  Heuristic for relevance of suggestion
+      begin
+         if Relevant then
+            return " Did you mean '" & Possible_Values (Closest) & "'?";
+         else
+            return " Can be: " & Possible_Values.Flatten (", ") & ".";
+         end if;
+      end;
+   end Suggestion;
+
+   ---------------------
+   -- Enum_Suggestion --
+   ---------------------
+
+   function Enum_Suggestion (Input : String) return String is
+      Possible_Values : AAA.Strings.Vector;
+   begin
+      for V in Enum loop
+         Possible_Values.Append
+           (case Transform is
+               when None => V'Img,
+               when Lower_Case => AAA.Strings.To_Lower_Case (V'Img),
+               when Upper_Case => AAA.Strings.To_Lower_Case (V'Img),
+               when Tomify => TOML_Adapters.Tomify (V'Img));
+      end loop;
+
+      return Suggestion (Input, Possible_Values);
+   end Enum_Suggestion;
+
+end Alire.Utils.Did_You_Mean;

--- a/src/alire/alire-utils-did_you_mean.ads
+++ b/src/alire/alire-utils-did_you_mean.ads
@@ -1,0 +1,18 @@
+package Alire.Utils.Did_You_Mean with Preelaborate is
+
+   function Suggestion (Input           : String;
+                        Possible_Values : AAA.Strings.Vector)
+                        return String;
+   --  Return "Did you mean '<suggestion>'?" if a good enought suggestion
+   --  can be found in Possible_Value, otherwise return an empty string.
+
+   type String_Transform is (None, Lower_Case, Upper_Case, Tomify);
+
+   generic
+      type Enum is (<>);
+      Transform : String_Transform;
+   function Enum_Suggestion (Input : String) return String;
+   --  Convert all possible Enum values in a string vector and call Suggestion.
+   --  The enum string values are converted acording to the Transform value.
+
+end Alire.Utils.Did_You_Mean;

--- a/src/alire/alire-utils-switches.adb
+++ b/src/alire/alire-utils-switches.adb
@@ -69,63 +69,72 @@ package body Alire.Utils.Switches is
    --------------
 
    function Get_List (S : Optimization_Switches) return Switch_List
-   is (case S.Kind is
-          when Performance => Empty_List
-                              .Append (GNAT_Optimize_Performance)
-                              .Append (GNAT_Enable_Inlining)
-                              .Append (GNAT_Function_Sections)
-                              .Append (GNAT_Data_Sections),
-          when Size        => Empty_List
-                              .Append (GNAT_Optimize_Size)
-                              .Append (GNAT_Enable_Inlining)
-                              .Append (GNAT_Function_Sections)
-                              .Append (GNAT_Data_Sections),
-          when Debug       => Empty_List
-                              .Append (GNAT_Optimize_Debug)
-                              .Append (GNAT_Function_Sections)
-                              .Append (GNAT_Data_Sections),
-          when Custom      => S.List);
+   is (if S.Custom
+       then S.List
+       else (case S.Value is
+             when Performance => Empty_List
+                                 .Append (GNAT_Optimize_Performance)
+                                 .Append (GNAT_Enable_Inlining)
+                                 .Append (GNAT_Function_Sections)
+                                 .Append (GNAT_Data_Sections),
+             when Size        => Empty_List
+                                 .Append (GNAT_Optimize_Size)
+                                 .Append (GNAT_Enable_Inlining)
+                                 .Append (GNAT_Function_Sections)
+                                 .Append (GNAT_Data_Sections),
+             when Debug       => Empty_List
+                                 .Append (GNAT_Optimize_Debug)
+                                 .Append (GNAT_Function_Sections)
+                                 .Append (GNAT_Data_Sections)));
 
    --------------
    -- Get_List --
    --------------
 
    function Get_List (S : Debug_Info_Switches) return Switch_List
-   is (case S.Kind is
-          when No     => Empty_List,
-          when Yes    => Empty_List.Append (GNAT_Debug_Info),
-          when Custom => S.List);
+   is (if S.Custom
+       then S.List
+       else (case S.Value is
+             when No  => Empty_List,
+             when Yes => Empty_List.Append (GNAT_Debug_Info)));
 
    --------------
    -- Get_List --
    --------------
 
    function Get_List (S : Contracts_Switches) return Switch_List
-   is (case S.Kind is
-          when No         => Empty_List,
-          when Yes        => Empty_List.Append (GNAT_Asserts_And_Contracts),
-          when Custom     => S.List);
+   is (if S.Custom
+       then S.List
+       else (case S.Value is
+             when No  => Empty_List,
+             when Yes => Empty_List.Append (GNAT_Asserts_And_Contracts)));
 
    --------------
    -- Get_List --
    --------------
 
    function Get_List (S : Runtime_Checks_Switches) return Switch_List
-   is (case S.Kind is
-          when None       => Empty_List.Append (GNAT_Suppress_Runtime_Check),
-          when Default    => Empty_List,
-          when Overflow   => Empty_List
-                             .Append (GNAT_Suppress_Runtime_Check)
-                             .Append (GNAT_Enable_Overflow_Check),
-          when Everything => Empty_List.Append (GNAT_Enable_Overflow_Check),
-          when Custom     => S.List);
+   is (if S.Custom
+       then S.List
+       else (case S.Value is
+             when None       => Empty_List
+                                .Append (GNAT_Suppress_Runtime_Check),
+             when Default    => Empty_List,
+             when Overflow   => Empty_List
+                                .Append (GNAT_Suppress_Runtime_Check)
+                                .Append (GNAT_Enable_Overflow_Check),
+             when Everything => Empty_List
+                                .Append (GNAT_Enable_Overflow_Check)));
 
    --------------
    -- Get_List --
    --------------
 
    function Get_List (S : Compile_Checks_Switches) return Switch_List
-   is (case S.Kind is
+   is (if S.Custom
+       then S.List
+       else
+         (case S.Value is
           when None     => Empty_List,
           when Warnings => Empty_List
                            .Append (GNAT_All_Warnings)
@@ -135,58 +144,60 @@ package body Alire.Utils.Switches is
                            .Append (GNAT_All_Warnings)
                            .Append (GNAT_Disable_Warn_No_Exception_Propagation)
                            .Append (GNAT_All_Validity_Checks)
-                           .Append (GNAT_Warnings_As_Errors),
-          when Custom   => S.List);
+                           .Append (GNAT_Warnings_As_Errors)));
 
    --------------
    -- Get_List --
    --------------
 
    function Get_List (S : Style_Checks_Switches) return Switch_List
-   is (case S.Kind is
-          when No     => Empty_List,
-          when Yes    => Empty_List
-                         .Append ("-gnaty3")
-                         .Append ("-gnatya")
-                         .Append ("-gnatyA")
-                         .Append ("-gnatyB")
-                         .Append ("-gnatyb")
-                         .Append ("-gnatyc")
-                         .Append ("-gnaty-d")
-                         --  -gnatyD is not available in GNAT 9
-                         --  .Append ("-gnatyD")
-                         .Append ("-gnatye")
-                         .Append ("-gnatyf")
-                         .Append ("-gnatyh")
-                         .Append ("-gnatyi")
-                         .Append ("-gnatyI")
-                         .Append ("-gnatyk")
-                         .Append ("-gnatyl")
-                         .Append ("-gnatym")
-                         .Append ("-gnatyn")
-                         .Append ("-gnatyO")
-                         .Append ("-gnatyp")
-                         .Append ("-gnatyr")
-                         .Append ("-gnatyS")
-                         .Append ("-gnatyt")
-                         .Append ("-gnatyu")
-                         .Append ("-gnatyx"),
-          when Custom => S.List);
+   is (if S.Custom
+       then S.List
+       else (case S.Value is
+             when No     => Empty_List,
+             when Yes    => Empty_List
+                            .Append ("-gnaty3")
+                            .Append ("-gnatya")
+                            .Append ("-gnatyA")
+                            .Append ("-gnatyB")
+                            .Append ("-gnatyb")
+                            .Append ("-gnatyc")
+                            .Append ("-gnaty-d")
+                            --  -gnatyD is not available in GNAT 9
+                            --  .Append ("-gnatyD")
+                            .Append ("-gnatye")
+                            .Append ("-gnatyf")
+                            .Append ("-gnatyh")
+                            .Append ("-gnatyi")
+                            .Append ("-gnatyI")
+                            .Append ("-gnatyk")
+                            .Append ("-gnatyl")
+                            .Append ("-gnatym")
+                            .Append ("-gnatyn")
+                            .Append ("-gnatyO")
+                            .Append ("-gnatyp")
+                            .Append ("-gnatyr")
+                            .Append ("-gnatyS")
+                            .Append ("-gnatyt")
+                            .Append ("-gnatyu")
+                            .Append ("-gnatyx")));
 
    --------------
    -- Get_List --
    --------------
 
    function Get_List (S : Ada_Version_Switches) return Switch_List
-   is (case S.Kind is
+   is (if S.Custom
+       then S.List
+       else
+         (case S.Value is
           when Compiler_Default => Empty_List,
           when Ada83            => Empty_List.Append (GNAT_Ada83),
           when Ada95            => Empty_List.Append (GNAT_Ada95),
           when Ada05            => Empty_List.Append (GNAT_Ada05),
           when Ada12            => Empty_List.Append (GNAT_Ada12),
           when Ada2022          => Empty_List.Append (GNAT_Ada2022),
-          when GNAT_Extensions  => Empty_List.Append (GNAT_Ada_Extensions),
-          when Custom           => S.List);
+          when GNAT_Extensions  => Empty_List.Append (GNAT_Ada_Extensions)));
 
    --------------
    -- Get_List --

--- a/src/alire/alire-utils-switches.ads
+++ b/src/alire/alire-utils-switches.ads
@@ -32,12 +32,17 @@ is
                                 Style_Checks,
                                 Ada_Version);
 
-   type Optimization_Kind is (Performance, Size, Debug, Custom);
-   type Debug_Info_Kind is (No, Yes, Custom);
-   type Runtime_Checks_Kind is (None, Default, Overflow, Everything, Custom);
-   type Compile_Checks_Kind is (None, Warnings, Errors, Custom);
-   type Contracts_Kind is (No, Yes, Custom);
-   type Style_Checks_Kind is (No, Yes, Custom);
+   type Optimization_Kind is (Performance, Size, Debug);
+
+   type Debug_Info_Kind is (No, Yes);
+
+   type Runtime_Checks_Kind is (None, Default, Overflow, Everything);
+
+   type Compile_Checks_Kind is (None, Warnings, Errors);
+
+   type Contracts_Kind is (No, Yes);
+
+   type Style_Checks_Kind is (No, Yes);
 
    type Ada_Version_Kind is (Compiler_Default,
                              --  This value means that no switch will be added
@@ -45,62 +50,61 @@ is
                              --  Ada version will be used.
 
                              Ada83, Ada95, Ada05, Ada12, Ada2022,
-                             GNAT_Extensions,
-                             Custom);
+                             GNAT_Extensions);
 
-   type Optimization_Switches (Kind : Optimization_Kind := Performance)
+   type Optimization_Switches (Custom : Boolean := False)
    is record
-      case Kind is
-         when Custom => List : Switch_List;
-         when others => null;
+      case Custom is
+         when True  => List : Switch_List;
+         when False => Value : Optimization_Kind;
       end case;
    end record;
 
-   type Debug_Info_Switches (Kind : Debug_Info_Kind := No)
+   type Debug_Info_Switches (Custom : Boolean := False)
    is record
-      case Kind is
-         when Custom => List : Switch_List;
-         when others => null;
+      case Custom is
+         when True  => List : Switch_List;
+         when False => Value : Debug_Info_Kind;
       end case;
    end record;
 
-   type Runtime_Checks_Switches (Kind : Runtime_Checks_Kind := None)
+   type Runtime_Checks_Switches (Custom : Boolean := False)
    is record
-      case Kind is
-         when Custom => List : Switch_List;
-         when others => null;
+      case Custom is
+         when True  => List : Switch_List;
+         when False => Value : Runtime_Checks_Kind;
       end case;
    end record;
 
-   type Compile_Checks_Switches (Kind : Compile_Checks_Kind := None)
+   type Compile_Checks_Switches (Custom : Boolean := False)
    is record
-      case Kind is
-         when Custom => List : Switch_List;
-         when others => null;
+      case Custom is
+         when True  => List : Switch_List;
+         when False => Value : Compile_Checks_Kind;
       end case;
    end record;
 
-   type Contracts_Switches (Kind : Contracts_Kind := No)
+   type Contracts_Switches (Custom : Boolean := False)
    is record
-      case Kind is
-         when Custom => List : Switch_List;
-         when others => null;
+      case Custom is
+         when True  => List : Switch_List;
+         when False => Value : Contracts_Kind;
       end case;
    end record;
 
-   type Style_Checks_Switches (Kind : Style_Checks_Kind := No)
+   type Style_Checks_Switches (Custom : Boolean := False)
    is record
-      case Kind is
-         when Custom => List : Switch_List;
-         when others => null;
+      case Custom is
+         when True  => List : Switch_List;
+         when False => Value : Style_Checks_Kind;
       end case;
    end record;
 
-   type Ada_Version_Switches (Kind : Ada_Version_Kind := Compiler_Default)
+   type Ada_Version_Switches (Custom : Boolean := False)
    is record
-      case Kind is
-         when Custom => List : Switch_List;
-         when others => null;
+      case Custom is
+         when True  => List : Switch_List;
+         when False => Value : Ada_Version_Kind;
       end case;
    end record;
 
@@ -125,31 +129,31 @@ is
    function Get_List (C : Switches_Configuration) return Switch_List;
 
    Default_Release_Switches : constant Switches_Configuration
-     := (Optimization   => (Kind => Performance),
-         Debug_Info     => (Kind => No),
-         Runtime_Checks => (Kind => Default),
-         Compile_Checks => (Kind => None),
-         Contracts      => (Kind => No),
-         Style_Checks   => (Kind => No),
-         Ada_Version    => (Kind => Compiler_Default));
+     := (Optimization   => (Custom => False, Value => Performance),
+         Debug_Info     => (Custom => False, Value => No),
+         Runtime_Checks => (Custom => False, Value => Default),
+         Compile_Checks => (Custom => False, Value => None),
+         Contracts      => (Custom => False, Value => No),
+         Style_Checks   => (Custom => False, Value => No),
+         Ada_Version    => (Custom => False, Value => Compiler_Default));
 
    Default_Validation_Switches : constant Switches_Configuration
-     := (Optimization   => (Kind => Performance),
-         Debug_Info     => (Kind => Yes),
-         Runtime_Checks => (Kind => Everything),
-         Compile_Checks => (Kind => Errors),
-         Contracts      => (Kind => Yes),
-         Style_Checks   => (Kind => Yes),
-         Ada_Version    => (Kind => Compiler_Default));
+     := (Optimization   => (Custom => False, Value => Performance),
+         Debug_Info     => (Custom => False, Value => Yes),
+         Runtime_Checks => (Custom => False, Value => Everything),
+         Compile_Checks => (Custom => False, Value => Errors),
+         Contracts      => (Custom => False, Value => Yes),
+         Style_Checks   => (Custom => False, Value => Yes),
+         Ada_Version    => (Custom => False, Value => Compiler_Default));
 
    Default_Development_Switches : constant Switches_Configuration
-     := (Optimization   => (Kind => Debug),
-         Debug_Info     => (Kind => Yes),
-         Runtime_Checks => (Kind => Default),
-         Compile_Checks => (Kind => Warnings),
-         Contracts      => (Kind => No),
-         Style_Checks   => (Kind => Yes),
-         Ada_Version    => (Kind => Compiler_Default));
+     := (Optimization   => (Custom => False, Value => Debug),
+         Debug_Info     => (Custom => False, Value => Yes),
+         Runtime_Checks => (Custom => False, Value => Default),
+         Compile_Checks => (Custom => False, Value => Warnings),
+         Contracts      => (Custom => False, Value => No),
+         Style_Checks   => (Custom => False, Value => Yes),
+         Ada_Version    => (Custom => False, Value => Compiler_Default));
 
 private
    Empty_List : constant Switch_List :=

--- a/testsuite/tests/misc/did-you-mean/test.py
+++ b/testsuite/tests/misc/did-you-mean/test.py
@@ -1,0 +1,60 @@
+"""
+Verify that an origin definition is rejected in a local manifest
+"""
+
+from drivers.alr import run_alr, init_local_crate
+from drivers.asserts import assert_match
+from drivers.helpers import content_of
+from os.path import join
+
+
+init_local_crate("xxx")
+
+original_toml = content_of("alire.toml")
+
+def test(new_content, expected):
+    with open("alire.toml", "w") as file:
+        file.write (original_toml)
+        file.write(new_content)
+
+    p = run_alr("show", complain_on_error=False)
+    assert_match(expected, p.out)
+
+
+test("websit = true\n",
+     ".*invalid property: 'websit'. Did you mean 'website'\?.*")
+
+test("[build-profile]\n",
+     ".*invalid property: 'build-profile'. Did you mean 'build-profiles'\?.*")
+
+test("[build-profiles]\nxxx = \"releas\"",
+     ".*Invalid build profile name: 'releas' for 'xxx'. Did you mean 'release'\?.*")
+
+test("[build-profiles]\nxxx = \"rel\"",
+     ".*nvalid build profile name: 'rel' for 'xxx'. Can be: release, validation, development.*")
+
+test("[build-switche]\n",
+     ".*invalid property: 'build-switche'. Did you mean 'build-switches'\?.*")
+
+test("[build-switches]\nreleas.ada_version = \"ada12\"\n",
+     ".*Invalid profile name: 'releas'. Did you mean 'release'\?.*")
+
+test("[build-switches]\nrelease.ada_versino = \"ada12\"\n",
+     ".*Invalid switch category: 'ada_versino'. Did you mean 'ada_version'\?.*")
+
+test("[build-switches]\nrelease.ada_version = \"gnat_extensoni\"\n",
+     ".*Invalid switch selector 'gnat_extensoni' for category 'ADA_VERSION'. Did you mean 'gnat_extensions'\?.*")
+
+test("[environement]\nTEST.append = \"test\"\n",
+     ".*invalid property: 'environement'. Did you mean 'environment'\?.*")
+
+test("[environment.'case(os)'.linusc]\nTEST.append = \"test\"\n",
+     ".*invalid enumeration value: 'linusc'. Did you mean 'linux'\?.*")
+
+test("[environment.'case(host-arch)'.x86-46]\nTEST.append = \"test\"\n",
+     ".*invalid enumeration value: 'x86-46'. Did you mean 'x86-64'\?.*")
+
+test("[environment.'case(host-arch)'.plop]\nTEST.append = \"test\"\n",
+     ".*invalid enumeration value: 'plop'. Can be: aarch64, aarch64-be, architecture-unknown, arm, i386, i686, x86-64.*")
+
+print('SUCCESS')

--- a/testsuite/tests/misc/did-you-mean/test.yaml
+++ b/testsuite/tests/misc/did-you-mean/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script

--- a/testsuite/tests/misc/local-reject-origin/test.py
+++ b/testsuite/tests/misc/local-reject-origin/test.py
@@ -14,6 +14,6 @@ with open("alire.toml", "a") as file:
     file.write("\n[origin]\n")
 
 p = run_alr("show", complain_on_error=False)
-assert_match(".*invalid property: origin.*", p.out)
+assert_match(".*invalid property: 'origin'.*", p.out)
 
 print('SUCCESS')


### PR DESCRIPTION
This is patch introduces suggestions in various error messages from the manifest parser. A potential suggestion is made using edit distance computing from a list of possible values. If the quality is not deemed good enough, the full list of values is printed.