### PR TITLE
Better random generation of temp file names

### DIFF
--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -249,6 +249,7 @@ private
 
    overriding
    procedure Initialize (This : in out Temp_File);
+
    overriding
    procedure Finalize (This : in out Temp_File);
 


### PR DESCRIPTION
The issue was with the default random seed being the same during a whole second, so batch runs in the testsuite did clash from time to time, even in the Github VMs, causing spurious errors.