### PR TITLE
More explicit identifier error message

### DIFF
--- a/src/alire/alire.adb
+++ b/src/alire/alire.adb
@@ -180,7 +180,11 @@ package body Alire is
            & " with 'alr help identifiers'";
       end if;
 
-      return +Err;
+      if Err /= "" then
+         return "Invalid name '" & Utils.TTY.Name (S) & "': " & (+Err);
+      else
+         return "";
+      end if;
    end Error_In_Name;
 
    -------------------


### PR DESCRIPTION
Say the offending identifier before the diagnosis.

Fixes #1257 