### PR TITLE
Use XDG_CACHE_DIR for cache

### DIFF
--- a/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
+++ b/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
@@ -8,7 +8,7 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return String is (Common.XDG_Config_Folder);
+   function Cache return String is (Common.XDG_Cache_Folder);
 
    -----------
    -- Config--

--- a/src/alire/os_linux/alire-platforms-folders__linux.adb
+++ b/src/alire/os_linux/alire-platforms-folders__linux.adb
@@ -8,7 +8,7 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return String is (Common.XDG_Config_Folder);
+   function Cache return String is (Common.XDG_Cache_Folder);
 
    -----------
    -- Config--

--- a/src/alire/os_macos/alire-platforms-folders__macos.adb
+++ b/src/alire/os_macos/alire-platforms-folders__macos.adb
@@ -8,7 +8,7 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return String is (Common.XDG_Config_Folder);
+   function Cache return String is (Common.XDG_Cache_Folder);
 
    -----------
    -- Config--


### PR DESCRIPTION
Currently cache files are downloaded to the config directory. This should be changed to the cache directory.

fixes #1266