### PR TITLE
Add `--alr` testsuite option

### DIFF
--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -92,7 +92,7 @@ def run_alr(*args, **kwargs):
         first_unknown_kwarg = sorted(kwargs)[0]
         raise ValueError('Invalid argument: {}'.format(first_unknown_kwarg))
 
-    argv = ['alr']
+    argv = [os.environ['ALR_PATH']]
     argv.insert(1, '-n')  # always non-interactive
     if debug:
         argv.insert(1, '-d')


### PR DESCRIPTION
The testsuite runs tests against `alr` from project's `bin` dir by default. This option makes it possible to select arbitrary `alr` to test. Resolves #1268.