### PR TITLE
Update getting-started.md

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -14,7 +14,7 @@ This may be done for the duration of a terminal session by running the command b
 ```bash
 $ export PATH="<PATH_TO_EXTRACTED>/bin/:$PATH"
 ```
-Those wanting to keep this path permanently in their `PATH` environment may do so by pasting the above command into the .bashrc file of their user's account.
+Those wanting to keep this path permanently in their `PATH` environment may do so by pasting the above command into the `.profile` file of their user's account.
 
 Alire provides GNAT toolchains hosted on x86-64 for Linux. If those toolchains do not 
 work for you, or if you are on another host architecture like ARM, you have the option 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -9,9 +9,9 @@ repository](https://github.com/alire-project/alire/releases).
 
 On Linux, `Alire` is simply provided in an archive.
 
-Once the archive is extracted you have to add `alr` in the environment `PATH`:
+Once the archive is extracted you have to add `alr` in the environment `PATH`in the .bashrc file of the user's home directory:
 ```bash
-$ export PATH=<PATH_TO_EXTRACTED>/bin/:$PATH
+$ export PATH="<PATH_TO_EXTRACTED>/bin/:$PATH"
 ```
 
 Alire provides GNAT toolchains hosted on x86-64 for Linux. If those toolchains do not 
@@ -39,7 +39,7 @@ On macOS, `Alire` is simply provided in an archive.
 
 Once the archive is extracted you have to add `alr` in the environment `PATH`:
 ```bash
-$ export PATH=<PATH_TO_EXTRACTED>/bin/:$PATH
+$ export PATH="<PATH_TO_EXTRACTED>/bin/:$PATH"
 ```
 
 If you try to run it on recent versions of macOS, you will get a popup saying 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -9,10 +9,12 @@ repository](https://github.com/alire-project/alire/releases).
 
 On Linux, `Alire` is simply provided in an archive.
 
-Once the archive is extracted you have to add `alr` in the environment `PATH`in the .bashrc file of the user's home directory:
+Once the archive is extracted you have to add `alr` in the environment `PATH` .
+This may be done for the duration of a terminal session by running the command below: 
 ```bash
 $ export PATH="<PATH_TO_EXTRACTED>/bin/:$PATH"
 ```
+Those wanting to keep this path permanently in their `PATH` environment may do so by pasting the above command into the .bashrc file of their user's account.
 
 Alire provides GNAT toolchains hosted on x86-64 for Linux. If those toolchains do not 
 work for you, or if you are on another host architecture like ARM, you have the option 


### PR DESCRIPTION
Lines 12 - 15.

More clarity on how to add PATH entry for Alire ecosystem client installed on a user's local Linux machine.  
PATH value was missing the double quotes that _may_ be needed when file paths contain spaces, e.g. /home/me/ada stuff/alr/bin.