### PR TITLE
New `alr publish --request-review`

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -6,6 +6,14 @@ stay on top of `alr` new features.
 
 ## Release `2.0-dev`
 
+### Request review of an index submission with `alr publish --request-review`
+
+PR [#1409](https://github.com/alire-project/alire/pull/1409)
+
+When a submission has passed all server-side tests, for the time being it must
+be reviewed and merged manually. This can now be done with `alr publish
+--request-review <num>`.
+
 ### Cancel an index submission with `alr publish --cancel`
 
 PR [#1406](https://github.com/alire-project/alire/pull/1406)

--- a/src/alire/alire-github.adb
+++ b/src/alire/alire-github.adb
@@ -21,6 +21,18 @@ package body Alire.GitHub is
    Base_URL    : constant URL    := "https://api.github.com";
    Header_Rate : constant String := "X-Ratelimit-Remaining";
 
+   Repos       : constant String := "repos";
+   Pulls       : constant String := "pulls";
+
+   -------------------
+   -- Community_API --
+   -------------------
+
+   function Community_API return String
+   is (Repos
+       / Index.Community_Organization
+       / Index.Community_Repo_Name);
+
    -----------------
    -- JSON_Escape --
    -----------------
@@ -322,6 +334,32 @@ package body Alire.GitHub is
 
       return Pending;
    end Fork;
+
+   ------------
+   -- Checks --
+   ------------
+
+   function Checks (SHA : String) return JSON_Value
+   is (API_Call
+       (Community_API
+          / "actions"
+          / "runs",
+          Args =>
+             "per_page" = 100
+         and "head_sha" = SHA));
+
+   -------------
+   -- Reviews --
+   -------------
+
+   function Reviews (PR : Natural) return JSON_Value
+   is (API_Call
+       (Repos
+          / Index.Community_Organization
+          / Index.Community_Repo_Name
+          / Pulls
+          / AAA.Strings.Trim (PR'Image)
+          / "reviews"));
 
    -----------------
    -- Repo_Exists --

--- a/src/alire/alire-github.ads
+++ b/src/alire/alire-github.ads
@@ -73,6 +73,11 @@ package Alire.GitHub is
    --  elapses without succeeding, it will return Pending. It'll only raise if
    --  the initial request is denied.
 
+   procedure Request_Review (Number  : Natural;
+                             Node_ID : String);
+   --  The Node_ID is the "node_id" returned by the REST API, which is the "id"
+   --  needed by the GraphQL API.
+
    function Checks (SHA : String) return JSON_Value;
    --  Get the workflow run results on a commit
 

--- a/src/alire/alire-github.ads
+++ b/src/alire/alire-github.ads
@@ -6,6 +6,8 @@ with GNATCOLL.JSON;
 
 package Alire.GitHub is
 
+   subtype JSON_Value is GNATCOLL.JSON.JSON_Value;
+
    Env_GH_Token : constant String := "GH_TOKEN";
    --  This is the environment variable used by the `gh` tool to look for the
    --  user token. We can reuse it so if it's available, we need not pester the
@@ -40,16 +42,16 @@ package Alire.GitHub is
    --  Returns the number of the PR just created
 
    function Find_Pull_Request (M : Milestones.Milestone)
-                               return GNATCOLL.JSON.JSON_Value;
+                               return JSON_Value;
    --  Find a pull request that matches the user and branch, and return the raw
    --  JSON info. It will return the unique open PR, or the most recent closed
    --  one.
 
    function Find_Pull_Request (Number : Natural)
-                               return GNATCOLL.JSON.JSON_Value;
+                               return JSON_Value;
    --  Find the PR with the given number, in any state
 
-   function Find_Pull_Requests return GNATCOLL.JSON.JSON_Value;
+   function Find_Pull_Requests return JSON_Value;
    --  Return open pull requests created by the user
 
    procedure Comment (Number : Natural; Text : String);
@@ -70,6 +72,12 @@ package Alire.GitHub is
    --  accepted, so we have to busy wait for it to become available. If Timeout
    --  elapses without succeeding, it will return Pending. It'll only raise if
    --  the initial request is denied.
+
+   function Checks (SHA : String) return JSON_Value;
+   --  Get the workflow run results on a commit
+
+   function Reviews (PR : Natural) return JSON_Value;
+   --  Get the reviews for a pull request
 
    function Repo_Exists
      (User : String := User_Info.User_GitHub_Login;

--- a/src/alire/alire-publish-states.adb
+++ b/src/alire/alire-publish-states.adb
@@ -6,6 +6,8 @@ with Alire.URI;
 with Alire.Utils.Tables;
 with Alire.Utils.User_Input.Query_Config;
 
+with AnsiAda;
+
 with CLIC.User_Input;
 
 with GNATCOLL.JSON;
@@ -268,8 +270,26 @@ package body Alire.Publish.States is
    ------------------
 
    procedure Print_Status is
+
+      use AAA.Strings;
+      use AnsiAda;
+
       States : constant Status_Array := Find_Pull_Requests;
       Table  : Utils.Tables.Table;
+
+      -----------
+      -- Color --
+      -----------
+
+      function Color (Status : Lifecycle_States) return String
+      is (case Status is
+             when Checks_Failed | Rejected =>
+                Foreground (Light_Red),
+             when Checks_Passed | Merged   =>
+                Foreground (Light_Green),
+             when Checks_Pending | Under_Review | Changes_Requested =>
+                Foreground (Light_Yellow));
+
    begin
       if States'Length = 0 then
          Trace.Always ("No pending submissions found.");
@@ -283,7 +303,8 @@ package body Alire.Publish.States is
          Table
            .Append (TTY.Emph (AAA.Strings.Trim (PR.Number'Image)))
            .Append (+PR.Branch)
-           .Append (AAA.Strings.To_Mixed_Case (PR.Status'Image))
+           .Append (Color_Wrap (To_Mixed_Case (PR.Status'Image),
+                                Color (PR.Status)))
            .Append (TTY.URL (Webpage (PR)))
            .New_Row;
       end loop;

--- a/src/alire/alire-publish-states.adb
+++ b/src/alire/alire-publish-states.adb
@@ -20,7 +20,7 @@ package body Alire.Publish.States is
    -------------
    -- Matches --
    -------------
-   --  The API isn't fully consistent on the case of returned enums
+   --  The GitHub API isn't fully consistent on the case of returned enums
    function Matches (S : String; Target : String) return Boolean
    is
       use AAA.Strings;

--- a/src/alire/alire-publish-states.ads
+++ b/src/alire/alire-publish-states.ads
@@ -27,6 +27,7 @@ package Alire.Publish.States is
          when True  =>
             Branch  : UString; -- In truth, it's `user:branch`
             Number  : Natural           := 0;
+            Node_ID : UString;
             Title   : UString;
             Status  : Lifecycle_States  := Checks_Ongoing;
       end case;
@@ -47,6 +48,8 @@ package Alire.Publish.States is
    --  Find the status of a PR. Only one can be open, that will be returned in
    --  preference. Otherwise, the one closed more recently will be returned.
 
+   function Find_Pull_Request (PR : Natural) return PR_Status;
+
    function Find_Pull_Requests return Status_Array
      with Post => (for all PR of Find_Pull_Requests'Result =>
                      PR.Status in Open_States);
@@ -55,5 +58,8 @@ package Alire.Publish.States is
    procedure Print_Status;
 
    procedure Cancel (PR : Natural; Reason : String);
+
+   procedure Request_Review (PR : Natural);
+   --  Remove Draft flag from PR and request review from Alire developers team
 
 end Alire.Publish.States;

--- a/src/alire/alire-publish-states.ads
+++ b/src/alire/alire-publish-states.ads
@@ -27,7 +27,7 @@ package Alire.Publish.States is
          when True  =>
             Branch  : UString; -- In truth, it's `user:branch`
             Number  : Natural           := 0;
-            Node_ID : UString;
+            Node_ID : UString; -- Internal ID for the GraphQL API
             Title   : UString;
             Status  : Lifecycle_States  := Checks_Ongoing;
       end case;

--- a/src/alire/alire-publish-states.ads
+++ b/src/alire/alire-publish-states.ads
@@ -3,7 +3,7 @@ with Alire.Milestones;
 package Alire.Publish.States is
 
    type Lifecycle_States is
-     (Checks_Pending,    -- Waiting for checks to complete, draft or not
+     (Checks_Ongoing,    -- Waiting for checks to complete, draft or not
       Checks_Failed,     -- Some automated check failed
       Checks_Passed,     -- Checks successful, still in draft mode
       Under_Review,      -- Checks successful, no longer a draft, devs notified
@@ -16,10 +16,10 @@ package Alire.Publish.States is
    --  checks, and reviews.
 
    subtype Check_States
-     is Lifecycle_States range Checks_Pending .. Checks_Passed;
+     is Lifecycle_States range Checks_Ongoing .. Checks_Passed;
 
    subtype Open_States
-     is Lifecycle_States range Checks_Pending .. Changes_Requested;
+     is Lifecycle_States range Checks_Ongoing .. Changes_Requested;
 
    type PR_Status (Exists : Boolean) is tagged record
       case Exists is
@@ -28,7 +28,7 @@ package Alire.Publish.States is
             Branch  : UString; -- In truth, it's `user:branch`
             Number  : Natural           := 0;
             Title   : UString;
-            Status  : Lifecycle_States  := Checks_Pending;
+            Status  : Lifecycle_States  := Checks_Ongoing;
       end case;
    end record;
 

--- a/src/alire/alire-publish-states.ads
+++ b/src/alire/alire-publish-states.ads
@@ -2,21 +2,33 @@ with Alire.Milestones;
 
 package Alire.Publish.States is
 
-   type Check_States is (Pending, Running, Failed, Succeeded);
+   type Lifecycle_States is
+     (Checks_Pending,    -- Waiting for checks to complete, draft or not
+      Checks_Failed,     -- Some automated check failed
+      Checks_Passed,     -- Checks successful, still in draft mode
+      Under_Review,      -- Checks successful, no longer a draft, devs notified
+      Changes_Requested, -- Open with changes requested by some reviewer
+      Merged,            -- Closed with merge
+      Rejected           -- Closed without merge
+     );
+   --  These states correspond to our desired workflow and not exactly to GH
+   --  states. See explanations for each state. It uses a combo of PR status,
+   --  checks, and reviews.
 
-   type Life_States is (Open, Changes_Requested, Merged, Rejected);
+   subtype Check_States
+     is Lifecycle_States range Checks_Pending .. Checks_Passed;
 
-   subtype Open_States is Life_States range Open .. Changes_Requested;
+   subtype Open_States
+     is Lifecycle_States range Checks_Pending .. Changes_Requested;
 
    type PR_Status (Exists : Boolean) is tagged record
       case Exists is
          when False => null;
          when True  =>
             Branch  : UString; -- In truth, it's `user:branch`
-            Number  : Natural      := 0;
+            Number  : Natural           := 0;
             Title   : UString;
-            Status  : Life_States  := Open;
-            Checks  : Check_States := Pending;
+            Status  : Lifecycle_States  := Checks_Pending;
       end case;
    end record;
 

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -39,7 +39,7 @@ package body Alr.Commands.Publish is
    begin
       if Alire.Utils.Count_True
         ((Cmd.Tar, Cmd.Print_Trusted, Cmd.Status,
-          Cmd.Cancel.all /= Unset)) > 1
+          Cmd.Cancel.all /= Unset, Cmd.Review.all /= Unset)) > 1
         or else
         (Cmd.Manifest.all /= "" and then Cmd.Print_Trusted)
       then
@@ -76,11 +76,18 @@ package body Alr.Commands.Publish is
 
          if not Args.Is_Empty then
             Reportaise_Wrong_Arguments
-              ("Unexpected argumets; verify --reason text is quoted");
+              ("Unexpected arguments; verify --reason text is quoted");
          end if;
 
          Alire.Publish.States.Cancel (PR     => To_Int (Cmd.Cancel.all),
                                       Reason => Cmd.Reason.all);
+
+      elsif Cmd.Review.all /= Unset then
+         if not Args.Is_Empty then
+            Reportaise_Wrong_Arguments ("Unexpected arguments");
+         end if;
+
+         Alire.Publish.States.Request_Review (To_Int (Cmd.Review.all));
 
       elsif Cmd.Status then
          Alire.Publish.States.Print_Status;
@@ -169,6 +176,13 @@ package body Alr.Commands.Publish is
          "", "--reason=",
          "Give a message for the record on why the PR is being closed",
          Argument => "'short text'");
+
+      Define_Switch
+        (Config,
+         Cmd.Review'Access,
+         "", "--request-review=",
+         "Remove draft status from the pull request and request a review",
+         Argument => "NUM");
 
       Define_Switch
         (Config,

--- a/src/alr/alr-commands-publish.ads
+++ b/src/alr/alr-commands-publish.ads
@@ -52,7 +52,7 @@ package Alr.Commands.Publish is
    overriding
    function Usage_Custom_Parameters (Cmd : Command) return String
    is ("[--skip-build] [--skip-submit] [--tar] "
-       & "[--manifest <file>] [<URL> [commit]]]");
+       & "[--manifest <file>] [<URL> [commit]]] [--request-review NUM]");
 
 private
 

--- a/src/alr/alr-commands-publish.ads
+++ b/src/alr/alr-commands-publish.ads
@@ -74,6 +74,9 @@ private
       Reason     : aliased GNAT.Strings.String_Access := new String'(Unset);
       --  Reason to give when closing the PR
 
+      Review     : aliased GNAT.Strings.String_Access := new String'(Unset);
+      --  True when requesting a review for a PR
+
       Status     : aliased Boolean := False;
       --  Retrieve the status of PRs opened by the user
 


### PR DESCRIPTION
This one also includes a more fine grained status for the open PRs, which allows seeing how a PR is doing with more precision.

With this the ability to automate submission of new releases is complete: submit online, check status, and request review or cancel once tests finish.