### PR TITLE
Indicators in solution diff about non-source dependencies

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         tag: # Those are our ghcr.io/alire-project/docker/gnat:tag machines
             - centos-stream-fsf-latest # Test unsupported package manager

--- a/.gitmodules
+++ b/.gitmodules
@@ -51,3 +51,6 @@
 [submodule "deps/clic"]
 	path = deps/clic
 	url = https://github.com/alire-project/clic.git
+[submodule "deps/umwi"]
+	path = deps/umwi
+	url = https://github.com/mosteo/umwi

--- a/alire.toml
+++ b/alire.toml
@@ -45,7 +45,7 @@ windows = { ALIRE_OS = "windows" }
 
 # Some dependencies require precise versions during the development cycle:
 [[pins]]
-aaa = { url = "https://github.com/mosteo/aaa", commit = "906d9eaf4fb8efabfbc3d8cfb34d04ceec340e13" }
+aaa = { url = "https://github.com/mosteo/aaa", commit = "f60254934a7d6e39b72380b496527295602f75e3" }
 ada_toml = { url = "https://github.com/mosteo/ada-toml", commit = "da4e59c382ceb0de6733d571ecbab7ea4919b33d" }
 clic = { url = "https://github.com/alire-project/clic", commit = "8d26222de71014554999e48c821906fca0e3dc41" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "403efe11405113cf12ae3d014df474cf7a046176" }

--- a/alr_env.gpr
+++ b/alr_env.gpr
@@ -23,6 +23,7 @@ aggregate project Alr_Env is
                          "deps/spdx",
                          "deps/stopwatch",
                          "deps/toml_slicer",
+                         "deps/umwi",
                          "deps/uri-ada",
                          "deps/xmlezout"
                         );

--- a/scripts/ci-github.sh
+++ b/scripts/ci-github.sh
@@ -51,14 +51,19 @@ echo TESTSUITE:
 echo
 cd testsuite
 
-# On Windows, python3/pip3 don't explicitly exist
+# On Windows, python3/pip3 don't explicitly exist. Also we don't need a venv.
 if [ "${OS:-}" == "Windows_NT" ]; then
     run_python=python
     run_pip=pip
 else
     run_python=python3
     run_pip=pip3
+    # Some distros complain that we are trying to install packages globally,
+    # e.g. latest Debian, so use a virtualenv:
+    $run_python -m venv venv && . venv/bin/activate
 fi
+
+echo PYTHON installing testsuite dependencies...
 
 echo Python version: $($run_python --version)
 echo Pip version: $($run_pip --version)


### PR DESCRIPTION
Increase awareness when a crate not packaged as sources is added to the solution: binaries, system packages, executables in path.

Collaterally, fix tabulation in `aaa` when emojis are involved, which in turn allows using fancier emojis.