### PR TITLE
alire_common.gpr: remove default host os to avoid mistakes on macOS

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -10,6 +10,9 @@ on:
   release:
     types: [created]
 
+env:
+  ALIRE_OS: "windows"
+
 jobs:
 
   build:

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ https://alire.ada.dev/
 
 ## TL;DR ##
 
-Available for Linux/macOS/Windows.
+Available for Linux/macOS/Windows/FreeBSD.
 
 Download the latest stable version from the [Releases](https://github.com/alire-project/alire/releases) page. See the [Getting Started](doc/getting-started.md) guide for binary downloads.
 
-If, instead, you want to test the latest development version, see [Building from sources](#building-from-sources).
+If, instead, you want to test the latest development version, see [Building from sources](#building-from-sources) or, if you already have a recent `alr` in your system, [Building with `alr`](#building-with-alr).
 
 ## Installation and First Steps ##
 
@@ -32,14 +32,16 @@ See the [Getting Started](doc/getting-started.md) guide.
 
 ## Building from sources ##
 
-The build process of `alr` is straighforward and depends only on a recent GNAT Ada 2012 compiler. All dependencies are included as submodules. A project file (`alr_env.gpr`) is provided to drive the build with all necessary configuration (see the macOS extra step below, though).
+The build process of `alr` is straighforward and depends only on a recent GNAT Ada 2012 compiler. All dependencies are included as submodules. A project file (`alr_env.gpr`) is provided to drive the build with all necessary configuration (which is also valid for editing with GNAT Studio).
+
+The ALIRE_OS environment variable must be set to the OS for which `alr` is being build, taking one of the values in `freebsd`, `linux`, `macos`, `windows`.
 
 Follow these steps:
 
 1. Clone the repository: `git clone --recurse-submodules https://github.com/alire-project/alire.git`
 1. Enter the cloned repository folder.
-1. Only on macOS: define the environment variable `OS=macOS`
-1. Build the executable: `gprbuild -j0 -P alr_env`
+1. Export the environment variable `ALIRE_OS=<one of: freebsd, linux, macos, windows>`
+1. Build the executable: `gprbuild -j0 -p -P alr_env`
 
 The binary will be found at `bin/alr`. You can run `alr version` to see version and diagnostics information.
 
@@ -49,7 +51,8 @@ Sourcing the `scripts/alr-completion.bash` file will provide bash tab autocomple
 
 If you already have a recent enough `alr` binary, you can alternative build
 `alr` by simply running `alr build` at the root of the repository. This command
-will retrieve all necessary dependencies prior to launching the build.
+will retrieve all necessary dependencies prior to launching the build and 
+configure the environment.
 
 The master branch should normally be able to build itself in this fashion, as
 this is one of our integration tests.
@@ -75,6 +78,8 @@ projects to its own project GPR file with their simple name. You can check the
 environment `alr` is using with `alr printenv`.
 
 ## Supported platforms ##
+
+Alire can be built on Linux, macOS, Windows, and FreeBSD.
 
 Alire requires a recent Ada 2012 compiler. In practice, this currently means
 the latest [GNAT Community](https://www.adacore.com/download) or a somewhat

--- a/alire.gpr
+++ b/alire.gpr
@@ -20,29 +20,31 @@ library project Alire is
 
    for Library_Name use "alire";
 
+   --  Set OS-dependent source files
+
    Src_Dirs := ("src/alire");
 
    case Alire_Common.Host_Os is
-      when "windows" => Src_Dirs := Src_Dirs & ("src/alire/os_windows");
-      when "osx"     => Src_Dirs := Src_Dirs & ("src/alire/os_macos");
       when "freebsd" => Src_Dirs := Src_Dirs & ("src/alire/os_freebsd");
-      when others    => Src_Dirs := Src_Dirs & ("src/alire/os_linux");
+      when "linux"   => Src_Dirs := Src_Dirs & ("src/alire/os_linux");
+      when "macos"   => Src_Dirs := Src_Dirs & ("src/alire/os_macos");
+      when "windows" => Src_Dirs := Src_Dirs & ("src/alire/os_windows");
    end case;
 
    package Naming is
       case Alire_Common.Host_OS is
-         when "windows" =>
-            for body ("Alire.Platforms.Current") use "alire-platforms-current__windows.adb";
-            for body ("Alire.Platforms.Folders") use "alire-platforms-folders__windows.adb";
-         when "osx"     =>
-            for body ("Alire.Platforms.Current") use "alire-platforms-current__macos.adb";
-            for body ("Alire.Platforms.Folders") use "alire-platforms-folders__macos.adb";
          when "freebsd" =>
             for body ("Alire.Platforms.Current") use "alire-platforms-current__freebsd.adb";
             for body ("Alire.Platforms.Folders") use "alire-platforms-folders__freebsd.adb";
-         when others    =>
+         when "linux" =>
             for body ("Alire.Platforms.Current") use "alire-platforms-current__linux.adb";
             for body ("Alire.Platforms.Folders") use "alire-platforms-folders__linux.adb";
+         when "macos" =>
+            for body ("Alire.Platforms.Current") use "alire-platforms-current__macos.adb";
+            for body ("Alire.Platforms.Folders") use "alire-platforms-folders__macos.adb";
+         when "windows" =>
+            for body ("Alire.Platforms.Current") use "alire-platforms-current__windows.adb";
+            for body ("Alire.Platforms.Folders") use "alire-platforms-folders__windows.adb";
       end case;
    end Naming;
 

--- a/alire.toml
+++ b/alire.toml
@@ -37,7 +37,11 @@ CLIC_LIBRARY_TYPE="static"
 
 # Building alr requires the explicit setting of this variable
 [gpr-set-externals."case(os)"]
-macos   = { OS = "macOS" }
+freebsd = { ALIRE_OS = "freebsd" }
+linux   = { ALIRE_OS = "linux" }
+macos   = { ALIRE_OS = "macos" }
+windows = { ALIRE_OS = "windows" }
+"..."   = { ALIRE_OS = "unknown" } # Will cause the build to fail
 
 # Some dependencies require precise versions during the development cycle:
 [[pins]]

--- a/alire_common.gpr
+++ b/alire_common.gpr
@@ -2,8 +2,13 @@ abstract project Alire_Common is
 
    for Create_Missing_Dirs use "True";
 
-   Host_OS := external ("ALIRE_OS");
-   --  Defined in alr_env.gpr.
+   type Host_OSes is ("linux", 
+                      "freebsd", 
+                      "macos", 
+                      "windows");
+
+   Host_OS : Host_OSes := external ("ALIRE_OS");
+   --  Set by user or in alire.toml
 
    type Any_Build_Mode is ("debug", "release");
    Build_Mode : Any_Build_Mode := external ("ALIRE_BUILD_MODE", "debug");

--- a/alire_common.gpr
+++ b/alire_common.gpr
@@ -2,7 +2,7 @@ abstract project Alire_Common is
 
    for Create_Missing_Dirs use "True";
 
-   Host_OS := external ("ALIRE_OS", "default");
+   Host_OS := external ("ALIRE_OS");
    --  Defined in alr_env.gpr.
 
    type Any_Build_Mode is ("debug", "release");

--- a/alr.gpr
+++ b/alr.gpr
@@ -13,9 +13,10 @@ project Alr is
    Src_Dirs := ("src/alr");
 
    case Alire_Common.Host_Os is
+      when "freebsd" => Src_Dirs := Src_Dirs & ("src/alr/os_linux");
+      when "linux"   => Src_Dirs := Src_Dirs & ("src/alr/os_linux");
+      when "macos"   => Src_Dirs := Src_Dirs & ("src/alr/os_macos");
       when "windows" => Src_Dirs := Src_Dirs & ("src/alr/os_windows");
-      when "osx"     => Src_Dirs := Src_Dirs & ("src/alr/os_macos");
-      when others    => Src_Dirs := Src_Dirs & ("src/alr/os_linux");
    end case;
 
    for Source_Dirs use Src_Dirs;

--- a/alr_env.gpr
+++ b/alr_env.gpr
@@ -1,4 +1,10 @@
+with "alire_common.gpr"; -- To gain access to Host_OS without redefining it
+
 aggregate project Alr_Env is
+
+   --  To be able to build with this project file, the user must set the
+   --  host operating system in ALIRE_OS using one of the values defined
+   --  in alire_common.gpr
 
    for Create_Missing_Dirs use "True";
 
@@ -23,32 +29,19 @@ aggregate project Alr_Env is
 
    for Project_Files use ("alr.gpr");
 
-   --  Provide defaults for environment variables that GNATcoll requires
+   --  Set environment variables for dependencies
+
+   case Alire_Common.Host_Os is
+      when "freebsd" => for External ("GNATCOLL_OS") use "unix";
+      when "linux"   => for External ("GNATCOLL_OS") use "unix";
+      when "macos"   => for External ("GNATCOLL_OS") use "osx";
+      when "windows" => for External ("GNATCOLL_OS") use "windows";
+   end case;
 
    for External ("LIBRARY_TYPE") use "static";
    for External ("BUILD") use "DEBUG";
 
-   Host_OS := external ("OS", "default");
-   --  On Windows an OS environment variable is defined, we can use it to
-   --  determine if we are compiling on Windows.
-   --
-   --  On macOS, the nearest equivalent is OSTYPE; however this is
-   --  e.g. "darwin18", so not useful here. Set "macOS" by hand.
+   --  The user must set ALIRE_OS before building. See the list of valid values
+   --  in alire_common.gpr
 
-   --  ALIRE_OS is used in alire_common.gpr.
-   --  GNATCOLL_OS is used in gnatcoll.gpr.
-   case Host_OS is
-      when "Windows_NT" | "windows_nt" | "windows" | "Windows" =>
-         for External ("ALIRE_OS") use "windows";
-         for External ("GNATCOLL_OS") use "windows";
-      when "macOS" | "macos" | "OSX" | "osx" =>
-         for External ("ALIRE_OS") use "osx";
-         for External ("GNATCOLL_OS") use "osx";
-      when "freebsd" =>
-         for External ("ALIRE_OS") use "freebsd";
-         for External ("GNATCOLL_OS") use "unix";
-      when others =>
-         for External ("ALIRE_OS") use "unix";
-         for External ("GNATCOLL_OS") use "unix";
-   end case;
 end Alr_Env;

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Import reusable bits
+pushd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) > /dev/null
+    . functions.sh
+popd > /dev/null
+
+export ALIRE_OS=$(get_OS)
+
+echo Building with ALIRE_OS=$ALIRE_OS...
+gprbuild -j0 -r -p -P `dirname $0`/../alr_env.gpr "$@"

--- a/dev/devbuild.sh
+++ b/dev/devbuild.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gprbuild -j0 -r -p -P `dirname $0`/../alr_env.gpr "$@"

--- a/dev/functions.sh
+++ b/dev/functions.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+function guess_OS() {
+    # Returns one of the values needed in ALIRE_OS, using environment variables
+
+    if [ -n "$WINDIR" ]; then
+        echo windows
+    elif [ -n "$OSTYPE" ]; then
+        case "$OSTYPE" in # only available on bash shells
+            "linux-gnu")
+                echo linux
+                ;;
+            "freebsd")
+                echo freebsd
+                ;;
+            "darwin"*) # varies with versions: darwin18, darwin19, etc.
+                echo macos
+                ;;
+            *)
+                echo unknown # give up, builds depending on ALIRE_OS will fail.
+                ;;
+        esac
+    else
+        echo unknown
+    fi
+}
+
+function get_OS() {
+    # Returns one of the values needed in ALIRE_OS, using `uname``
+
+    OS=`uname -s`
+
+    case "$OS" in
+    "Linux")
+        echo linux
+        ;;
+    "FreeBSD")
+        echo freebsd
+        ;;
+    "Darwin")
+        echo macos
+        ;;
+    "Windows")
+        echo windows
+        ;;
+    *)
+        # Fall back to use environment clues
+        guess_OS
+        ;;
+    esac
+}

--- a/dev/gpslaunch.sh
+++ b/dev/gpslaunch.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Launch latest GPL but with platform compiler
-~/opt/gnat-gpl-2017/bin/gps -P `dirname $0`/../alr_env.gpr &

--- a/dev/pull.sh
+++ b/dev/pull.sh
@@ -1,9 +1,0 @@
-#/bin/bash
-
-git pull --all
-git submodule update --init --recursive
-git-recurse "git checkout master"
-git-recurse "git pull --ff-only"
-
-echo ' '
-git submodule status --recursive

--- a/dev/push.sh
+++ b/dev/push.sh
@@ -1,4 +1,0 @@
-git pull &&
-git rm -f status/g*.md &&
-git commit status -m "Delete old release status" &&
-git push

--- a/dev/unused.sh
+++ b/dev/unused.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Import reusable bits
+pushd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) > /dev/null
+    . functions.sh
+popd > /dev/null
+
+export ALIRE_OS=$(get_OS)
+
 gprclean -q -r -Palr_env
 
 {

--- a/scripts/ci-github.sh
+++ b/scripts/ci-github.sh
@@ -8,13 +8,13 @@ set -o nounset
 
 export PATH+=:${PWD}/bin
 
-# For Darwin, have to define OS=macOS for alr_env.gpr
-# Windows defines it anyway
-# Linux (undefined) selects the default
-
-[ `uname -s` == "Darwin" ] && export OS=macOS
+# Import reusable bits
+pushd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    . ../dev/functions.sh
+popd
 
 # Build alr
+export ALIRE_OS=$(get_OS) 
 gprbuild -j0 -p -P alr_env
 
 # Disable distro detection if supported


### PR DESCRIPTION
With the default being Linux, macOS users will not notice any issue until they try to use the executable. Even then the issue will be obscure.