### PR TITLE
Don't raise on bad external detection from output

### DIFF
--- a/src/alire/alire-externals-from_output.adb
+++ b/src/alire/alire-externals-from_output.adb
@@ -7,6 +7,7 @@ with Alire.OS_Lib.Subprocess;
 with Alire.Paths;
 with Alire.Releases;
 with Alire.TOML_Keys;
+with Alire.Utils.TTY;
 
 with Semantic_Versioning;
 
@@ -26,6 +27,7 @@ package body Alire.Externals.From_Output is
       Location : GNAT.OS_Lib.String_Access :=
                    GNAT.OS_Lib.Locate_Exec_On_Path
                      (This.Command.First_Element);
+      Result : Alire.Releases.Containers.Release_Set;
    begin
       if Location in null then
          Trace.Debug
@@ -69,36 +71,43 @@ package body Alire.Externals.From_Output is
             return Releases.Containers.Empty_Release_Set;
          end if;
 
-         return Releases : Alire.Releases.Containers.Release_Set do
-            Trace.Debug ("Looking for external in version string: " & Output);
-            Match (This.Regexp, Output, Matches);
+         Trace.Debug
+           ("Looking for external in version string '" & Output & "'");
+         Match (This.Regexp, Output, Matches);
 
-            for I in Matches'Range loop
-               if Matches (I) /= No_Match then
-                  declare
-                     Version : constant String :=
-                                Output (Matches (I).First .. Matches (I).Last);
-                     Path    : constant Any_Path :=
-                                OS_Lib.Subprocess.Locate_In_Path
-                                  (This.Command.First_Element);
-                  begin
-                     Trace.Debug ("Identified external from version: "
-                                  & Version);
+         for I in Matches'Range loop
+            if Matches (I) /= No_Match then
+               declare
+                  Version : constant String :=
+                              Output (Matches (I).First .. Matches (I).Last);
+                  Path    : constant Any_Path :=
+                              OS_Lib.Subprocess.Locate_In_Path
+                                (This.Command.First_Element);
+               begin
+                  Trace.Debug ("Identified external from version: "
+                               & Version);
 
-                     Releases.Insert
-                       (Index.Crate (Name, Index.Query_Mem_Only).Base
-                        .Retagging (Semantic_Versioning.Parse (Version))
-                        .Providing (This.Provides)
-                        .Replacing (Origins.New_External ("path " & Path))
-                        .Replacing (Notes => "Detected at " -- length is 12
-                                    & Shorten
-                                      (String (Path),
-                                       Max_Description_Length - 12)));
-                  end;
-               end if;
-            end loop;
-         end return;
+                  Result.Insert
+                    (Index.Crate (Name, Index.Query_Mem_Only).Base
+                     .Retagging (Semantic_Versioning.Parse (Version))
+                     .Providing (This.Provides)
+                     .Replacing (Origins.New_External ("path " & Path))
+                     .Replacing (Notes => "Detected at " -- length is 12
+                                 & Shorten
+                                   (String (Path),
+                                    Max_Description_Length - 12)));
+               end;
+            end if;
+         end loop;
       end;
+
+      return Result;
+   exception
+      when E : others =>
+         Trace.Debug ("Unexpected exception while attempting detection of "
+                      & "external crate " & Utils.TTY.Name (Name));
+         Log_Exception (E);
+         return Result;
    end Detect;
 
    ---------------

--- a/testsuite/tests/index/external-from-output/my_index/index/ba/bad_version/bad_version-external.toml
+++ b/testsuite/tests/index/external-from-output/my_index/index/ba/bad_version/bad_version-external.toml
@@ -1,0 +1,10 @@
+description = "An external with bad regex that results in empty version"
+name = "bad_version"
+licenses = "GPL-3.0-only"
+maintainers = ["example@example.com"]
+maintainers-logins = ["mylogin"]
+
+[[external]]
+kind = "version-output"
+version-regexp = ".*Ma(ke).*" # Captures "ke" as the version
+version-command = ["make", "--version"]

--- a/testsuite/tests/index/external-from-output/test.py
+++ b/testsuite/tests/index/external-from-output/test.py
@@ -48,4 +48,15 @@ assert_eq('Kind       Description                   '
 p = run_alr('show', 'bad_switch', '--external-detect', quiet=False)
 assert_match('.*Not found: bad_switch', p.out)
 
+
+# Verify that a bad version being captured doesn't raise
+
+p = run_alr("show", "bad_version", quiet=False)
+assert_match(".*There are external definitions for the crate.",
+             p.out)
+
+# External detection fails (no release found, but without error)
+p = run_alr('show', 'bad_version', '--external-detect', quiet=False)
+assert_match('.*Not found: bad_version', p.out)
+
 print('SUCCESS')

--- a/testsuite/tests/index/external-from-output/test.py
+++ b/testsuite/tests/index/external-from-output/test.py
@@ -52,8 +52,7 @@ assert_match('.*Not found: bad_switch', p.out)
 # Verify that a bad version being captured doesn't raise
 
 p = run_alr("show", "bad_version", quiet=False)
-assert_match(".*There are external definitions for the crate.",
-             p.out)
+assert_match(".*There are external definitions for the crate.", p.out)
 
 # External detection fails (no release found, but without error)
 p = run_alr('show', 'bad_version', '--external-detect', quiet=False)


### PR DESCRIPTION
A bad version being matched in "From_Output" kind of externals resulted in an exception instead of ignoring the external.

It's safe to assume that if the regex isn't working as expected, whatever is producing the output is not the intended release.