### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,10 +31,14 @@ jobs:
       with:
         submodules: true
 
+    # Until some stable alr with `alr install` is available, we cannot rely on
+    # the alr-install action, as that introduces a circular dependency. If a
+    # nightly build were to fail, there's no way to do an `alr install` anymore
+    # TODO: replace with `alr-install` once alr 2.0 is out.
     - name: Install FSF toolchain
-      uses: alire-project/alr-install@v1
+      uses: ada-actions/toolchain@ce2020
       with:
-        crates: gnat_native gprbuild
+        distrib: community
 
     - name: Install Python 3.x (required for the testsuite)
       uses: actions/setup-python@v2


### PR DESCRIPTION
At some point I got ahead of myself and introduced a circularity where the nightly build must exist before a new one can be produced. So, the first time a nightly build failed because of some network glitch, it couldn't succeed anymore.