### PR TITLE
dev: use env for executable shebangs

### DIFF
--- a/dev/build.sh
+++ b/dev/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Import reusable bits
 pushd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) > /dev/null

--- a/dev/functions.sh
+++ b/dev/functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env
 
 function guess_OS() {
     # Returns one of the values needed in ALIRE_OS, using environment variables

--- a/dev/unused.sh
+++ b/dev/unused.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env
 
 # Import reusable bits
 pushd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) > /dev/null


### PR DESCRIPTION
Use `/usr/bin/env bash` instead of `/bin/bash` so that the scripts can run in more exotic environments, i.e., NixOS. Thanks!