### PR TITLE
`alr publish --status`

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -49,7 +49,7 @@ aaa = { url = "https://github.com/mosteo/aaa", commit = "f60254934a7d6e39b72380b
 ada_toml = { url = "https://github.com/mosteo/ada-toml", commit = "da4e59c382ceb0de6733d571ecbab7ea4919b33d" }
 clic = { url = "https://github.com/alire-project/clic", commit = "8d26222de71014554999e48c821906fca0e3dc41" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "403efe11405113cf12ae3d014df474cf7a046176" }
-minirest = { url = "https://github.com/mosteo/minirest.git", commit = "9045d8faafcea996fa7b51ccda84c54712eff821" }
+minirest = { url = "https://github.com/mosteo/minirest.git", commit = "17fa789b71ccaf65e8c892816456c94a09a384d0" }
 semantic_versioning = { url = "https://github.com/alire-project/semantic_versioning", commit = "2f23fc5f6b4855b836b599adf292fed9c0ed4144" }
 simple_logging = { url = "https://github.com/alire-project/simple_logging", commit = "3505dc645f3eef6799a486aae223d37e88cfc4d5" }
 stopwatch = { url = "https://github.com/mosteo/stopwatch", commit = "f607a63b714f09bbf6126de9851cbc21cf8666c9" }

--- a/doc/publishing.md
+++ b/doc/publishing.md
@@ -10,13 +10,14 @@ the [gitter channel](https://gitter.im/ada-lang/Alire) of the project.
 The simplest publishing experience, provided you have a GitHub account and
 Personal Access Token, consist on issuing
 ```
-alr publish --submit
+alr publish
 ```
 at the root of your workspace, when said workspace is an up-to-date clone of a
 git repository.
 
 The publishing assistant will review your submission, point out any necessary
-fixes or additional information required, and provide you with a tracking URL.
+fixes or additional information required, and request a pull into the community
+index on GitHub on your behalf.
 
 Read on for the details underlying these automated steps, or in case you need
 to perform further tweaking.
@@ -48,10 +49,11 @@ The community index is supported through two kinds of branches:
   format, during the development of `alr`.
 
 Your `alr` version knows which branch to use, so you do not need to manually
-select one. When using `alr publish` to assist on creating a release, you will
+select one. When using `alr publish` to assist on creating a release, `alr`
+will either create the pull request against the proper branch, or you will
 be provided with an upload link for the branch your `alr` is using.
 
-However, when submitting releases manually, you must decide to which branch
+However, when submitting releases manually, you can decide to which branch
 they will be added: selecting the latest stable branch results in the release
 becoming immediately available to the latest stable `alr`. Conversely, using
 the latest development branch will make the releases available for testing by
@@ -122,8 +124,9 @@ path to it.
 
 At this point, `alr publish` will carry out a few tests and, if everything
 checks out, it will create a `${repo_root}/alire/releases/crate-version.toml`
-file. This file must be submitted to the community index via a PR. A link for
-conveniently creating this PR will also be provided by `alr`:
+file. This file must be submitted to the community index via a PR. `alr` will
+offer to create the pull request for you, unless you specify `--skip-submit`.
+If so, a link for conveniently creating this PR will also be provided by `alr`:
 
 - Upload the generated index manifest file (`crate-version.toml`) to the
   supplied page link on github and create a pull-request.
@@ -185,8 +188,7 @@ URL to do so.
 
 Invoking `alr publish --tar` inside an Alire workspace will result in the
 creation of a source archive at `${CRATE_ROOT}/alire/archives/`. This archive
-must be manually uploaded (for now) by the user to a publicly accessible
-hosting service.
+must be manually uploaded by the user to a publicly accessible hosting service.
 
 After the upload, the user can supply the URL to fetch this archive to the
 publishing assistant (which will be waiting for this information), and the
@@ -251,8 +253,9 @@ link, you can follow the usual procedure to submit a PR to a github repository:
 ## Publishing outcome
 
 Once the pull request is verified and merged, the new release will become
-available for normal use. The open source Ada ecosystem needs all the help it
-can get, so thank you for contributing!
+available for normal use after running `alr index --update-all`. The open
+source Ada ecosystem needs all the help it can get, so thank you for
+contributing!
 
 ## ALR Badge
 

--- a/src/alire/alire-github.ads
+++ b/src/alire/alire-github.ads
@@ -46,7 +46,7 @@ package Alire.GitHub is
    --  one.
 
    function Find_Pull_Requests return GNATCOLL.JSON.JSON_Value;
-   --  Return open pull requests for the user
+   --  Return open pull requests created by the user
 
    function Fork
      (User    : String := User_Info.User_GitHub_Login;

--- a/src/alire/alire-github.ads
+++ b/src/alire/alire-github.ads
@@ -45,6 +45,9 @@ package Alire.GitHub is
    --  JSON info. It will return the unique open PR, or the most recent closed
    --  one.
 
+   function Find_Pull_Requests return GNATCOLL.JSON.JSON_Value;
+   --  Return open pull requests for the user
+
    function Fork
      (User    : String := User_Info.User_GitHub_Login;
       Owner   : String;

--- a/src/alire/alire-publish-states.adb
+++ b/src/alire/alire-publish-states.adb
@@ -1,6 +1,8 @@
 with Alire.GitHub;
 with Alire.Index;
 with Alire.URI;
+with Alire.Utils.Tables;
+with Alire.Utils.User_Input.Query_Config;
 
 with GNATCOLL.JSON;
 
@@ -26,6 +28,39 @@ package body Alire.Publish.States is
    function Webpage (PR : PR_Status) return URL
    is (Webpage (PR.Number));
 
+   ---------
+   -- Key --
+   ---------
+
+   package Key is
+      Head   : constant String := "head";
+      Label  : constant String := "label";
+      Number : constant String := "number";
+      State  : constant String := "state";
+   end Key;
+
+   package Val is
+      Open   : constant String := "open";
+   end Val;
+
+   ---------------
+   -- To_Status --
+   ---------------
+
+   function To_Status (Info : GNATCOLL.JSON.JSON_Value) return PR_Status
+   is
+   begin
+      return
+        (Exists  => True,
+         Branch  => +Info.Get (Key.Head).Get (Key.Label),
+         Number  => Info.Get (Key.Number),
+         Status  => (if Info.Get (Key.State) = Val.Open
+                     then Open
+                     else Rejected), -- TODO: be more precise in the future
+         Checks  => <> -- TODO: extract info about checks
+        );
+   end To_Status;
+
    -----------------------
    -- Find_Pull_Request --
    -----------------------
@@ -36,25 +71,21 @@ package body Alire.Publish.States is
       Result : constant JSON_Value := GitHub.Find_Pull_Request (M);
       List   : constant JSON_Array := Result.Get;
       Target :          JSON_Value := JSON_Null;
-
-      Key_Number : constant String := "number";
-      Key_State  : constant String := "state";
-      Val_Open   : constant String := "open";
    begin
       for I in 1 .. Length (List) loop
          declare
             Obj : constant JSON_Value := Get (List, I);
          begin
             --  Keep the first one we see
-            if Obj.Get (Key_State).Get = Val_Open then
+            if Obj.Get (Key.State).Get = Val.Open then
                Target := Obj;
                exit;
 
             elsif Target.Is_Empty
               or else
-                (Target.Get (Key_State) /= Val_Open
-                 and then Integer'(Target.Get (Key_Number).Get) <
-                   Obj.Get (Key_Number))
+                (Target.Get (Key.State) /= Val.Open
+                 and then Integer'(Target.Get (Key.Number).Get) <
+                   Obj.Get (Key.Number))
             then
                --  Keep the one with the highest #number
                Target := Obj;
@@ -65,14 +96,66 @@ package body Alire.Publish.States is
       if Target.Is_Empty then
          return (Exists => False);
       else
-         return
-           (Exists => True,
-            Number => Target.Get (Key_Number),
-            Status => (if Target.Get (Key_State) = Val_Open
-                       then Open
-                       else Rejected), -- TODO: be more precise in the future
-            others => <>); -- TODO: likewise, inform the rest of fields
+         return To_Status (Target);
       end if;
    end Find_Pull_Request;
+
+   ------------------------
+   -- Find_Pull_Requests --
+   ------------------------
+
+   function Find_Pull_Requests return Status_Array is
+      use AAA.Strings;
+      use GNATCOLL.JSON;
+      List : constant JSON_Array := GitHub.Find_Pull_Requests.Get;
+      Result : Status_Array (1 .. Length (List));
+      I      : Natural := Result'First;
+   begin
+      --  We can filter at GitHub side using the complete reference, but
+      --  surprisingly not by author only. Hence we have to filter here.
+      for J in 1 .. Length (List) loop
+         declare
+            Status : constant PR_Status := To_Status (Get (List, J));
+         begin
+            if Has_Prefix
+              (+Status.Branch,
+               Utils.User_Input.Query_Config.User_GitHub_Login & ":")
+            then
+               Result (I) := Status;
+               I := I + 1;
+            end if;
+         end;
+      end loop;
+
+      return Result (Result'First .. I - 1);
+   end Find_Pull_Requests;
+
+   ------------------
+   -- Print_Status --
+   ------------------
+
+   procedure Print_Status is
+      States : constant Status_Array := Find_Pull_Requests;
+      Table  : Utils.Tables.Table;
+   begin
+      if States'Length = 0 then
+         Trace.Always ("No pending submissions found.");
+         return;
+      end if;
+
+      Table.Header ("PR").Header ("Reference").Header ("Status").Header ("URL")
+        .New_Row;
+
+      for PR of States loop
+         Table
+           .Append (TTY.Emph (AAA.Strings.Trim (PR.Number'Image)))
+           .Append (+PR.Branch)
+           .Append (AAA.Strings.To_Mixed_Case (PR.Status'Image))
+           .Append (TTY.URL (Webpage (PR)))
+           .New_Row;
+      end loop;
+
+      Table.Print (Always);
+   end Print_Status;
 
 end Alire.Publish.States;

--- a/src/alire/alire-publish-states.ads
+++ b/src/alire/alire-publish-states.ads
@@ -28,7 +28,7 @@ package Alire.Publish.States is
    type Status_Array is array (Positive range <>) of Existing_PR_Status;
 
    function Is_Open (PR : PR_Status) return Boolean
-   is (PR.Exists and then PR.Status in Open | Changes_Requested);
+   is (PR.Exists and then PR.Status in Open_States);
 
    function Find_Pull_Request (M : Milestones.Milestone) return PR_Status;
    --  Find the status of a PR. Only one can be open, that will be returned in
@@ -37,7 +37,7 @@ package Alire.Publish.States is
    function Find_Pull_Requests return Status_Array
      with Post => (for all PR of Find_Pull_Requests'Result =>
                      PR.Status in Open_States);
-   --  Find all open pull requests for Crate
+   --  Find all open pull requests created by the user
 
    procedure Print_Status;
 

--- a/src/alire/alire-publish-states.ads
+++ b/src/alire/alire-publish-states.ads
@@ -4,30 +4,41 @@ package Alire.Publish.States is
 
    type Check_States is (Pending, Running, Failed, Succeeded);
 
-   type Life_States is (Open, Merged, Changes_Requested, Rejected);
-   --  Those are specific to our publishing needs, and cooked from github data
+   type Life_States is (Open, Changes_Requested, Merged, Rejected);
+
+   subtype Open_States is Life_States range Open .. Changes_Requested;
 
    type PR_Status (Exists : Boolean) is tagged record
       case Exists is
          when False => null;
          when True  =>
-            Number            : Natural      := 0;
-            Status            : Life_States  := Open;
-            Checks            : Check_States := Pending;
-            Changes_Requested : Boolean      := False;
+            Branch  : UString; -- In truth, it's `user:branch`
+            Number  : Natural      := 0;
+            Status  : Life_States  := Open;
+            Checks  : Check_States := Pending;
       end case;
    end record;
-
-   function Is_Open (PR : PR_Status) return Boolean
-   is (PR.Exists and then PR.Status in Open | Changes_Requested);
 
    function Webpage (PR : PR_Status) return URL;
 
    function Webpage (PR : Natural) return URL;
-   --  Build the URL from the PR number
+
+   subtype Existing_PR_Status is PR_Status (Exists => True);
+
+   type Status_Array is array (Positive range <>) of Existing_PR_Status;
+
+   function Is_Open (PR : PR_Status) return Boolean
+   is (PR.Exists and then PR.Status in Open | Changes_Requested);
 
    function Find_Pull_Request (M : Milestones.Milestone) return PR_Status;
    --  Find the status of a PR. Only one can be open, that will be returned in
    --  preference. Otherwise, the one closed more recently will be returned.
+
+   function Find_Pull_Requests return Status_Array
+     with Post => (for all PR of Find_Pull_Requests'Result =>
+                     PR.Status in Open_States);
+   --  Find all open pull requests for Crate
+
+   procedure Print_Status;
 
 end Alire.Publish.States;

--- a/src/alire/alire-utils-tables.adb
+++ b/src/alire/alire-utils-tables.adb
@@ -11,6 +11,14 @@ package body Alire.Utils.Tables is
       T.Append (TTY.Emph (AAA.Strings.To_Upper_Case (Cell)));
    end Header;
 
+   function Header (T    : aliased in out Table;
+                    Cell : String)
+                    return access Table is
+   begin
+      T.Header (Cell);
+      return T'Access;
+   end Header;
+
    -----------
    -- Print --
    -----------

--- a/src/alire/alire-utils-tables.ads
+++ b/src/alire/alire-utils-tables.ads
@@ -6,6 +6,10 @@ package Alire.Utils.Tables with Preelaborate is
 
    procedure Header (T : in out Table; Cell : String);
 
+   function Header (T    : aliased in out Table;
+                    Cell : String)
+                    return access Table;
+
    procedure Print (T         : Table;
                     Level     : Trace.Levels            := Info;
                     Separator : String                  := " ";

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -113,6 +113,12 @@ package body Alr.Commands.Publish is
 
       Define_Switch
         (Config,
+         Cmd.Skip_Build'Access,
+         "", "--skip-build",
+         "Skip the build check step");
+
+      Define_Switch
+        (Config,
          Cmd.Skip_Submit'Access,
          "", "--skip-submit",
          "Do not create the online pull request onto the community index");
@@ -129,12 +135,6 @@ package body Alr.Commands.Publish is
          Cmd.Print_Trusted'Access,
          "", "--trusted-sites",
          "Print a list of trusted git repository sites");
-
-      Define_Switch
-        (Config,
-         Cmd.Skip_Build'Access,
-         "", "--skip-build",
-         "Skip the build check step");
    end Setup_Switches;
 
 end Alr.Commands.Publish;

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -1,5 +1,5 @@
 with Alire.Origins;
-with Alire.Publish;
+with Alire.Publish.States;
 with Alire.URI;
 with Alire.Utils;
 
@@ -29,7 +29,8 @@ package body Alr.Commands.Publish is
                      Skip_Submit => Cmd.Skip_Submit);
 
    begin
-      if Alire.Utils.Count_True ((Cmd.Tar, Cmd.Print_Trusted)) > 1 or else
+      if Alire.Utils.Count_True
+        ((Cmd.Tar, Cmd.Print_Trusted, Cmd.Status)) > 1 or else
         (Cmd.Manifest.all /= "" and then Cmd.Print_Trusted)
       then
          Reportaise_Wrong_Arguments
@@ -51,6 +52,9 @@ package body Alr.Commands.Publish is
            (Path     => (if Args.Count >= 1 then Args (1) else "."),
             Revision => (if Args.Count >= 2 then Args (2) else "HEAD"),
             Options  => Options);
+
+      elsif Cmd.Status then
+         Alire.Publish.States.Print_Status;
 
       else
          if Args.Count < 1 then
@@ -122,6 +126,12 @@ package body Alr.Commands.Publish is
          Cmd.Skip_Submit'Access,
          "", "--skip-submit",
          "Do not create the online pull request onto the community index");
+
+      Define_Switch
+        (Config,
+         Cmd.Status'Access,
+         "", "--status",
+         "Check the status of the last pull request for the crate");
 
       Define_Switch
         (Config,

--- a/src/alr/alr-commands-publish.ads
+++ b/src/alr/alr-commands-publish.ads
@@ -69,7 +69,7 @@ private
       --  Stop after generation instead of asking the user to continue
 
       Status     : aliased Boolean := False;
-      --  Retrieve the status of the last opened PR for the crate
+      --  Retrieve the status of PRs opened by the user
 
       Tar        : aliased Boolean := False;
       --  Start the assistant from a local folder to be tar'ed and uploaded

--- a/src/alr/alr-commands-publish.ads
+++ b/src/alr/alr-commands-publish.ads
@@ -68,6 +68,9 @@ private
       Skip_Submit : aliased Boolean := False;
       --  Stop after generation instead of asking the user to continue
 
+      Status     : aliased Boolean := False;
+      --  Retrieve the status of the last opened PR for the crate
+
       Tar        : aliased Boolean := False;
       --  Start the assistant from a local folder to be tar'ed and uploaded
    end record;


### PR DESCRIPTION
Doubt: make it `alr publish --list` as with other commands?

Prints a table with PRs opened by the user. To be refined with check status later on:
```
PR  REFERENCE                 STATUS URL
999 mosteo:release/umwi-0.1.0 Open   https://github.com/alire-project/alire-index/pull/999
817 mosteo:gnat_ce_alt        Open   https://github.com/alire-project/alire-index/pull/817
734 mosteo:crate/gnatstudio   Open   https://github.com/alire-project/alire-index/pull/734
```
The first one is created by `alr`, the rest were created manually so the reference name isn't as informative.