### PR TITLE
Actually use the cache location for shared releases

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,11 @@
 {
-    "ada.projectFile": "alr_env.gpr"
+    "ada.projectFile": "alr_env.gpr",
+    "cSpell.words": [
+        "alire",
+        "rlimit"
+    ],
+    "ada.defaultCharset": "utf-8",
+    "ada.scenarioVariables": {
+        ALIRE_OS="linux",
+    }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,10 +8,7 @@
 				"$ada"
 			],
 			"label": "Alire: Build alr",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
+			"group": "build"
 		},
 		{
 			"type": "shell",
@@ -19,7 +16,7 @@
 			"problemMatcher": [
 				"$ada"
 			],
-			"label": "Alire: Compile current file",
+			"label": "Alire: Compile current file"
 		},
 		{
 			"type": "shell",
@@ -27,7 +24,7 @@
 			"problemMatcher": [
 				"$ada"
 			],
-			"label": "Alire: Clean all projects",
+			"label": "Alire: Clean all projects"
 		},
 		{
 			"type": "shell",

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -4,7 +4,20 @@ This document is a development diary summarizing changes in `alr` that notably
 affect the user experience. It is intended as a one-stop point for users to
 stay on top of `alr` new features.
 
-## Release 1.3-dev
+## Release `1.3-dev`
+
+### Binary releases moved to system cache from system config directory
+
+PR [#1349](https://github.com/alire-project/alire/pull/1349)
+
+Alire was storing large binary releases like compilers in the config location,
+which is against best practices.
+
+Users are advised to delete the old location to recover disk space, or to
+manually move the contents to avoid redownloading toolchains.
+
+- Old location: `<user home>/.config/alire/cache`
+- New location: `<user home>/.cache/alire`
 
 ### Installation of indexed crates
 
@@ -168,7 +181,7 @@ PR [#1080](https://github.com/alire-project/alire/pull/1080)
 this PR this was always a development build. Now, the last profile used during
 an `alr build` will be reused.
 
-## Release 1.2
+## Release `1.2`
 
 ### New subcommand for listing and manual triggering of actions
 

--- a/src/alire/alire-config-edit.adb
+++ b/src/alire/alire-config-edit.adb
@@ -171,6 +171,13 @@ package body Alire.Config.Edit is
       end if;
    end Set_Path;
 
+   -----------------------
+   -- Is_At_Default_Dir --
+   -----------------------
+
+   function Is_At_Default_Dir return Boolean
+   is (Path = Platforms.Folders.Config);
+
    -------------------
    -- Valid_Builtin --
    -------------------

--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -36,6 +36,9 @@ package Alire.Config.Edit is
    procedure Set_Path (Path : Absolute_Path);
    --  Override global config folder path
 
+   function Is_At_Default_Dir return Boolean;
+   --  Says if we are using the default config location (no -c or env override)
+
    function Indexes_Directory return Absolute_Path is (Path / "indexes");
 
    function Filepath (Lvl : Level) return Absolute_Path

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -39,15 +39,14 @@ package Alire.Directories is
    procedure Create_Tree (Path : Any_Path);
    --  Create Path and all necessary intermediate folders
 
-   procedure Delete_Tree (Path : Any_Path);
-   --  Equivalent to Ensure_Deletable + Ada.Directories.Delete_Tree
-
    procedure Ensure_Deletable (Path : Any_Path);
    --  In Windows, git checkouts are created with read-only file that do not
    --  sit well with Ada.Directories.Delete_Tree.
 
    procedure Force_Delete (Path : Any_Path);
-   --  Calls Ensure_Deletable and then Adirs.Delete_Tree
+   --  Calls Ensure_Deletable and then uses GNATCOLL.VFS deletion
+
+   procedure Delete_Tree (Path : Any_Path) renames Force_Delete;
 
    function Find_Files_Under (Folder    : String;
                               Name      : String;
@@ -78,7 +77,8 @@ package Alire.Directories is
 
    procedure Merge_Contents (Src, Dst              : Any_Path;
                              Skip_Top_Level_Files  : Boolean;
-                             Fail_On_Existing_File : Boolean);
+                             Fail_On_Existing_File : Boolean;
+                             Remove_From_Source    : Boolean);
    --  Move all contents from Src into Dst, recursively. Dirs already existing
    --  on Dst tree will be merged. For existing regular files, either log
    --  at debug level or fail. If Skip, discard files at the Src top-level.

--- a/src/alire/alire-environment.ads
+++ b/src/alire/alire-environment.ads
@@ -15,10 +15,6 @@ package Alire.Environment is
    Config : constant String := "ALR_CONFIG";
    --  Folder where current alr will look for configuration
 
-   Source : constant String := "ALR_SOURCE";
-   --  Folder that overrides where alr sources are checked out
-   --  Intended to help developers by pointing it to their sources
-
    type Context is tagged limited private;
 
    procedure Set (This : in out Context; Name, Value, Origin : String);

--- a/src/alire/alire-install.adb
+++ b/src/alire/alire-install.adb
@@ -71,7 +71,8 @@ package body Alire.Install is
            (Src                   => Prefix / Rel.Base_Folder,
             Dst                   => Prefix,
             Skip_Top_Level_Files  => True,
-            Fail_On_Existing_File => not Alire.Force);
+            Fail_On_Existing_File => not Alire.Force,
+            Remove_From_Source    => True);
 
          --  Keep track that this was installed
 

--- a/src/alire/alire-platforms-folders.ads
+++ b/src/alire/alire-platforms-folders.ads
@@ -2,14 +2,14 @@ package Alire.Platforms.Folders is
 
    --  This spec must be fulfilled by bodies for each different OS we support
 
-   function Config return String;
+   function Config return Absolute_Path;
    --  Folder where alire will store its global configuration, indexes, and
    --  any other global data. Deleting it is akin to running alr afresh for
    --  the first time.
    --  On Linux/macOS it is ${XDG_CONFIG_HOME:-$HOME/.config}/alire
    --  On Windows it is $UserProfile\.config\alire
 
-   function Cache return String;
+   function Cache return Absolute_Path;
    --  Folder for dependencies, global toolchains, and any other info that is
    --  not critical to lose. Can be deleted freely, it's repopulated on-demand.
    --  On Linux/macOS it is ${XDG_CACHE_HOME:-$HOME/.cache}/alire

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -1263,7 +1263,7 @@ package body Alire.Roots is
    begin
       if This.Solution.State (Crate).Is_Solved then
          if This.Solution.State (Crate).Is_Shared then
-            return Shared.Install_Path;
+            return Shared.Path;
          else
             return This.Cache_Dir
               / Paths.Deps_Folder_Inside_Cache_Folder;

--- a/src/alire/alire-shared.adb
+++ b/src/alire/alire-shared.adb
@@ -98,7 +98,7 @@ package body Alire.Shared is
        then Global_Cache_Path.all
        else OS_Lib.Getenv (Environment.Config,
                            Platforms.Folders.Cache))
-       --  Up to here, is the default prefix or an overriden prefix
+       --  Up to here, it's the default prefix or an overriden prefix
        /
          (if Global_Cache_Path = null and then
              OS_Lib.Getenv (Environment.Config, "") = ""

--- a/src/alire/alire-shared.ads
+++ b/src/alire/alire-shared.ads
@@ -19,11 +19,17 @@ package Alire.Shared is
    --  Retrieve the release corresponding to Target, if it exists. Will raise
    --  Constraint_Error if not among Available.
 
-   function Install_Path return Any_Path;
-   --  Returns the base folder in which all shared releases live
+   function Path return Any_Path;
+   --  Returns the base folder in which all shared releases live:
+   --  * <config>/cache/dependencies if set with --config/-c
+   --  * <config>/cache/dependencies if set through ALR_CONFIG
+   --  * ~/.cache/alire/dependencies by default
+
+   procedure Set_Path (Path : Absolute_Path);
+   --  Override the location of the global cache location
 
    procedure Share (Release  : Releases.Release;
-                    Location : Any_Path := Install_Path);
+                    Location : Any_Path := Path);
    --  Deploy a release in the specified location
 
    procedure Remove

--- a/src/alire/alire-toolchains-solutions.adb
+++ b/src/alire/alire-toolchains-solutions.adb
@@ -1,108 +1,10 @@
 with AAA.Strings;
 
-with Alire.Config.Edit;
-with Alire.Directories;
 with Alire.Index;
-with Alire.Paths;
-with Alire.Platforms.Folders;
 with Alire.Root;
 with Alire.Shared;
 
-with CLIC.User_Input;
-
 package body Alire.Toolchains.Solutions is
-
-   -------------------
-   -- Migrate_Cache --
-   -------------------
-
-   procedure Migrate_Cache is
-      use Directories.Operators;
-      Config_Flag : constant String := "alire.cache_migrated";
-      Old_Dir     : constant Absolute_Path
-        := Platforms.Folders.Config
-           / Paths.Cache_Folder_Inside_Working_Folder;
-   begin
-      if not Config.Edit.Is_At_Default_Dir then
-         return; -- Not using default configuration
-      end if;
-
-      if Config.DB.Get (Config_Flag, False) then
-         return; -- Already migrated
-      end if;
-
-      if not Directories.Is_Directory (Old_Dir / "dependencies") then
-         Config.Edit.Set_Globally (Config_Flag, "true");
-         return; -- Nothing to migrate
-      end if;
-
-      Put_Info
-        ("The storage location for compilers has changed to better adhere to "
-         & "best practices.");
-      Trace.Always ("  Old location: " & TTY.URL (Old_Dir));
-      Trace.Always ("  New Location: " & TTY.URL (Platforms.Folders.Cache));
-
-      Trace.Always ("");
-      Put_Info ("Alire will continue operating normally in any case, "
-                & "but you can choose what to do in this one-time operation to"
-                & " avoid large redownloads.");
-      Put_Info ("Unless you are using the old location explicitly somehow, "
-                & "it can be safely deleted.");
-      Trace.Always ("");
-
-      declare
-         type Choices is (Zero, Copy, Move, Pass);
-         Choice : constant Choices := Choices'Val (
-           CLIC.User_Input.Query_Multi
-             (Question => "Please choose your migration preference:",
-              Choices  => AAA.Strings.Empty_Vector
-              .Append ("Copy toolchains to new location")
-              .Append ("Move toolchains to new location")
-              .Append ("Do nothing (compilers will be redownloaded on demand)")
-             ));
-      begin
-         case Choice is
-            when Zero => raise Program_Error with "Query_Multi violated Post";
-            when Copy =>
-               Put_Info ("Copying...");
-               Directories.Create_Tree (Platforms.Folders.Cache);
-               Directories.Merge_Contents (Src => Old_Dir,
-                                           Dst => Platforms.Folders.Cache,
-                                           Skip_Top_Level_Files  => False,
-                                           Fail_On_Existing_File => False,
-                                           Remove_From_Source    => False);
-               Put_Success ("Contents copied, the old location can be deleted"
-                            & " at your convenience.");
-            when Move =>
-               Put_Info ("Moving...");
-               Directories.Create_Tree (Platforms.Folders.Cache);
-               Directories.Merge_Contents (Src => Old_Dir,
-                                           Dst => Platforms.Folders.Cache,
-                                           Skip_Top_Level_Files  => False,
-                                           Fail_On_Existing_File => False,
-                                           Remove_From_Source    => True);
-               Directories.Force_Delete (Old_Dir);
-               Put_Success ("Contents moved successfully.");
-            when Pass =>
-               Put_Info ("Did nothing, compilers will be redownloaded on "
-                         & " demand. The old location can be deleted at your"
-                         & " convenience.");
-         end case;
-      end;
-
-      Config.Edit.Set_Globally (Config_Flag, "true");
-   exception
-      when E : others =>
-         --  Since this involves HD use, a number of things can go wrong...
-         --  Don't reattempt, compilers will be redownloaded and the old
-         --  location will have to be deleted manually.
-         Log_Exception (E, Warning);
-         Config.Edit.Set_Globally (Config_Flag, "true");
-         Put_Warning ("The operation failed and will not be reattempted. "
-                      & " Compilers will be downloaded again when needed. "
-                      & " You can delete the old location manually to recover "
-                      & "disk space.");
-   end Migrate_Cache;
 
    -------------------
    -- Add_Toolchain --
@@ -132,11 +34,6 @@ package body Alire.Toolchains.Solutions is
 
       Result : Alire.Solutions.Solution := Solution;
    begin
-
-      --  For the users' sake, offer to relocate a toolchain in the former
-      --  cache location to the new location as gnat downloads are quite heavy.
-
-      Migrate_Cache;
 
       --  For every tool in the toolchain that does not appear in the solution,
       --  we will insert the user-configured tool, if any.

--- a/src/alire/alire-toolchains-solutions.adb
+++ b/src/alire/alire-toolchains-solutions.adb
@@ -1,7 +1,108 @@
+with AAA.Strings;
+
+with Alire.Config.Edit;
+with Alire.Directories;
+with Alire.Index;
+with Alire.Paths;
+with Alire.Platforms.Folders;
 with Alire.Root;
 with Alire.Shared;
 
+with CLIC.User_Input;
+
 package body Alire.Toolchains.Solutions is
+
+   -------------------
+   -- Migrate_Cache --
+   -------------------
+
+   procedure Migrate_Cache is
+      use Directories.Operators;
+      Config_Flag : constant String := "alire.cache_migrated";
+      Old_Dir     : constant Absolute_Path
+        := Platforms.Folders.Config
+           / Paths.Cache_Folder_Inside_Working_Folder;
+   begin
+      if not Config.Edit.Is_At_Default_Dir then
+         return; -- Not using default configuration
+      end if;
+
+      if Config.DB.Get (Config_Flag, False) then
+         return; -- Already migrated
+      end if;
+
+      if not Directories.Is_Directory (Old_Dir / "dependencies") then
+         Config.Edit.Set_Globally (Config_Flag, "true");
+         return; -- Nothing to migrate
+      end if;
+
+      Put_Info
+        ("The storage location for compilers has changed to better adhere to "
+         & "best practices.");
+      Trace.Always ("  Old location: " & TTY.URL (Old_Dir));
+      Trace.Always ("  New Location: " & TTY.URL (Platforms.Folders.Cache));
+
+      Trace.Always ("");
+      Put_Info ("Alire will continue operating normally in any case, "
+                & "but you can choose what to do in this one-time operation to"
+                & " avoid large redownloads.");
+      Put_Info ("Unless you are using the old location explicitly somehow, "
+                & "it can be safely deleted.");
+      Trace.Always ("");
+
+      declare
+         type Choices is (Zero, Copy, Move, Pass);
+         Choice : constant Choices := Choices'Val (
+           CLIC.User_Input.Query_Multi
+             (Question => "Please choose your migration preference:",
+              Choices  => AAA.Strings.Empty_Vector
+              .Append ("Copy toolchains to new location")
+              .Append ("Move toolchains to new location")
+              .Append ("Do nothing (compilers will be redownloaded on demand)")
+             ));
+      begin
+         case Choice is
+            when Zero => raise Program_Error with "Query_Multi violated Post";
+            when Copy =>
+               Put_Info ("Copying...");
+               Directories.Create_Tree (Platforms.Folders.Cache);
+               Directories.Merge_Contents (Src => Old_Dir,
+                                           Dst => Platforms.Folders.Cache,
+                                           Skip_Top_Level_Files  => False,
+                                           Fail_On_Existing_File => False,
+                                           Remove_From_Source    => False);
+               Put_Success ("Contents copied, the old location can be deleted"
+                            & " at your convenience.");
+            when Move =>
+               Put_Info ("Moving...");
+               Directories.Create_Tree (Platforms.Folders.Cache);
+               Directories.Merge_Contents (Src => Old_Dir,
+                                           Dst => Platforms.Folders.Cache,
+                                           Skip_Top_Level_Files  => False,
+                                           Fail_On_Existing_File => False,
+                                           Remove_From_Source    => True);
+               Directories.Force_Delete (Old_Dir);
+               Put_Success ("Contents moved successfully.");
+            when Pass =>
+               Put_Info ("Did nothing, compilers will be redownloaded on "
+                         & " demand. The old location can be deleted at your"
+                         & " convenience.");
+         end case;
+      end;
+
+      Config.Edit.Set_Globally (Config_Flag, "true");
+   exception
+      when E : others =>
+         --  Since this involves HD use, a number of things can go wrong...
+         --  Don't reattempt, compilers will be redownloaded and the old
+         --  location will have to be deleted manually.
+         Log_Exception (E, Warning);
+         Config.Edit.Set_Globally (Config_Flag, "true");
+         Put_Warning ("The operation failed and will not be reattempted. "
+                      & " Compilers will be downloaded again when needed. "
+                      & " You can delete the old location manually to recover "
+                      & "disk space.");
+   end Migrate_Cache;
 
    -------------------
    -- Add_Toolchain --
@@ -10,8 +111,33 @@ package body Alire.Toolchains.Solutions is
    function Add_Toolchain (Solution : Alire.Solutions.Solution)
                               return Alire.Solutions.Solution
    is
+
+      ------------------------
+      -- Redeploy_If_Needed --
+      ------------------------
+
+      procedure Redeploy_If_Needed (Mil : Milestones.Milestone) is
+         use type Milestones.Milestone;
+      begin
+         --  Check that is not already there
+         if (for some Rel of Shared.Available => Rel.Milestone = Mil) then
+            return;
+         end if;
+
+         --  It must be redeployed
+         Put_Warning ("Tool " & Mil.TTY_Image & " is missing, redeploying...");
+
+         Shared.Share (Index.Find (Mil.Crate, Mil.Version));
+      end Redeploy_If_Needed;
+
       Result : Alire.Solutions.Solution := Solution;
    begin
+
+      --  For the users' sake, offer to relocate a toolchain in the former
+      --  cache location to the new location as gnat downloads are quite heavy.
+
+      Migrate_Cache;
+
       --  For every tool in the toolchain that does not appear in the solution,
       --  we will insert the user-configured tool, if any.
 
@@ -21,6 +147,14 @@ package body Alire.Toolchains.Solutions is
               ("Toolchain environment: solution already depends on "
                & Solution.State (Tool).TTY_Image);
          elsif Toolchains.Tool_Is_Configured (Tool) then
+
+            --  This shouldn't happen normally, but it can happen if the user
+            --  has just changed the cache location.
+            if not Tool_Is_External (Tool) then
+               Redeploy_If_Needed (Tool_Milestone (Tool));
+            end if;
+
+            --  Add the configured tool release to the solution
             Result := Result.Including
               (Release        => Shared.Release
                  (Target           => Tool_Milestone (Tool),

--- a/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
+++ b/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
@@ -8,13 +8,13 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return String is (Common.XDG_Cache_Folder);
+   function Cache return Absolute_Path is (Common.XDG_Cache_Folder);
 
    -----------
    -- Config--
    -----------
 
-   function Config return String is (Common.XDG_Config_Folder);
+   function Config return Absolute_Path is (Common.XDG_Config_Folder);
 
    ----------
    -- Home --

--- a/src/alire/os_linux/alire-platforms-folders__linux.adb
+++ b/src/alire/os_linux/alire-platforms-folders__linux.adb
@@ -8,13 +8,13 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return String is (Common.XDG_Cache_Folder);
+   function Cache return Absolute_Path is (Common.XDG_Cache_Folder);
 
    -----------
    -- Config--
    -----------
 
-   function Config return String is (Common.XDG_Config_Folder);
+   function Config return Absolute_Path is (Common.XDG_Config_Folder);
 
    ----------
    -- Home --

--- a/src/alire/os_macos/alire-platforms-folders__macos.adb
+++ b/src/alire/os_macos/alire-platforms-folders__macos.adb
@@ -8,13 +8,13 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return String is (Common.XDG_Cache_Folder);
+   function Cache return Absolute_Path is (Common.XDG_Cache_Folder);
 
    -----------
    -- Config--
    -----------
 
-   function Config return String is (Common.XDG_Config_Folder);
+   function Config return Absolute_Path is (Common.XDG_Config_Folder);
 
    ----------
    -- Home --

--- a/src/alire/os_windows/alire-platforms-folders__windows.adb
+++ b/src/alire/os_windows/alire-platforms-folders__windows.adb
@@ -15,12 +15,12 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return String is (Home / ".cache" / "alire");
+   function Cache return Absolute_Path is (Home / ".cache" / "alire");
 
    ------------
    -- Config --
    ------------
 
-   function Config return String is (Home / ".config" / "alire");
+   function Config return Absolute_Path is (Home / ".config" / "alire");
 
 end Alire.Platforms.Folders;

--- a/src/alr/alr-commands-version.adb
+++ b/src/alr/alr-commands-version.adb
@@ -4,6 +4,7 @@ with Alire.Index_On_Disk.Loading;
 with Alire.Milestones;
 with Alire.Properties;
 with Alire.Roots.Optional;
+with Alire.Shared;
 with Alire.Toolchains;
 with Alire.Utils.Tables;
 
@@ -51,6 +52,7 @@ package body Alr.Commands.Version is
       Table.Append ("").New_Row;
       Table.Append ("CONFIGURATION").New_Row;
       Table.Append ("config folder:").Append (Alire.Config.Edit.Path).New_Row;
+      Table.Append ("cache folder:").Append (Alire.Shared.Path).New_Row;
       Table.Append ("force flag:").Append (Alire.Force'Image).New_Row;
       Table.Append ("non-interactive flag:")
         .Append (CLIC.User_Input.Not_Interactive'Image).New_Row;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -16,6 +16,7 @@ with Alire.Lockfiles;
 with Alire.Paths;
 with Alire.Platforms.Current;
 with Alire.Root;
+with Alire.Shared;
 with Alire.Solutions;
 with Alire.Toolchains;
 
@@ -471,18 +472,22 @@ package body Alr.Commands is
          --  Also use a fancier busy spinner
       end if;
 
+      --  Set overriden config path. For now, we tie the config and cache paths
+      --  to a single location when overridden, as this was the old behavior
+      --  before we started using ~/.cache for dependencies, so people using
+      --  custom config locations will expect shared dependencies to be at the
+      --  new config location, as always.
+
       if Command_Line_Config_Path /= null and then
          Command_Line_Config_Path.all /= ""
       then
-         if not Alire.Check_Absolute_Path (Command_Line_Config_Path.all) then
-            --  Make an absolute path from user relative path
-            Alire.Config.Edit.Set_Path
-              (Ada.Directories.Full_Name (Command_Line_Config_Path.all));
-         else
-
-            --  Use absolute path from user
-            Alire.Config.Edit.Set_Path (Command_Line_Config_Path.all);
-         end if;
+         declare
+            Config_Path : constant Alire.Absolute_Path
+              := Ada.Directories.Full_Name (Command_Line_Config_Path.all);
+         begin
+            Alire.Config.Edit.Set_Path (Config_Path);
+            Alire.Shared.Set_Path (Config_Path);
+         end;
       end if;
 
       Create_Alire_Folders;


### PR DESCRIPTION
We fixed the cache path in #1265 but the deployer of binary releases was defaulting to the config location.