### PR TITLE
Alr.Commands.Search: unify "search" and "search --crates" behavior

### DIFF
--- a/src/alr/alr-commands-search.adb
+++ b/src/alr/alr-commands-search.adb
@@ -239,10 +239,12 @@ package body Alr.Commands.Search is
          while Has_Element (I) loop
 
             declare
+               use AAA.Strings;
+
                Crate   : Alire.Crates.Crate renames Element (I);
                Pattern : constant String := (if Cmd.List
                                              then ""
-                                             else Args (1));
+                                             else To_Lower_Case (Args (1)));
             begin
                if Cmd.List then
 
@@ -251,8 +253,11 @@ package body Alr.Commands.Search is
 
                else
 
-                  --  Search into release names
-                  if AAA.Strings.Contains (+Crate.Name, Pattern) then
+                  --  Search into release names and descriptions
+                  if Contains (To_Lower_Case (+Crate.Name), Pattern)
+                    or else
+                     Contains (To_Lower_Case (Crate.Description), Pattern)
+                  then
                      List_Crate (Crate);
                   end if;
 

--- a/testsuite/fixtures/basic_index/li/libhello/libhello-1.0.0.toml
+++ b/testsuite/fixtures/basic_index/li/libhello/libhello-1.0.0.toml
@@ -3,6 +3,7 @@ name = "libhello"
 version = "1.0.0"
 maintainers = ["alejandro@mosteo.com"]
 maintainers-logins = ["mylogin"]
+tags = ["libhello-tag1"]
 
 [configuration.variables]
 Var1={type="Boolean", default=true}

--- a/testsuite/tests/search/basic/test.py
+++ b/testsuite/tests/search/basic/test.py
@@ -37,19 +37,19 @@ assert_eq(format_table(
 ), p.out)
 
 
-# Actually search in the index. First, on crate names
+# Actually search in the index. First, on crate names/description
 p = run_alr('search', 'lib')
 assert_eq(format_table(
     ('libhello', '', '1.0.0',
      '"Hello, world!" demonstration project support library', ''),
 ), p.out)
 
-p = run_alr('search', 'support')
+p = run_alr('search', 'libhello-tag1')
 assert_eq('', p.out)
 
 
 # Then on crate properties
-p = run_alr('search', '--property', 'support')
+p = run_alr('search', '--property', 'libhello-tag1')
 assert_eq(format_table(
     ('libhello', '', '1.0.0',
      '"Hello, world!" demonstration project support library', ''),


### PR DESCRIPTION
They now both look in names and descriptions, case insensitive.