### PR TITLE
"Compiler version" --> "Compiled with version"

### DIFF
--- a/src/alr/alr-commands-version.adb
+++ b/src/alr/alr-commands-version.adb
@@ -54,7 +54,8 @@ package body Alr.Commands.Version is
       Table.Append ("compilation date:")
         .Append (GNAT.Source_Info.Compilation_ISO_Date & " "
                  & GNAT.Source_Info.Compilation_Time).New_Row;
-      Table.Append ("compiler version:").Append (GNAT_Version.Version).New_Row;
+      Table.Append ("compiled with version:")
+        .Append (GNAT_Version.Version).New_Row;
 
       Table.Append ("").New_Row;
       Table.Append ("CONFIGURATION").New_Row;


### PR DESCRIPTION
In the output of `alr version`

I've already seen some confused report where this version is thought of as being the GNAT being configured.