### PR TITLE
Use hyphens for action usage output

### DIFF
--- a/src/alr/alr-commands-action.adb
+++ b/src/alr/alr-commands-action.adb
@@ -22,11 +22,15 @@ package body Alr.Commands.Action is
       -----------
 
       function Build (Moment : Alire.Properties.Actions.Moments) return String
-      is ((if Moment /= Moments'First then "|" else "")
-          & AAA.Strings.To_Lower_Case (Moment'Image)
-          & (if Moment = Moments'Pred (On_Demand)
-            then ""
-            else Build (Moments'Succ (Moment))));
+      is
+         use AAA.Strings;
+      begin
+         return (if Moment /= Moments'First then "|" else "")
+                & To_Lower_Case (Replace (Moment'Image, "_", "-"))
+                & (if Moment = Moments'Pred (On_Demand)
+                  then ""
+                  else Build (Moments'Succ (Moment)));
+      end Build;
 
    begin
       return Build (Alire.Properties.Actions.Moments'First);


### PR DESCRIPTION
Currently action usage output looks like:
`alr action [options] [post_fetch|pre_build|post_build|test]`,
but it should look like:
`alr action [options] [post-fetch|pre-build|post-build|test]`,
because TOML expects keys to be hyphenated.

This PR fixes #1230 by replacing underscores with hyphens.