### PR TITLE
New `--nested` switch for `alr show`

### DIFF
--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -664,32 +664,84 @@ package body Alire.Directories is
                             Doing   : access procedure
                               (Item : Ada.Directories.Directory_Entry_Type;
                                Stop : in out Boolean);
-                            Recurse : Boolean := False)
+                            Recurse : Boolean := False;
+                            Spinner : Boolean := False)
    is
       use Ada.Directories;
 
+      Visited : AAA.Strings.Set;
+      --  To avoid infinite recursion in case of softlinks pointed to parent
+      --  folders
+
+      Progress : Simple_Logging.Ongoing :=
+                   Simple_Logging.Activity (Text  => "Exploring " & Start,
+                                            Level => (if Spinner
+                                                      then Info
+                                                      else Debug));
+
+      procedure Go_Down (Item : Directory_Entry_Type);
+
+      procedure Traverse_Tree_Internal
+        (Start   : Any_Path;
+         Doing   : access procedure
+           (Item : Ada.Directories.Directory_Entry_Type;
+            Stop : in out Boolean);
+         Recurse : Boolean := False)
+      is
+         pragma Unreferenced (Doing, Recurse);
+      begin
+         Search (Start,
+                 "",
+                 (Directory => True, Ordinary_File => True, others => False),
+                 Go_Down'Access);
+      end Traverse_Tree_Internal;
+
       procedure Go_Down (Item : Directory_Entry_Type) is
-         Stop : Boolean := False;
+         Stop  : Boolean := False;
+         Prune : Boolean := False;
       begin
          if Simple_Name (Item) /= "." and then Simple_Name (Item) /= ".." then
-            Doing (Item, Stop);
+            begin
+               Doing (Item, Stop);
+            exception
+               when Traverse_Tree_Prune_Dir =>
+                  Prune := True;
+            end;
             if Stop then
                return;
             end if;
 
-            if Recurse and then Kind (Item) = Directory then
-               Traverse_Tree (Start / Simple_Name (Item), Doing, Recurse);
+            if not Prune and then Recurse and then Kind (Item) = Directory then
+               declare
+                  Normal_Name : constant String
+                    :=
+                      String (GNATCOLL.VFS.Full_Name
+                              (VFS.New_Virtual_File (Full_Name (Item)),
+                                   Normalize        => True,
+                                   Resolve_Links    => True).all);
+               begin
+                  if Visited.Contains (Normal_Name) then
+                     Trace.Debug ("Not revisiting " & Normal_Name);
+                  else
+                     Visited.Insert (Normal_Name);
+                     if Spinner then
+                        Progress.Step ("Exploring .../" & Simple_Name (Item));
+                     end if;
+                     Traverse_Tree_Internal (Normal_Name, Doing, Recurse);
+                  end if;
+               end;
+            elsif Prune and then Kind (Item) = Directory then
+               Trace.Debug ("Skipping dir: " & Full_Name (Item));
+            elsif Prune and then Kind (Item) /= Directory then
+               Trace.Warning ("Pruning of non-dir entry has no effect: "
+                              & Full_Name (Item));
             end if;
          end if;
       end Go_Down;
 
    begin
-      Trace.Debug ("Traversing folder: " & Start);
-
-      Search (Start,
-              "",
-              (Directory => True, Ordinary_File => True, others => False),
-              Go_Down'Access);
+      Trace.Debug ("Traversing folder: " & Adirs.Full_Name (Start));
+      Traverse_Tree_Internal (Start, Doing, Recurse);
    end Traverse_Tree;
 
    ---------------

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -90,14 +90,22 @@ package Alire.Directories is
    --  If the file exists, update last edition time; otherwise create it. If
    --  File denotes anything else than a regular file, raise.
 
+   Traverse_Tree_Prune_Dir : exception;
+   --  In Traverse_Tree, the Doing procedure can raise this exception to
+   --  signal that a directory must not be entered, but without stopping
+   --  the traversal.
+
    procedure Traverse_Tree (Start   : Any_Path;
                             Doing   : access procedure
                               (Item : Ada.Directories.Directory_Entry_Type;
                                Stop : in out Boolean);
-                            Recurse : Boolean := False);
+                            Recurse : Boolean := False;
+                            Spinner : Boolean := False);
    --  Traverse all items in a folder, optionally recursively If recursively,
    --  the directory entry is passed before entering it "." and ".." are
-   --  ignored. If Stop is set to True, traversal will not continue.
+   --  ignored. If Stop is set to True, traversal will not continue. See also
+   --  the comments in Traverse_Tree_Prune_Dir. If Spinner, show a busy spinner
+   --  with the current dir being explored.
 
    function Tree_Size (Path : Any_Path) return Ada.Directories.File_Size;
    --  Size of files under a given point, in bytes. Will return 0 for an

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -793,7 +793,8 @@ package body Alire.Roots is
                --  If the release was newly deployed, we can inform about its
                --  nested crates now.
 
-               if not Was_There then
+               if not Was_There and then not CLIC.User_Input.Not_Interactive
+               then
                   Print_Nested_Crates (This.Release_Base (Rel.Name));
                end if;
             end if;

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -264,6 +264,10 @@ package Alire.Roots is
    procedure Generate_Configuration (This : in out Root);
    --  Generate or re-generate the crate configuration files
 
+   procedure Print_Nested_Crates (Path : Any_Path);
+   --  Look for nested crates below the given path and print a summary of
+   --  path/milestone:description for each one found. Won't enter `alire` dirs.
+
    --  Files and folders derived from the root path (this obsoletes Alr.Paths):
 
    function Working_Folder (This : Root) return Absolute_Path;

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -164,7 +164,10 @@ package body Alr.Commands.Get is
             Alire.Config.Edit.Set_Locally
               (Alire.Config.Keys.Update_Manually, "true");
 
-            Alire.Roots.Print_Nested_Crates (Cmd.Root.Path);
+            if not CLIC.User_Input.Not_Interactive then
+               Alire.Roots.Print_Nested_Crates (Cmd.Root.Path);
+            end if;
+
             return;
          end if;
 

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -163,6 +163,8 @@ package body Alr.Commands.Get is
                           " use `alr update` to apply dependency changes");
             Alire.Config.Edit.Set_Locally
               (Alire.Config.Keys.Update_Manually, "true");
+
+            Alire.Roots.Print_Nested_Crates (Cmd.Root.Path);
             return;
          end if;
 
@@ -216,6 +218,8 @@ package body Alr.Commands.Get is
                  Level => (if not Cmd.Build or else Build_OK
                            then Info
                            else Warning));
+
+      Alire.Roots.Print_Nested_Crates (Cmd.Root.Path);
 
       if Diff.Contains_Changes then
          Trace.Info ("Dependencies were solved as follows:");

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -219,7 +219,9 @@ package body Alr.Commands.Get is
                            then Info
                            else Warning));
 
-      Alire.Roots.Print_Nested_Crates (Cmd.Root.Path);
+      if not CLIC.User_Input.Not_Interactive then
+         Alire.Roots.Print_Nested_Crates (Cmd.Root.Path);
+      end if;
 
       if Diff.Contains_Changes then
          Trace.Info ("Dependencies were solved as follows:");

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -280,6 +280,15 @@ package body Alr.Commands.Show is
    begin
       Cmd.Validate (Args);
 
+      --  Early case, --nested doesn't require either root or argument
+
+      if Cmd.Nested then
+         Alire.Roots.Print_Nested_Crates (Alire.Directories.Current);
+         return;
+      end if;
+
+      --  Rest of cases require either being inside a root or a crate name
+
       declare
          Allowed : constant Alire.Dependencies.Dependency :=
            (if Args.Count = 1
@@ -407,6 +416,10 @@ package body Alr.Commands.Show is
       Define_Switch (Config,
                      Cmd.Jekyll'Access,
                      "", "--jekyll", "Enable Jekyll output format");
+
+      Define_Switch (Config,
+                     Cmd.Nested'Access,
+                     "", "--nested", "Show info on nested crates");
    end Setup_Switches;
 
    --------------
@@ -421,10 +434,10 @@ package body Alr.Commands.Show is
       end if;
 
       if Args.Count = 0 then
-         if Alire.Root.Current.Outside then
+         if Alire.Root.Current.Outside and not Cmd.Nested then
             Reportaise_Wrong_Arguments
               ("Cannot proceed without a crate name");
-         else
+         elsif not Cmd.Nested then
             Cmd.Requires_Valid_Session;
          end if;
       end if;
@@ -441,7 +454,7 @@ package body Alr.Commands.Show is
       if Cmd.Dependents.all /= "unset" then
          if Alire.Utils.Count_True ((Cmd.Detect, Cmd.Detail, Cmd.External,
                                      Cmd.Graph, Cmd.Solve, Cmd.System,
-                                     Cmd.Tree, Cmd.Jekyll)) > 0
+                                     Cmd.Tree, Cmd.Jekyll, Cmd.Nested)) > 0
          then
             Reportaise_Wrong_Arguments
               ("Switch --dependents is not compatible with other switches");

--- a/src/alr/alr-commands-show.ads
+++ b/src/alr/alr-commands-show.ads
@@ -27,7 +27,7 @@ package Alr.Commands.Show is
 
    overriding function Usage_Custom_Parameters (Cmd : Command) return String is
      ("[<crate>[allowed versions]] [--system] [--external[-detect]]"
-      & " | --graph | --jekyll | --solve | --tree "
+      & " | --graph | --jekyll | --solve | --tree | --nested"
       & "| --dependents[=direct|shortest|all]");
 
 private
@@ -45,6 +45,7 @@ private
       System     : aliased Boolean := False;
       Tree       : aliased Boolean := False;
       Jekyll     : aliased Boolean := False;
+      Nested     : aliased Boolean := False;
    end record;
 
 end Alr.Commands.Show;

--- a/testsuite/tests/show/nested/test.py
+++ b/testsuite/tests/show/nested/test.py
@@ -1,0 +1,31 @@
+"""
+Test working of `alr show --nested`
+"""
+
+from drivers.alr import run_alr, init_local_crate
+from drivers.asserts import assert_eq, assert_match
+
+import os
+
+#  We create a crate below us; this should be detected
+
+init_local_crate(enter=False)
+assert_match(".*Found 1 nested crate in .*:\n"
+             r"   xxx/xxx=0.1.0-dev: \(no description\)\n",
+             run_alr("show", "--nested", quiet=False).out)
+
+# After entering the crate, it is no longer nested and shouldn't be detected
+
+os.chdir("xxx")
+assert_match("\s*",
+             run_alr("show", "--nested", quiet=False).out)
+
+# If we initialize another crate without entering it, it should again be
+# detected
+
+init_local_crate(name="yyy", enter=False)
+assert_match(".*Found 1 nested crate in .*:\n"
+             r"   yyy/yyy=0.1.0-dev: \(no description\)\n",
+             run_alr("show", "--nested", quiet=False).out)
+
+print('SUCCESS')

--- a/testsuite/tests/show/nested/test.yaml
+++ b/testsuite/tests/show/nested/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
Shows a summary of crates found under the current directory. The purpose is to raise awareness of demos, tests, examples, etc. in the crates, but it may also come in handy to locate local crates in general.

Example in my dev folder:
```
$ alr show --nested
ⓘ Found 80 nested crates in /home/user/prog:
   ...
   wordle_ada/wordle=0.1.0: Wordle for the terminal
   wordlist_ada/wordlist=0.1.3: An English word list
   wordlist_ada/demo/demo=0.1.0-dev: Shiny new project
   yeison/yeison=0.1.0-dev: A JSON-like data structure using Ada 2022 features
   yeison/demo/demo=0.0.0: Shiny new project
$ cd wordlist_ada/
$ alr show --nested
ⓘ Found 1 nested crate in /home/user/prog/wordlist_ada:
   demo/demo=0.1.0-dev: Shiny new project
```
Automatically invoked after `alr get` and `alr with` when interactive:
```
$ cd /tmp
$ alr get ansiada
ⓘ Deploying ansiada=1.0.0...
ansiada=1.0.0 successfully retrieved.
ⓘ Found 1 nested crate in /tmp/ansiada_1.0.0_dc770a5a:
   demo/demo=0.1.0-dev: Ansiada demo
There are no dependencies.
```