### PR TITLE
Switch to ghcr.io from dockerhub

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -17,8 +17,8 @@ jobs:
 
     strategy:
       matrix:
-        tag: # Those are our dockerhub alire/gnat:tag machines
-            - centos-stream-fsf-latest # Test unsupported package manager 
+        tag: # Those are our ghcr.io/alire-project/docker/gnat:tag machines
+            - centos-stream-fsf-latest # Test unsupported package manager
             - debian-stable            # Test current stable Debian compiler
             - fedora-latest            # Test current Fedora compiler
             - ubuntu-lts               # Test current LTS Ubuntu compiler
@@ -31,7 +31,7 @@ jobs:
         submodules: true
 
     - name: Pull docker image
-      run: docker pull alire/gnat:${{ matrix.tag }}
+      run: docker pull ghcr.io/alire-project/docker/gnat:${{ matrix.tag }}
 
     - name: Run test script
       run: >

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -30,13 +30,12 @@ jobs:
       with:
         submodules: true
 
-    - name: Pull docker image
-      run: docker pull ghcr.io/alire-project/docker/gnat:${{ matrix.tag }}
-
-    - name: Run test script
-      run: >
-        docker run -v${PWD}:/alire -w /alire
-        alire/gnat:${{ matrix.tag }} scripts/ci-github.sh
+    - name: Run test script (${{ matrix.tag }})
+      uses: mosteo-actions/docker-run@v1
+      with:
+        image: ghcr.io/alire-project/docker/gnat:${{matrix.tag}}
+        command: scripts/ci-github.sh
+        params: -v${PWD}:/alire -w /alire
 
     - name: Upload logs (if failed)
       if: failure()


### PR DESCRIPTION
As long as we are committed to GH services, we can also use it for Docker images and eliminate an extra dependency.