### PR TITLE
Run testsuite on selfbuilds too

### DIFF
--- a/.github/workflows/ci-toolchain.yml
+++ b/.github/workflows/ci-toolchain.yml
@@ -1,7 +1,6 @@
 name: CI self+toolchain
 # Build Alire with `alr build` and using a toolchain installed from Alire
-# NOTE that tests are not run, this test only checks alr is able to self build.
-# (Should we also run self-tests here or is it overkill?)
+# The `alr` being tested is the one which is being submitted in the PR
 
 on:
   pull_request:
@@ -14,47 +13,81 @@ on:
 jobs:
 
   build:
+
     name: ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: 
+        os:
           - macos-10.15
           - ubuntu-latest
           - windows-latest
 
     steps:
     - name: Check out
-      uses: actions/checkout@v2
-
-    - uses: actions/cache@v2
+      uses: actions/checkout@v3
       with:
-        path: ./cache/gnat-ce-2020
-        key: ${{ runner.os }}-gnat-ce-2020
+        submodules: true
 
-    - name: Install toolchain
-      uses: ada-actions/toolchain@ce2020 # macOS hasn't 2021
-      with:
-        distrib: community
-        install_dir: ./cache/gnat-ce-2020
+    # Use a stock alr to make the latest toolchain available
 
-    - name: Build alr with default indexed toolchain
-      uses: alire-project/setup-alire@v1
+    - uses: alire-project/setup-alire@v2
       with:
-        branch: master
+        toolchain: --disable-assistant
+        version: nightly
+
+    - name: Install latest toolchain
+      run: |
+        alr install gprbuild gnat_native --prefix=tools
+
+    - name: Add toolchain to path (!Windows)
+      if: matrix.os != 'windows-latest'
+      run: |
+        echo "$PWD/tools/bin" >> $GITHUB_PATH
+
+    - name: Add toolchain to path (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        $Target = Join-Path (Get-Location) "\tools\bin"
+        Add-Content $env:GITHUB_PATH $Target
+
+    - name: Build alr with default toolchain
+      shell: bash
+      run: dev/build.sh
+
+    # We can start using the alr we just built
+
+    - name: Update dependencies 
+      run: ./bin/alr -n update
 
     - name: Show dependencies/pins
-      run: alr -n -q with --solve || alr -n -v -d with --solve
+      run: ./bin/alr -n -q with --solve || ./bin/alr -n -v -d with --solve
 
     - name: Show build environment
-      run: alr -n printenv
+      run: ./bin/alr -n printenv
 
-    - run: alr -n build
+    - shell: bash
+      run: mv ./bin ./bin-old 
+      # Windows doesn't allow to replace a running exe so the next command fails otherwise
 
-    # For some reason I cannot pinpoint, the Windows build is seeing two
-    # different environments that mess things up. The build succeeds though.
+    - name: SELF-BUILD
+      run: ./bin-old/alr -n build
+
     - name: Show built version
-      if: matrix.os != 'windows-latest'
       run: ./bin/alr -n version
+
+    # Run the testsuite with the just build alr. The testsuite picks the proper
+    # alr in the ./bin/alr location.
+
+    - name: Install Python 3.x # required by testsuite
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install e3
+      run: pip install --upgrade e3-testsuite
+
+    - name: Run testsuite
+      run: cd testsuite; ./run.py -E

--- a/alire.toml
+++ b/alire.toml
@@ -46,7 +46,8 @@ windows = { ALIRE_OS = "windows" }
 # Some dependencies require precise versions during the development cycle:
 [[pins]]
 aaa = { url = "https://github.com/mosteo/aaa", commit = "906d9eaf4fb8efabfbc3d8cfb34d04ceec340e13" }
-clic = { url = "https://github.com/alire-project/clic", commit = "769f7f4af71e4c2d3b37245b175c038572150258" }
+ada_toml = { url = "https://github.com/mosteo/ada-toml", commit = "da4e59c382ceb0de6733d571ecbab7ea4919b33d" }
+clic = { url = "https://github.com/alire-project/clic", commit = "102bc38c7e9469112145e12100449664b5c74764" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "92bb91130a9ec628b4c48b7ef9fe7f24d9dc25fa" }
 semantic_versioning = { url = "https://github.com/alire-project/semantic_versioning", commit = "c2345fca8b685d6d3fc9334fac81140a0cdbea89" }
 simple_logging = { url = "https://github.com/alire-project/simple_logging", commit = "703b15ba6e2392951b65a484ce703209750dd0fc" }

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -240,15 +240,24 @@ package body Alire.Roots is
             --  For dependencies that appear in the solution as releases, get
             --  their project files in the current environment.
 
-            if Sol.Releases.Contains (Dep.Crate)
-              and then
-                Sol.Releases.Element (Dep.Crate).Auto_GPR_With
-            then
-               for File of Sol.Releases.Element (Dep.Crate).Project_Files
-                 (This.Environment, With_Path => False)
-               loop
-                  Files.Include (File);
-               end loop;
+            if Sol.Releases.Contains (Dep.Crate) then
+               if Sol.Releases.Element (Dep.Crate).Auto_GPR_With then
+                  for File of Sol.Releases.Element (Dep.Crate).Project_Files
+                    (This.Environment, With_Path => False)
+                  loop
+                     Files.Include (File);
+                  end loop;
+               end if;
+
+            elsif Sol.Links.Contains (Dep.Crate) then
+
+               --  If a dependency appears as a link but not as a release, this
+               --  means it is a "raw" link (no target manifest); we cannot
+               --  know its project files so we default to using the crate
+               --  name.
+
+               Files.Include (Dep.Crate.As_String & ".gpr");
+
             end if;
          end loop;
       end return;


### PR DESCRIPTION
Run the testsuite after `alr build`ing ourselves. This ensures no only that `alire.toml` allows building, but that the dependency versions are proper.

Also start using `setup-alire@v2` which should result in speed-up.

Edit: also includes a bugfix for pinned crates without a manifest that arose when pinning `ada-toml`.