### PR TITLE
Typed variants of Alire.Config.Edit.Set

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -47,7 +47,7 @@ windows = { ALIRE_OS = "windows" }
 [[pins]]
 aaa = { url = "https://github.com/mosteo/aaa", commit = "906d9eaf4fb8efabfbc3d8cfb34d04ceec340e13" }
 ada_toml = { url = "https://github.com/mosteo/ada-toml", commit = "da4e59c382ceb0de6733d571ecbab7ea4919b33d" }
-clic = { url = "https://github.com/alire-project/clic", commit = "102bc38c7e9469112145e12100449664b5c74764" }
+clic = { url = "https://github.com/alire-project/clic", commit = "84a68fa5e39195614f985b6c0b3d67cbdec5b09e" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "92bb91130a9ec628b4c48b7ef9fe7f24d9dc25fa" }
 semantic_versioning = { url = "https://github.com/alire-project/semantic_versioning", commit = "c2345fca8b685d6d3fc9334fac81140a0cdbea89" }
 simple_logging = { url = "https://github.com/alire-project/simple_logging", commit = "2b62010b6d66c106c65eb9ae604aabcf64522fac" }

--- a/alire.toml
+++ b/alire.toml
@@ -47,7 +47,7 @@ windows = { ALIRE_OS = "windows" }
 [[pins]]
 aaa = { url = "https://github.com/mosteo/aaa", commit = "906d9eaf4fb8efabfbc3d8cfb34d04ceec340e13" }
 ada_toml = { url = "https://github.com/mosteo/ada-toml", commit = "da4e59c382ceb0de6733d571ecbab7ea4919b33d" }
-clic = { url = "https://github.com/alire-project/clic", commit = "84a68fa5e39195614f985b6c0b3d67cbdec5b09e" }
+clic = { url = "https://github.com/alire-project/clic", commit = "ce4668206bbd038e857ce6a2d463c3de9a0cc9bb" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "92bb91130a9ec628b4c48b7ef9fe7f24d9dc25fa" }
 semantic_versioning = { url = "https://github.com/alire-project/semantic_versioning", commit = "c2345fca8b685d6d3fc9334fac81140a0cdbea89" }
 simple_logging = { url = "https://github.com/alire-project/simple_logging", commit = "2b62010b6d66c106c65eb9ae604aabcf64522fac" }

--- a/dev/edit.sh
+++ b/dev/edit.sh
@@ -1,1 +1,1 @@
-gnatstudio -P alr_env &
+gnatstudio -P alr_env & >/dev/null 2>&1

--- a/src/alire/alire-config-edit.adb
+++ b/src/alire/alire-config-edit.adb
@@ -81,6 +81,8 @@ package body Alire.Config.Edit is
    begin
       Assert (Typed.Set_Boolean (Filepath (Level), Key, Value, Check),
               "Cannot set config key '" & Key & "' at level " & Level'Image);
+      --  Reload after change
+      Load_Config;
    end Set_Boolean;
 
    -----------------
@@ -95,21 +97,9 @@ package body Alire.Config.Edit is
    begin
       Assert (Typed.Set_Integer (Filepath (Level), Key, Value, Check),
               "Cannot set config key '" & Key & "' at level " & Level'Image);
+      --  Reload after change
+      Load_Config;
    end Set_Integer;
-
-   ---------------
-   -- Set_Float --
-   ---------------
-
-   procedure Set_Float (Level : Config.Level;
-                        Key   : CLIC.Config.Config_Key;
-                        Value : Float;
-                        Check : CLIC.Config.Check_Import := null)
-   is
-   begin
-      Assert (Typed.Set_Float (Filepath (Level), Key, Value, Check),
-              "Cannot set config key '" & Key & "' at level " & Level'Image);
-   end Set_Float;
 
    --------------
    -- Filepath --

--- a/src/alire/alire-config-edit.adb
+++ b/src/alire/alire-config-edit.adb
@@ -5,7 +5,7 @@ with Alire.Platforms.Folders;
 with Alire.Platforms.Current;
 with Alire.Utils;
 
-with CLIC.Config.Edit;
+with CLIC.Config.Edit.Typed;
 with CLIC.Config.Load;
 
 package body Alire.Config.Edit is
@@ -13,6 +13,7 @@ package body Alire.Config.Edit is
    use Ada.Strings.Unbounded;
    use AAA.Strings;
    use TOML;
+   package Typed renames CLIC.Config.Edit.Typed;
 
    type String_Access is access String;
    Config_Path : String_Access;
@@ -66,6 +67,49 @@ package body Alire.Config.Edit is
          when Global => Set_Globally (Key, Value, Check);
       end case;
    end Set;
+
+   -----------------
+   -- Set_Boolean --
+   -----------------
+
+   procedure Set_Boolean (Level : Config.Level;
+                          Key   : CLIC.Config.Config_Key;
+                          Value : Boolean;
+                          Check : CLIC.Config.Check_Import := null)
+   is
+
+   begin
+      Assert (Typed.Set_Boolean (Filepath (Level), Key, Value, Check),
+              "Cannot set config key '" & Key & "' at level " & Level'Image);
+   end Set_Boolean;
+
+   -----------------
+   -- Set_Integer --
+   -----------------
+
+   procedure Set_Integer (Level : Config.Level;
+                          Key   : CLIC.Config.Config_Key;
+                          Value : Integer;
+                          Check : CLIC.Config.Check_Import := null)
+   is
+   begin
+      Assert (Typed.Set_Integer (Filepath (Level), Key, Value, Check),
+              "Cannot set config key '" & Key & "' at level " & Level'Image);
+   end Set_Integer;
+
+   ---------------
+   -- Set_Float --
+   ---------------
+
+   procedure Set_Float (Level : Config.Level;
+                        Key   : CLIC.Config.Config_Key;
+                        Value : Float;
+                        Check : CLIC.Config.Check_Import := null)
+   is
+   begin
+      Assert (Typed.Set_Float (Filepath (Level), Key, Value, Check),
+              "Cannot set config key '" & Key & "' at level " & Level'Image);
+   end Set_Float;
 
    --------------
    -- Filepath --

--- a/src/alire/alire-config-edit.adb
+++ b/src/alire/alire-config-edit.adb
@@ -5,7 +5,7 @@ with Alire.Platforms.Folders;
 with Alire.Platforms.Current;
 with Alire.Utils;
 
-with CLIC.Config.Edit.Typed;
+with CLIC.Config.Edit;
 with CLIC.Config.Load;
 
 package body Alire.Config.Edit is
@@ -13,7 +13,6 @@ package body Alire.Config.Edit is
    use Ada.Strings.Unbounded;
    use AAA.Strings;
    use TOML;
-   package Typed renames CLIC.Config.Edit.Typed;
 
    type String_Access is access String;
    Config_Path : String_Access;
@@ -77,29 +76,14 @@ package body Alire.Config.Edit is
                           Value : Boolean;
                           Check : CLIC.Config.Check_Import := null)
    is
-
+      function Set_Boolean_Impl is new CLIC.Config.Edit.Set_Typed
+        (Boolean, TOML_Boolean, Boolean'Image);
    begin
-      Assert (Typed.Set_Boolean (Filepath (Level), Key, Value, Check),
+      Assert (Set_Boolean_Impl (Filepath (Level), Key, Value, Check),
               "Cannot set config key '" & Key & "' at level " & Level'Image);
       --  Reload after change
       Load_Config;
    end Set_Boolean;
-
-   -----------------
-   -- Set_Integer --
-   -----------------
-
-   procedure Set_Integer (Level : Config.Level;
-                          Key   : CLIC.Config.Config_Key;
-                          Value : Integer;
-                          Check : CLIC.Config.Check_Import := null)
-   is
-   begin
-      Assert (Typed.Set_Integer (Filepath (Level), Key, Value, Check),
-              "Cannot set config key '" & Key & "' at level " & Level'Image);
-      --  Reload after change
-      Load_Config;
-   end Set_Integer;
 
    --------------
    -- Filepath --

--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -35,11 +35,6 @@ package Alire.Config.Edit is
                           Value : Integer;
                           Check : CLIC.Config.Check_Import := null);
 
-   procedure Set_Float (Level : Config.Level;
-                        Key   : CLIC.Config.Config_Key;
-                        Value : Float;
-                        Check : CLIC.Config.Check_Import := null);
-
    --  To ease the pain with circularities in old GNAT versions, we have also
    --  here all non-preelaborable things related to config loading. This
    --  way, querying stays preelaborable.

--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -30,11 +30,6 @@ package Alire.Config.Edit is
                           Value : Boolean;
                           Check : CLIC.Config.Check_Import := null);
 
-   procedure Set_Integer (Level : Config.Level;
-                          Key   : CLIC.Config.Config_Key;
-                          Value : Integer;
-                          Check : CLIC.Config.Check_Import := null);
-
    --  To ease the pain with circularities in old GNAT versions, we have also
    --  here all non-preelaborable things related to config loading. This
    --  way, querying stays preelaborable.

--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -7,7 +7,8 @@ with Alire.Directories;
 
 package Alire.Config.Edit is
 
-   --  Shortcuts that use the standard config locations:
+   --  Shortcuts that use the standard config locations. These interpret the
+   --  value in string as a TOML type whenever possible.
 
    procedure Set_Locally (Key   : CLIC.Config.Config_Key;
                           Value : String;
@@ -21,6 +22,23 @@ package Alire.Config.Edit is
                   Key   : CLIC.Config.Config_Key;
                   Value : String;
                   Check : CLIC.Config.Check_Import := null);
+
+   --  Typed alternatives
+
+   procedure Set_Boolean (Level : Config.Level;
+                          Key   : CLIC.Config.Config_Key;
+                          Value : Boolean;
+                          Check : CLIC.Config.Check_Import := null);
+
+   procedure Set_Integer (Level : Config.Level;
+                          Key   : CLIC.Config.Config_Key;
+                          Value : Integer;
+                          Check : CLIC.Config.Check_Import := null);
+
+   procedure Set_Float (Level : Config.Level;
+                        Key   : CLIC.Config.Config_Key;
+                        Value : Float;
+                        Check : CLIC.Config.Check_Import := null);
 
    --  To ease the pain with circularities in old GNAT versions, we have also
    --  here all non-preelaborable things related to config loading. This

--- a/src/alire/alire-selftest.adb
+++ b/src/alire/alire-selftest.adb
@@ -14,6 +14,30 @@ package body Alire.Selftest is
       Config.Edit.Set_Globally (Key, Val);
       pragma Assert (Config.DB.Defined (Key));
       pragma Assert (Config.DB.Get (Key, "snafu") = Val);
+
+      --  Check typed storing
+
+      --  Raw storing of integer
+      Config.Edit.Set_Globally (Key, "777");
+      pragma Assert (Integer (Config.DB.Get (Key, 0)) = 777);
+
+      --  Typed storing of integer
+      Config.Edit.Set_Integer (Config.Global, Key, 888);
+      pragma Assert (Integer (Config.DB.Get (Key, 0)) = 888);
+
+      --  Raw storing of boolean
+      Config.Edit.Set_Globally (Key, "true");
+      pragma Assert (Config.DB.Get (Key, False) = True);
+
+      --  Typed storing of boolean
+      Config.Edit.Set_Boolean (Config.Global, Key, False);
+      pragma Assert (Config.DB.Get (Key, True) = False);
+
+      --  Raw storing of boolean with wrong type
+      Config.Edit.Set_Globally (Key, "True");
+      --  This causes a string to be stored, as in TOML only "true" is bool
+      pragma Assert (Config.DB.Get (Key, "False") = "True");
+
    end Check_Config_Changes;
 
    ------------------------

--- a/src/alire/alire-selftest.adb
+++ b/src/alire/alire-selftest.adb
@@ -21,10 +21,6 @@ package body Alire.Selftest is
       Config.Edit.Set_Globally (Key, "777");
       pragma Assert (Integer (Config.DB.Get (Key, 0)) = 777);
 
-      --  Typed storing of integer
-      Config.Edit.Set_Integer (Config.Global, Key, 888);
-      pragma Assert (Integer (Config.DB.Get (Key, 0)) = 888);
-
       --  Raw storing of boolean
       Config.Edit.Set_Globally (Key, "true");
       pragma Assert (Config.DB.Get (Key, False) = True);

--- a/src/alire/alire-toolchains.adb
+++ b/src/alire/alire-toolchains.adb
@@ -346,10 +346,10 @@ package body Alire.Toolchains is
         (Level,
          Key   => Tool_Key (Release.Name),
          Value => Release.Milestone.Image);
-      Alire.Config.Edit.Set
+      Alire.Config.Edit.Set_Boolean
         (Level,
          Key   => Tool_Key (Release.Name, For_Is_External),
-         Value => Boolean'(not Release.Origin.Is_Regular)'Image);
+         Value => not Release.Origin.Is_Regular);
    end Set_As_Default;
 
    -----------------------------
@@ -359,9 +359,9 @@ package body Alire.Toolchains is
    procedure Set_Automatic_Assistant (Enabled : Boolean; Level : Config.Level)
    is
    begin
-      Config.Edit.Set (Level,
-                       Config.Keys.Toolchain_Assistant,
-                       (if Enabled then "true" else "false"));
+      Config.Edit.Set_Boolean (Level,
+                               Config.Keys.Toolchain_Assistant,
+                               Enabled);
    end Set_Automatic_Assistant;
 
    ------------------------

--- a/src/alire/alire-toolchains.ads
+++ b/src/alire/alire-toolchains.ads
@@ -113,6 +113,15 @@ private
    function Assistant_Enabled return Boolean
    is (Config.DB.Get (Config.Keys.Toolchain_Assistant, Default => True));
 
+   ----------------------
+   -- Tool_Is_External --
+   ----------------------
+
+   function Tool_Is_External (Crate : Crate_Name) return Boolean
+   is (Boolean'Value
+       (Config.DB.Get_As_String -- because it could be stored as bool or string
+          (Tool_Key (Crate, For_Is_External), "True")));
+
    --------------
    -- Tool_Key --
    --------------
@@ -127,15 +136,6 @@ private
              when For_Use => Config.Keys.Toolchain_Use,
              when For_Is_External => Config.Keys.Toolchain_External)
           & "." & Crate.As_String));
-
-   ----------------------
-   -- Tool_Is_External --
-   ----------------------
-
-   function Tool_Is_External (Crate : Crate_Name) return Boolean
-   is (Boolean'Value
-       (Config.DB.Get
-          (Tool_Key (Crate, For_Is_External), Default => "True")));
 
    --------------------
    -- Tool_Milestone --

--- a/src/alr/alr-commands-config.adb
+++ b/src/alr/alr-commands-config.adb
@@ -1,9 +1,11 @@
-with CLIC.Config.Info;
-with CLIC.Config.Edit;
+with AAA.Enum_Tools;
 
 with Alire.Config;
 with Alire.Config.Edit;
 with Alire.Root;
+
+with CLIC.Config.Info;
+with CLIC.Config.Edit;
 
 package body Alr.Commands.Config is
 
@@ -105,10 +107,23 @@ package body Alr.Commands.Config is
                  Key & "'");
             end if;
 
-            Alire.Config.Edit.Set
-              (Lvl,
-               Key, Val,
-               Check => Alire.Config.Edit.Valid_Builtin'Access);
+            --  Check explicitly for booleans to store the proper TOML type
+            --  regardless of the capitalization used by the user.
+            declare
+               function Is_Boolean is new AAA.Enum_Tools.Is_Valid (Boolean);
+            begin
+               if Is_Boolean (Val) then
+                  Alire.Config.Edit.Set_Boolean
+                    (Lvl,
+                     Key, Boolean'Value (Val),
+                     Check => Alire.Config.Edit.Valid_Builtin'Access);
+               else
+                  Alire.Config.Edit.Set
+                    (Lvl,
+                     Key, Val,
+                     Check => Alire.Config.Edit.Valid_Builtin'Access);
+               end if;
+            end;
          end;
 
       elsif Cmd.Unset then

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -161,8 +161,10 @@ package body Alr.Commands.Get is
             Trace.Info ("Because --only was used, automatic dependency" &
                           " retrieval is disabled in this workspace:" &
                           " use `alr update` to apply dependency changes");
-            Alire.Config.Edit.Set_Locally
-              (Alire.Config.Keys.Update_Manually, "true");
+            Alire.Config.Edit.Set_Boolean
+              (Alire.Config.Local,
+               Alire.Config.Keys.Update_Manually,
+               True);
 
             if not CLIC.User_Input.Not_Interactive then
                Alire.Roots.Print_Nested_Crates (Cmd.Root.Path);


### PR DESCRIPTION
Mostly because it's too easy to mix Boolean with String now.