### PR TITLE
Add Alire.Platforms.Folders.Home for FreeBSD

### DIFF
--- a/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
+++ b/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
@@ -16,4 +16,10 @@ package body Alire.Platforms.Folders is
 
    function Config return String is (Common.XDG_Config_Folder);
 
+   ----------
+   -- Home --
+   ----------
+
+   function Home return Absolute_Path is (Common.Unix_Home_Folder);
+
 end Alire.Platforms.Folders;


### PR DESCRIPTION
This missing function caused compilation to fail with ALIRE_OS=freebsd