### PR TITLE
Write Warn/Error traces to stderr by default

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -50,5 +50,5 @@ ada_toml = { url = "https://github.com/mosteo/ada-toml", commit = "da4e59c382ceb
 clic = { url = "https://github.com/alire-project/clic", commit = "102bc38c7e9469112145e12100449664b5c74764" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "92bb91130a9ec628b4c48b7ef9fe7f24d9dc25fa" }
 semantic_versioning = { url = "https://github.com/alire-project/semantic_versioning", commit = "c2345fca8b685d6d3fc9334fac81140a0cdbea89" }
-simple_logging = { url = "https://github.com/alire-project/simple_logging", commit = "703b15ba6e2392951b65a484ce703209750dd0fc" }
+simple_logging = { url = "https://github.com/alire-project/simple_logging", commit = "2b62010b6d66c106c65eb9ae604aabcf64522fac" }
 stopwatch = { url = "https://github.com/mosteo/stopwatch", commit = "f607a63b714f09bbf6126de9851cbc21cf8666c9" }

--- a/src/alire/alire.adb
+++ b/src/alire/alire.adb
@@ -115,15 +115,18 @@ package body Alire is
    -----------------
 
    procedure Put_Warning (Text           : String;
-                          Level          : Trace.Levels := Info;
+                          Level          : Trace.Levels := Warning;
                           Disable_Config : String := "")
    is
+      Prefix : constant String :=
+                 (if Level = Warning
+                  then "" -- because the logging will add its own "Warning:"
+                  else TTY.Text_With_Fallback (TTY.Warn (U ("⚠ ")),
+                                               "Warning: "));
    begin
-      Trace.Log (TTY.Text_With_Fallback (TTY.Warn (U ("⚠ ")), "warning: ")
-                 & Text,
-                 Level);
+      Trace.Log (Prefix & Text, Level);
       if Disable_Config /= "" then
-         Trace.Log (TTY.Text_With_Fallback (TTY.Warn (U ("⚠ ")), "warning: ")
+         Trace.Log (Prefix
                     & "You can disable this warning with configuration key '"
                     & TTY.Emph (Disable_Config) & "'",
                     Level);

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -269,7 +269,7 @@ package Alire with Preelaborate is
    --  Prepend Text with a blue "🛈", or "Note: " & if no color/tty.
 
    procedure Put_Warning (Text           : String;
-                          Level          : Trace.Levels := Info;
+                          Level          : Trace.Levels := Warning;
                           Disable_Config : String := "");
    --  Prepend Text with a yellow "⚠", or "Warning: " if no color/tty. If
    --  Disable_setting /= "", append a line informing about how to disable

--- a/src/alire/alire_early_elaboration.adb
+++ b/src/alire/alire_early_elaboration.adb
@@ -160,6 +160,9 @@ package body Alire_Early_Elaboration is
    end TTY_Detection;
 
 begin
+   Simple_Logging.Stdout_Level := Simple_Logging.Info;
+   --  Display warnings and errors to stderr
+
    TTY_Detection;
    Early_Switch_Detection;
 end Alire_Early_Elaboration;


### PR DESCRIPTION
Bump dependency on `Simple_Logging` and minor tweak to warning text generation.

Fixes #1294