### PR TITLE
Fix the example for editor.cmd

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -468,13 +468,13 @@ PR [#611](https://github.com/alire-project/alire/pull/611).
 
 The code editor launched by `alr edit` can now be configured instead of using
 the hard-coded GNATstudio. Use
-`alr config --set --global editor.cmd "<BINARY> <ARGS>"`
+`alr config --set --global editor.cmd '<BINARY> <ARGS>'`
 for custom editor and command line arguments. The token ${GPR_FILE} is
 replaced by a path to the project file to open.
 
 For instance:
 ```shell
-$ alr config --set --global editor.cmd "emacs ${GPR_FILE}"
+$ alr config --set --global editor.cmd 'emacs ${GPR_FILE}'
 ```
 
 The default editor is still GNATstudio.


### PR DESCRIPTION
Using double quotes, the  ${GPR_FILE} is interpreted as a variable by Bourne-like shells and evaluated to an empty string or whatever value has when executed. Single quotes is a way to avoid that evaluation.

This example will not make Emacs select and load the GPR_FILE as the project file for ada-mode, that would be more cumbersome (and requires ada-mode 8.0.3), but I didn't want to complicate the example:
```
alr config --set --global editor.cmd 'emacs --eval=(ada-build-prompt-select-prj-file"${GPR_FILE}") ${GPR_FILE}'
```