### PR TITLE
Install a local crate

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -6,7 +6,30 @@ stay on top of `alr` new features.
 
 ## Release 1.3-dev
 
-### New subcommand `alr install
+### Installation of local crates
+
+PR [#1322](https://github.com/alire-project/alire/pull/1322)
+
+`alr install` accepts a new `--this` switch that performs the installation of a
+local crate. For example:
+
+```
+$ alr -n init --bin mycrate && cd mycrate
+$ alr install --this
+$ alr install
+Installation prefix found at /home/user/.alire
+Contents:
+   mycrate=0.1.0-dev
+```
+
+Or, to install the hangman game:
+
+```
+$ alr get hangman && cd hangman*
+$ alr install --this
+```
+
+### New subcommand `alr install`
 
 PR [#1302](https://github.com/alire-project/alire/pull/1302)
 
@@ -18,7 +41,7 @@ This is a experimental feature that will see improvements and tweaks in further
 PRs and as we gather feedback on its usage.
 
 At present, only binary releases can be installed (e.g., compilers, `gprbuild`,
-`gnatprove`, `gnatstudio`). There is no ability to uninstall releases either
+`gnatprove`). There is no ability to uninstall releases either
 (but reinstallation can be forced).
 
 Only one version per executable can be installed, meaning that, for example,

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -10,13 +10,13 @@ stay on top of `alr` new features.
 
 PR [#1322](https://github.com/alire-project/alire/pull/1322)
 
-`alr install` accepts a new `--this` switch that performs the installation of a
-local crate. For example:
+`alr install` without arguments performs the installation of the current crate.
+With `--info`, it shows the contents of an installation prefix. For example:
 
 ```
 $ alr -n init --bin mycrate && cd mycrate
-$ alr install --this
 $ alr install
+$ alr install --info
 Installation prefix found at /home/user/.alire
 Contents:
    mycrate=0.1.0-dev
@@ -26,7 +26,7 @@ Or, to install the hangman game:
 
 ```
 $ alr get hangman && cd hangman*
-$ alr install --this
+$ alr install
 ```
 
 ### New subcommand `alr install`

--- a/src/alire/alire-errors.ads
+++ b/src/alire/alire-errors.ads
@@ -84,7 +84,8 @@ package Alire.Errors with Preelaborate is
 
    function Wrap (This : Wrapper; Text : String) return Wrapper;
    --  Add an indented detail error msg to the current wrapping chain, unless
-   --  the wrapper is empty in which case the message will be top level.
+   --  the wrapper is empty in which case the message will be top level. If
+   --  Text is "", silently do nothing.
 
    function Wrap (This : Wrapper; Ex : Ada.Exceptions.Exception_Occurrence)
                   return Wrapper;
@@ -92,6 +93,9 @@ package Alire.Errors with Preelaborate is
 
    procedure Print (This : Wrapper);
    --  Complete the chain of errors and log it at error level
+
+   function Get (This : Wrapper) return String;
+   --  Return the entire error sequence
 
    function Set (This : Wrapper) return String;
    --  Store the msgs in This and return an Id for use as exception message
@@ -165,6 +169,9 @@ private
                   return Wrapper
    is (This.Wrap (Get (Ex)));
    --  Start a chain with an exception message instead of a given text
+
+   function Get (This : Wrapper) return String
+   is (This.Text);
 
    ---------
    -- Set --

--- a/src/alire/alire-install.ads
+++ b/src/alire/alire-install.ads
@@ -1,7 +1,8 @@
 limited with Alire.Dependencies.Containers;
 with Alire.Directories; use Alire.Directories.Operators;
-private with Alire.Milestones.Containers;
+with Alire.Milestones.Containers;
 with Alire.Platforms.Folders;
+with Alire.Releases;
 
 package Alire.Install is
 
@@ -15,8 +16,32 @@ package Alire.Install is
    --  Resolve the dependencies and install the resulting releases. If a
    --  crate is given twice it will raise.
 
+   procedure Check_Conflict (Prefix : Any_Path; Rel : Releases.Release);
+   --  Will cause a recoverable error if Rel is already installed, or another
+   --  release from the same crate is. This is regardless Rel containing
+   --  executables or not.
+
    procedure Info (Prefix : Any_Path);
    --  Display information about the given prefix
+
+   subtype Installed_Milestones is Milestones.Containers.Sets.Set;
+
+   function Find_Installed (Prefix : Any_Path)
+                            return Installed_Milestones;
+   --  Identify installed releases in the prefix
+
+   function Find_Installed (Prefix : Any_Path;
+                            Crate  : Crate_Name)
+                            return Installed_Milestones;
+   --  Return milestones for only the given crate
+
+   procedure Set_Installed (Prefix : Any_Path; Mil : Milestones.Milestone);
+   --  Stores an empty file in share/gpr/manifests/crate=version
+
+   procedure Set_Not_Installed (Prefix : Any_Path; Crate : Crate_Name);
+   --  Any and all versions will be marked as not installed. Intended for when
+   --  reinstalling a different executable crate version, as only one can be
+   --  installed.
 
 private
 
@@ -24,16 +49,5 @@ private
      := "share" / "gpr" / "manifests";
    --  This is used by gprinstall and we will reuse it for our "fake" binary
    --  installs.
-
-   subtype Installed_Milestones is Milestones.Containers.Maps.Map;
-
-   function Find_Installed (Prefix : Any_Path)
-                            return Installed_Milestones;
-   --  Identify installed releases in the prefix
-
-   procedure Set_Installed (Prefix : Any_Path; Mil : Milestones.Milestone);
-
-   procedure Set_Not_Installed (Prefix : Any_Path; Crate : Crate_Name);
-   --  Any and all versions will be marked as not installed
 
 end Alire.Install;

--- a/src/alire/alire-platforms-folders.ads
+++ b/src/alire/alire-platforms-folders.ads
@@ -7,15 +7,15 @@ package Alire.Platforms.Folders is
    --  any other global data. Deleting it is akin to running alr afresh for
    --  the first time.
    --  On Linux/macOS it is ${XDG_CONFIG_HOME:-$HOME/.config}/alire
-   --  On Windows it is $Homedrive:$Homepath\.config\alire
+   --  On Windows it is $UserProfile\.config\alire
 
    function Cache return String;
    --  Folder for dependencies, global toolchains, and any other info that is
    --  not critical to lose. Can be deleted freely, it's repopulated on-demand.
    --  On Linux/macOS it is ${XDG_CACHE_HOME:-$HOME/.cache}/alire
-   --  On Windows it is $Homedrive:$Homepath\.cache\alire
+   --  On Windows it is $UserProfile\.cache\alire
 
    function Home return Absolute_Path;
-   --  $HOME (Linux/macOS) or $Homedrive:$Homepath (Windows)
+   --  $HOME (Linux/macOS) or $UserProfile (Windows)
 
 end Alire.Platforms.Folders;

--- a/src/alire/alire-releases.ads
+++ b/src/alire/alire-releases.ads
@@ -221,7 +221,9 @@ package Alire.Releases is
                            P         : Alire.Properties.Vector;
                            With_Path : Boolean)
                            return AAA.Strings.Vector;
-   --  with relative path on demand
+   --  With relative path on demand. Will always return at least the default
+   --  project file when nothing is declared in the manifest for regular
+   --  crates, but nothing for system/binary/external.
 
    function Deployment_Folder (R : Release) return Folder_String;
    --  The folder under which the release origin will be deployed

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -216,15 +216,28 @@ package Alire.Roots is
    function Build (This             : in out Root;
                    Cmd_Args         : AAA.Strings.Vector;
                    Export_Build_Env : Boolean;
+                   Build_All_Deps   : Boolean := False;
                    Saved_Profiles   : Boolean := True)
                    return Boolean;
    --  Recursively build all dependencies that declare executables, and finally
    --  the root release. Also executes all pre-build/post-build actions for
-   --  all releases in the solution (even those not built). Returns True on
-   --  successful build. By default, profiles stored in the persistent crate
-   --  configuration are used (i.e. last explicit build); otherwise the ones
-   --  given in This.Configuration are used. These come in order of increasing
-   --  priority from: defaults -> manifests -> explicit set via API.
+   --  all releases in the solution (even those not built). Returns True
+   --  on successful build. When Build_All_Deps, all dependencies are built
+   --  explicitly; otherwise only those declaring executables are built.
+   --  This is useful when we are going to gprinstall dependencies
+   --  containing undeclared executables, which otherwise wouldn't be built.
+   --  Unfortunately, it's not mandatory to declare the default executable.
+   --  Saved_Profiles determines whether profiles stored in the persistent
+   --  crate configuration are used (i.e. last explicit build); otherwise
+   --  the ones given in This.Configuration are used. These come in order of
+   --  increasing priority from: defaults -> manifests -> explicit set via API.
+
+   procedure Install
+     (This       : in out Root;
+      Prefix     : Absolute_Path;
+      Build      : Boolean := True;
+      Export_Env : Boolean := True);
+   --  Call gprinstall on the releases in solution using --prefix=Prefix
 
    function Configuration (This : in out Root)
                            return Crate_Configuration.Global_Config;

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -344,10 +344,13 @@ package Alire.Solutions is
                     Root     : Alire.Releases.Release;
                     Env      : Properties.Vector;
                     Detailed : Boolean;
-                    Level    : Trace.Levels);
+                    Level    : Trace.Levels;
+                    Prefix   : String := "";
+                    Graph    : Boolean := True);
    --  Prints releases, and direct and transitive dependencies. Root is the
    --  crate not in solution that introduces the direct dependencies. When
-   --  Detailed, extra information about origins is shown.
+   --  Detailed, extra information about origins is shown. When Prefix, prepend
+   --  to each line. When Graph, print a textual dependency graph at the end.
 
    procedure Print_Graph (This     : Solution;
                           Root     : Alire.Releases.Release;

--- a/src/alire/alire-spawn.adb
+++ b/src/alire/alire-spawn.adb
@@ -48,4 +48,37 @@ package body Alire.Spawn is
                Understands_Verbose => True);
    end Gprbuild;
 
+   ----------------
+   -- Gprinstall --
+   ----------------
+
+   procedure Gprinstall
+     (Release      : Releases.Release;
+      Project_File : Absolute_File;
+      Prefix       : Absolute_Path;
+      Recursive    : Boolean;
+      Quiet        : Boolean;
+      Force        : Boolean := Alire.Force;
+      Extra_Args   : AAA.Strings.Vector := AAA.Strings.Empty_Vector)
+   is
+      use AAA.Strings;
+   begin
+      Spawn.Command
+        ("gprinstall",
+         AAA.Strings.Empty_Vector
+         & (if Recursive then To_Vector ("-r") else Empty_Vector)
+         & (if Quiet     then To_Vector ("-q") else Empty_Vector)
+         & (if Force     then To_Vector ("-f") else Empty_Vector)
+         & String'("--install-name=" & Release.Milestone.Image)
+         & "-m" -- minimal install (only needed sources)
+         & "-p" -- create missing dirs
+         & "--link-lib-subdir=bin"
+         --  Softlinks in same dir as executables, saves a path on Windows
+         & "--mode=usage" -- omit unwanted devel files
+         & String'("--prefix=" & Prefix)
+         & "-P" & Project_File
+         & Extra_Args
+        );
+   end Gprinstall;
+
 end Alire.Spawn;

--- a/src/alire/alire-spawn.ads
+++ b/src/alire/alire-spawn.ads
@@ -1,5 +1,7 @@
 with AAA.Strings;
 
+with Alire.Releases;
+
 package Alire.Spawn is
 
    --  Encapsulates all external spawns
@@ -17,7 +19,19 @@ package Alire.Spawn is
       Extra_Args    : AAA.Strings.Vector);
    --  Launches gprbuild for the building of a crate.
    --  Extra args can be -Xblah detected from command-line.
-   --  Out-of-tree build takes place in
-   --    $crate / Alire.Paths.Build_Folder ($crate/alire/build).
+
+   procedure Gprinstall
+     (Release      : Releases.Release;
+      Project_File : Absolute_File;
+      Prefix       : Absolute_Path;
+      Recursive    : Boolean;
+      Quiet        : Boolean;
+      Force        : Boolean := Alire.Force;
+      Extra_Args   : AAA.Strings.Vector := AAA.Strings.Empty_Vector);
+   --  Launches
+   --  gprinstall [-f] -m -p [-r] \
+   --             --mode=usage -P Project_File --prefix=Prefix -- Extra_Args \
+   --             --install-name=Release.Milestone.Image \
+   --             --link-lib-dir=Prefix/bin
 
 end Alire.Spawn;

--- a/src/alire/os_windows/alire-platforms-folders__windows.adb
+++ b/src/alire/os_windows/alire-platforms-folders__windows.adb
@@ -9,7 +9,7 @@ package body Alire.Platforms.Folders is
    ----------
 
    function Home return Absolute_Path
-   is (OS_Lib.Getenv ("HOMEDRIVE") & OS_Lib.Getenv ("HOMEPATH"));
+   is (OS_Lib.Getenv ("USERPROFILE"));
 
    -----------
    -- Cache --

--- a/src/alr/alr-commands-install.ads
+++ b/src/alr/alr-commands-install.ads
@@ -14,11 +14,15 @@ package Alr.Commands.Install is
    function Switch_Parsing (This : Command)
                             return CLIC.Subcommand.Switch_Parsing_Kind
    is (CLIC.Subcommand.Parse_All);
-   --  For this command we want the args after -- to pass them to gprinstall
+   --  To keep things simple we don't forward switches to neither gprbuild nor
+   --  gprinstall, and any scenarios have to be set up via environment e.g.,
+   --  $ LIBRARY_TYPE=relocatable alr install <whatever>. We could improve on
+   --  this down the line.
 
    overriding
    procedure Execute (Cmd  : in out Command;
                       Args :        AAA.Strings.Vector);
+   --  Will both build + gprinstall, to ensure both see the same environment
 
    overriding
    function Long_Description (Cmd : Command)
@@ -41,5 +45,6 @@ private
    type Command is new Commands.Command with record
       Target : aliased GNAT.Strings.String_Access; -- Crate[version] to install
       Prefix : aliased GNAT.Strings.String_Access; -- Prefix for gprinstall
+      This   : aliased Boolean := False; -- To install the current workspace
    end record;
 end Alr.Commands.Install;

--- a/src/alr/alr-commands-install.ads
+++ b/src/alr/alr-commands-install.ads
@@ -39,12 +39,12 @@ package Alr.Commands.Install is
 
    overriding
    function Usage_Custom_Parameters (Cmd : Command) return String
-   is ("[switches] [crate[versions]]...");
+   is ("[[--info] | [crate[versions]]...]");
 
 private
    type Command is new Commands.Command with record
       Target : aliased GNAT.Strings.String_Access; -- Crate[version] to install
       Prefix : aliased GNAT.Strings.String_Access; -- Prefix for gprinstall
-      This   : aliased Boolean := False; -- To install the current workspace
+      Info   : aliased Boolean := False; -- Show prefix info
    end record;
 end Alr.Commands.Install;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -279,8 +279,9 @@ package body Alr.Commands is
    -- Requires_Valid_Session --
    ----------------------------
 
-   procedure Requires_Valid_Session (Cmd  : in out Command'Class;
-                                     Sync : Boolean := True) is
+   procedure Requires_Valid_Session (Cmd   : in out Command'Class;
+                                     Sync  : Boolean := True;
+                                     Error : String  := "") is
       use Alire;
 
       Unchecked : Alire.Roots.Optional.Root renames Cmd.Optional_Root;
@@ -315,8 +316,13 @@ package body Alr.Commands is
 
       if not Unchecked.Is_Valid then
          Raise_Checked_Error
-           (Alire.Errors.Wrap
-              ("Cannot continue with invalid session", Unchecked.Message));
+           (Alire.Errors.New_Wrapper
+            .Wrap
+              (if Error /= ""
+               then Error
+               else "Cannot continue with invalid session")
+            .Wrap (Unchecked.Message)
+            .Get);
       end if;
 
       Unchecked.Value.Check_Stored;

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -59,13 +59,14 @@ package Alr.Commands is
    --  Unless Force_Reload, if the index is not empty we no nothing. When
    --  strict, don't allow unknown values in enums.
 
-   procedure Requires_Valid_Session (Cmd          : in out Command'Class;
-                                     Sync         : Boolean := True);
+   procedure Requires_Valid_Session (Cmd   : in out Command'Class;
+                                     Sync  : Boolean := True;
+                                     Error : String := "");
    --  Verifies that a valid working dir is in scope. After calling it,
    --  Cmd.Root will be usable if alr was run inside a Root. If Sync, enforce
    --  that the manifest, lockfile and dependencies on disk are in sync, by
    --  performing a silent update. If not Sync, only a minimal empty lockfile
-   --  is created.
+   --  is created. If Error, replace the first generic error message with it.
 
    procedure Load (Cmd       : Command'Class;
                    Crate     : Alire.Crate_Name;

--- a/testsuite/drivers/asserts.py
+++ b/testsuite/drivers/asserts.py
@@ -10,6 +10,7 @@ import difflib
 
 from drivers.alr import run_alr
 from drivers.helpers import contents, lines_of
+from typing import List
 
 def indent(text, prefix='  '):
     """
@@ -81,3 +82,17 @@ def match_solution(regex, escape=False, whole=False):
                  (regex if not escape else re.escape(regex)) +
                  wrap,
                  p.out)
+
+def assert_installed(prefix : str, milestones : List[str]):
+    """
+    Check that installed releases match those given in milestones
+    """
+
+    p = run_alr("install", f"--prefix={prefix}", quiet=False)
+
+    milestones.sort()
+
+    assert_eq(f"Installation prefix found at {prefix}\n"
+              "Contents:\n"
+              "   " + "\n   ".join(milestones) + "\n",
+              p.out)

--- a/testsuite/drivers/asserts.py
+++ b/testsuite/drivers/asserts.py
@@ -88,7 +88,7 @@ def assert_installed(prefix : str, milestones : List[str]):
     Check that installed releases match those given in milestones
     """
 
-    p = run_alr("install", f"--prefix={prefix}", quiet=False)
+    p = run_alr("install", "--info", f"--prefix={prefix}", quiet=False)
 
     milestones.sort()
 

--- a/testsuite/drivers/helpers.py
+++ b/testsuite/drivers/helpers.py
@@ -14,7 +14,7 @@ import stat
 
 
 # Return the entries (sorted) under a given folder, both folders and files
-# Optionally, return only those matching regex
+# Optionally, return only those matching regex. Uses '/' always as separator.
 def contents(dir, regex=""):
     assert os.path.exists(dir), "Bad path for enumeration: {}".format(dir)
     if regex != "":
@@ -231,3 +231,12 @@ def md5sum(file):
             file_hash.update(chunk)
 
     return file_hash.hexdigest()
+
+
+def replace_in_file(filename : str, old : str, new : str):
+    """
+    Replace all occurrences of a string in a file
+    """
+    old_contents = content_of(filename)
+    with open(filename, "wt") as file:
+        file.write(old_contents.replace(old, new))

--- a/testsuite/tests/install/binary-release/test.py
+++ b/testsuite/tests/install/binary-release/test.py
@@ -5,7 +5,7 @@ Test deployment of a binary release and basic `alr install` use
 # NOTE: this test only runs on Linux
 
 from drivers.alr import run_alr, init_local_crate
-from drivers.asserts import assert_eq, assert_match
+from drivers.asserts import assert_eq, assert_match, assert_installed
 from subprocess import run
 
 import platform
@@ -15,15 +15,16 @@ if platform.system() != "Linux":
     print('SUCCESS')
     exit(0)
 
-PREFIX=f"--prefix={os.path.join(os.getcwd(), 'install')}"
+PREFIX=os.path.join(os.getcwd(), "install")
+PREFIX_ARG=f"--prefix={PREFIX}"
 
 # Check that the prefix is empty
-p = run_alr("install", PREFIX, quiet=False)
+p = run_alr("install", "--info", PREFIX_ARG, quiet=False)
 assert_match("There is no installation at prefix .*",
              p.out)
 
 # Install the binary crate
-p = run_alr("install", PREFIX, "crate", quiet=False)
+p = run_alr("install", PREFIX_ARG, "crate", quiet=False)
 assert_match("""Note: Deploying crate=1.0.0...
 Note: Installing crate=1.0.0...
 Success: Install to .* finished successfully in .* seconds.
@@ -38,28 +39,23 @@ assert_eq("Bin crate OK\n", p.stdout.decode())
 
 # Verify release cannot be reinstalled
 assert_match(".*Requested release crate=1.0.0 is already installed.*",
-             run_alr("install", PREFIX, "crate",
+             run_alr("install", PREFIX_ARG, "crate",
                      quiet=False, complain_on_error=False).out)
 
 # Verify another version cannot be installed
 assert_match(".*Requested release crate=0.1.0 has another version already installed:\n"
              ".*   crate=1.0.0.*",
-             run_alr("install", PREFIX, "crate=0.1.0",
+             run_alr("install", PREFIX_ARG, "crate=0.1.0",
                      quiet=False, complain_on_error=False).out)
 
 # Force install of the same crate and see no failure
-run_alr("install", PREFIX, "crate=0.1.0", force=True)
+run_alr("install", PREFIX_ARG, "crate=0.1.0", force=True)
 
 # Recheck output
 p = run(f"{os.getcwd()}/install/bin/crate", capture_output=True)
 assert_eq("Bin crate OK\n", p.stdout.decode())
 
 # Check contents of the prefix
-p = run_alr("install", PREFIX, quiet=False)
-assert_match("""Installation prefix found at .*
-Contents:
-   crate=0.1.0
-""",
-             p.out)
+assert_installed(PREFIX, ["crate=0.1.0"])
 
 print('SUCCESS')

--- a/testsuite/tests/install/binary-release/test.py
+++ b/testsuite/tests/install/binary-release/test.py
@@ -15,7 +15,7 @@ if platform.system() != "Linux":
     print('SUCCESS')
     exit(0)
 
-PREFIX=f"--prefix={os.getcwd()}/install"
+PREFIX=f"--prefix={os.path.join(os.getcwd(), 'install')}"
 
 # Check that the prefix is empty
 p = run_alr("install", PREFIX, quiet=False)
@@ -24,9 +24,9 @@ assert_match("There is no installation at prefix .*",
 
 # Install the binary crate
 p = run_alr("install", PREFIX, "crate", quiet=False)
-assert_eq("""Note: Deploying crate=1.0.0...
+assert_match("""Note: Deploying crate=1.0.0...
 Note: Installing crate=1.0.0...
-Note: Installation complete.
+Success: Install to .* finished successfully in .* seconds.
 """,
              p.out)
 
@@ -42,7 +42,8 @@ assert_match(".*Requested release crate=1.0.0 is already installed.*",
                      quiet=False, complain_on_error=False).out)
 
 # Verify another version cannot be installed
-assert_match(".*Requested release crate=0.1.0 has another version already installed: crate=1.0.0.*",
+assert_match(".*Requested release crate=0.1.0 has another version already installed:\n"
+             ".*   crate=1.0.0.*",
              run_alr("install", PREFIX, "crate=0.1.0",
                      quiet=False, complain_on_error=False).out)
 

--- a/testsuite/tests/install/default-location/test.py
+++ b/testsuite/tests/install/default-location/test.py
@@ -21,15 +21,15 @@ else:
 if on_windows():
     os.makedirs(os.path.join(os.environ["USERPROFILE"], ".cache", "alire", "msys64"))
 
-p = run_alr("install", quiet=False)
+p = run_alr("install", "--info", quiet=False)
 assert_eq(f"There is no installation at prefix {os.path.join(os.getcwd(), '.alire')}\n", 
           p.out)
 
 # Install a local crate to check prefix creation and contents at expected place
 init_local_crate()
-run_alr("install", "--this")
+run_alr("install")
 os.chdir("..")
-p = run_alr("install", quiet=False)
+p = run_alr("install", "--info", quiet=False)
 assert_eq(f"Installation prefix found at {os.path.join(os.getcwd(), '.alire')}\n"
           "Contents:\n"
           "   xxx=0.1.0-dev\n", 

--- a/testsuite/tests/install/default-location/test.py
+++ b/testsuite/tests/install/default-location/test.py
@@ -1,0 +1,39 @@
+"""
+Test installation to default location
+"""
+
+from drivers.alr import run_alr, init_local_crate
+from drivers.asserts import assert_eq
+from drivers.helpers import on_windows
+
+import os
+
+# Override HOME to our test location so it is pristine
+
+if on_windows():
+    os.environ["USERPROFILE"] = os.getcwd()
+else:
+    os.environ["HOME"] = os.getcwd()
+
+# Disable msys2 as the home change doesn't sit well with it and we don't need it here.
+# This is a workaround because trying to disable it via config doesn't work on 1st run:
+# run_alr("config", "--global", "--set", "msys2.do_not_install", "true")
+if on_windows():
+    os.makedirs(os.path.join(os.environ["USERPROFILE"], ".cache", "alire", "msys64"))
+
+p = run_alr("install", quiet=False)
+assert_eq(f"There is no installation at prefix {os.path.join(os.getcwd(), '.alire')}\n", 
+          p.out)
+
+# Install a local crate to check prefix creation and contents at expected place
+init_local_crate()
+run_alr("install", "--this")
+os.chdir("..")
+p = run_alr("install", quiet=False)
+assert_eq(f"Installation prefix found at {os.path.join(os.getcwd(), '.alire')}\n"
+          "Contents:\n"
+          "   xxx=0.1.0-dev\n", 
+          p.out)
+
+
+print('SUCCESS')

--- a/testsuite/tests/install/default-location/test.yaml
+++ b/testsuite/tests/install/default-location/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script

--- a/testsuite/tests/install/dynamic-linking/test.py
+++ b/testsuite/tests/install/dynamic-linking/test.py
@@ -19,14 +19,14 @@ os.environ["LIBRARY_TYPE"] = "relocatable"
 init_local_crate()
 init_local_crate(name="dep", binary=False, enter=False)
 alr_with("dep", path="dep")
-run_alr("install", PREFIX_ARG, "--this")
+run_alr("install", PREFIX_ARG)
 assert_installed(PREFIX, ["dep=0.1.0-dev", "xxx=0.1.0-dev"])
 
 # Installing a second binary with the same dependency should be OK
 
 init_local_crate(name="yyy")
 alr_with("dep", path="../dep")  # portable paths required for pins
-run_alr("install", PREFIX_ARG, "--this")
+run_alr("install", PREFIX_ARG)
 assert_installed(PREFIX, ["dep=0.1.0-dev", 
                           "xxx=0.1.0-dev",
                           "yyy=0.1.0-dev"])
@@ -41,7 +41,7 @@ if not on_windows():
                     "0.1.0-dev", "0.2.0")
     init_local_crate(name="zzz")
     alr_with("dep", path="../dep")
-    run_alr("install", PREFIX_ARG, "--this")
+    run_alr("install", PREFIX_ARG)
     assert_installed(PREFIX, ["dep=0.1.0-dev", 
                             "dep=0.2.0", 
                             "xxx=0.1.0-dev",

--- a/testsuite/tests/install/dynamic-linking/test.py
+++ b/testsuite/tests/install/dynamic-linking/test.py
@@ -1,0 +1,53 @@
+"""
+Test installation of dynamically linked executables
+"""
+
+from drivers.alr import run_alr, init_local_crate, alr_with, alr_manifest
+from drivers.asserts import assert_installed
+from drivers.helpers import replace_in_file, on_windows
+
+import os
+
+PREFIX=os.path.join(os.getcwd(), "install")
+PREFIX_ARG=f"--prefix={PREFIX}"
+
+# Init a binary crate, add a dependency, and with dynamic linking both should
+# appear as installed
+
+os.environ["LIBRARY_TYPE"] = "relocatable"
+
+init_local_crate()
+init_local_crate(name="dep", binary=False, enter=False)
+alr_with("dep", path="dep")
+run_alr("install", PREFIX_ARG, "--this")
+assert_installed(PREFIX, ["dep=0.1.0-dev", "xxx=0.1.0-dev"])
+
+# Installing a second binary with the same dependency should be OK
+
+init_local_crate(name="yyy")
+alr_with("dep", path="../dep")  # portable paths required for pins
+run_alr("install", PREFIX_ARG, "--this")
+assert_installed(PREFIX, ["dep=0.1.0-dev", 
+                          "xxx=0.1.0-dev",
+                          "yyy=0.1.0-dev"])
+
+# Installing a second library version should be OK (not on Windows)
+# gprinstall for Windows do not uses Library_Version to create e.g.
+# libBlah.so.1 -> libBlah.dll.1. All libraries are simply libBlah.dll
+
+if not on_windows():
+    os.chdir("..")
+    replace_in_file(os.path.join("dep", alr_manifest()),
+                    "0.1.0-dev", "0.2.0")
+    init_local_crate(name="zzz")
+    alr_with("dep", path="../dep")
+    run_alr("install", PREFIX_ARG, "--this")
+    assert_installed(PREFIX, ["dep=0.1.0-dev", 
+                            "dep=0.2.0", 
+                            "xxx=0.1.0-dev",
+                            "yyy=0.1.0-dev",
+                            "zzz=0.1.0-dev"
+                            ])
+
+print('SUCCESS')
+

--- a/testsuite/tests/install/dynamic-linking/test.yaml
+++ b/testsuite/tests/install/dynamic-linking/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script

--- a/testsuite/tests/install/executable-dependency/test.py
+++ b/testsuite/tests/install/executable-dependency/test.py
@@ -20,7 +20,7 @@ os.environ["LIBRARY_TYPE"] = "static" # It's the default, but just in case
 init_local_crate()
 init_local_crate(name="dep", binary=True, enter=False)
 alr_with("dep", path="dep")
-run_alr("install", PREFIX_ARG, "--this")
+run_alr("install", PREFIX_ARG)
 
 # Check gprbuild manifests
 assert_installed(PREFIX, ["dep=0.1.0-dev",
@@ -43,7 +43,7 @@ replace_in_file(os.path.join("xxx", "dep", alr_manifest()),
                 "0.1.0-dev", "0.2.0")
 init_local_crate(name="yyy")
 alr_with("dep", path="../xxx/dep")
-p = run_alr("install", "--this", PREFIX_ARG, complain_on_error=False)
+p = run_alr("install", PREFIX_ARG, complain_on_error=False)
 assert_match(".*Release dep=0.2.0 conflicts with already installed dep=0.1.0-dev.*",
              p.out)
 

--- a/testsuite/tests/install/executable-dependency/test.py
+++ b/testsuite/tests/install/executable-dependency/test.py
@@ -1,0 +1,50 @@
+"""
+Test installation of executables in dependencies
+"""
+
+from drivers.alr import run_alr, init_local_crate, alr_with, alr_manifest
+from drivers.asserts import assert_contents, assert_installed, assert_match
+from drivers.helpers import on_windows, replace_in_file
+
+import os
+
+START=os.getcwd()
+PREFIX=os.path.join(os.getcwd(), "install")
+PREFIX_ARG=f"--prefix={PREFIX}"
+
+# Init a binary crate, add an executable dependency, and both should
+# end being installed.
+
+os.environ["LIBRARY_TYPE"] = "static" # It's the default, but just in case
+
+init_local_crate()
+init_local_crate(name="dep", binary=True, enter=False)
+alr_with("dep", path="dep")
+run_alr("install", PREFIX_ARG, "--this")
+
+# Check gprbuild manifests
+assert_installed(PREFIX, ["dep=0.1.0-dev",
+                          "xxx=0.1.0-dev"])
+
+ext = (".exe" if on_windows() else "")
+
+# Check actual executables in place
+os.chdir(os.path.join("..", "install", "bin"))  # simplifies paths in check
+assert_contents(".", 
+                [f"./dep{ext}",
+                 f"./xxx{ext}"])
+
+# Attempting to install a different version of the dependency should fail,
+# since only a single version of an executable can live in a prefix
+
+os.chdir(START)
+
+replace_in_file(os.path.join("xxx", "dep", alr_manifest()),
+                "0.1.0-dev", "0.2.0")
+init_local_crate(name="yyy")
+alr_with("dep", path="../xxx/dep")
+p = run_alr("install", "--this", PREFIX_ARG, complain_on_error=False)
+assert_match(".*Release dep=0.2.0 conflicts with already installed dep=0.1.0-dev.*",
+             p.out)
+
+print("SUCCESS")

--- a/testsuite/tests/install/executable-dependency/test.yaml
+++ b/testsuite/tests/install/executable-dependency/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script

--- a/testsuite/tests/install/static-linking/test.py
+++ b/testsuite/tests/install/static-linking/test.py
@@ -1,0 +1,24 @@
+"""
+Test installation of statically linked executables
+"""
+
+from drivers.alr import run_alr, init_local_crate, alr_with
+from drivers.asserts import assert_installed
+
+import os
+
+PREFIX=os.path.join(os.getcwd(), "install")
+PREFIX_ARG=f"--prefix={PREFIX}"
+
+# Init a binary crate, add a dependency, and by default with static linking
+# only the root dependency should show as installed
+
+os.environ["LIBRARY_TYPE"] = "static" # It's the default, but just in case
+
+init_local_crate()
+init_local_crate(name="dep", binary=False, enter=False)
+alr_with("dep", path="dep")
+run_alr("install", PREFIX_ARG, "--this")
+assert_installed(PREFIX, ["xxx=0.1.0-dev"])
+
+print('SUCCESS')

--- a/testsuite/tests/install/static-linking/test.py
+++ b/testsuite/tests/install/static-linking/test.py
@@ -18,7 +18,7 @@ os.environ["LIBRARY_TYPE"] = "static" # It's the default, but just in case
 init_local_crate()
 init_local_crate(name="dep", binary=False, enter=False)
 alr_with("dep", path="dep")
-run_alr("install", PREFIX_ARG, "--this")
+run_alr("install", PREFIX_ARG)
 assert_installed(PREFIX, ["xxx=0.1.0-dev"])
 
 print('SUCCESS')

--- a/testsuite/tests/install/static-linking/test.yaml
+++ b/testsuite/tests/install/static-linking/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
This one adds the ability to install a release locally available.

It's a bit more involved that just doing a blind `gprinstall -f -r` because with the info at hand we have easy ways to catch obvious problems like conflicting executables, and we can present more accurate info on what's going on during install. 

Everything ends in `<prefix>/bin` in usage mode, which means that only executables and dynamic libraries are installed, bypassing all the problems we discussed.