### PR TITLE
Delay syncing shared build dir until the actual build

### DIFF
--- a/src/alire/alire-crate_configuration.adb
+++ b/src/alire/alire-crate_configuration.adb
@@ -429,7 +429,8 @@ package body Alire.Crate_Configuration is
                      Ent : constant Config_Entry := Get_Config_Entry (Rel);
 
                      Conf_Dir : constant Absolute_Path :=
-                                 Root.Release_Base (Rel.Name) / Ent.Output_Dir;
+                                  Root.Release_Base (Rel.Name, Roots.For_Build)
+                                  / Ent.Output_Dir;
 
                      Version_Str : constant String := Rel.Version.Image;
                   begin

--- a/src/alire/alire-environment.adb
+++ b/src/alire/alire-environment.adb
@@ -168,7 +168,7 @@ package body Alire.Environment is
       Release_Base : constant String
         := (if For_Hashing
             then Rel.Base_Folder
-            else Root.Current.Release_Base (Rel.Name));
+            else Root.Current.Release_Base (Rel.Name, Roots.For_Build));
             --  Before we can known the Release_Base, we supplant it with its
             --  simple name. This shouldn't be a problem for hashing, as this
             --  is only used for $CRATE_ROOT paths, and the important parts

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -134,7 +134,8 @@ package Alire.Roots is
    --  and release particulars (binary...)
 
    function Release_Base (This  : in out Root;
-                          Crate : Crate_Name)
+                          Crate : Crate_Name;
+                          Usage : Usages)
                           return Absolute_Path;
    --  Find the base folder in which a release can be found for the given root
 
@@ -408,5 +409,8 @@ private
    procedure Commit (This : in out Root);
    --  Renames the manifest and lockfile to their regular places, making this
    --  root a regular one to all effects.
+
+   procedure Sync_Builds (This : in out Root);
+   --  Sync from vault to final build location, and generate config
 
 end Alire.Roots;

--- a/src/alr/alr-commands-action.adb
+++ b/src/alr/alr-commands-action.adb
@@ -126,7 +126,9 @@ package body Alr.Commands.Action is
             then
                Some_Output := True;
                declare
-                  CWD : Guard (Enter (Cmd.Root.Release_Base (Rel.Name)))
+                  use all type Alire.Roots.Usages;
+                  CWD : Guard (Enter (Cmd.Root.Release_Base (Rel.Name,
+                                                             For_Build)))
                     with Unreferenced;
                begin
                   Alire.Properties.Actions.Executor.Execute_Actions

--- a/testsuite/tests/config/shared-deps/test.py
+++ b/testsuite/tests/config/shared-deps/test.py
@@ -33,20 +33,31 @@ assert_contents(base := os.path.join(vault_dir, "hello_1.0.1_filesystem"),
                  f'{base}/src',
                  f'{base}/src/hello.adb'])
 
-# Check the contents in the build dir, that should include generated configs
+# Check the contents in the build dir, that should not include generated config
+# because no build has been attempted yet, hence a sync has not been performed.
 
 # We need to find the hash first
 base = glob.glob(os.path.join(build_dir, "hello_1.0.1_filesystem_*"))[0]
 
 assert_contents(base,
                 [f'{base}/alire',
+                 f'{base}/alire/build_hash_inputs'
+                 ])
+
+# Do a build, and now the sync should have happened and the build dir be filled
+run_alr("build")
+
+assert_contents(base,
+                [f'{base}/alire',
                  f'{base}/alire.toml',
+                 f'{base}/alire/build_hash_inputs',
                  f'{base}/alire/complete_copy',
                  f'{base}/config',
                  f'{base}/config/hello_config.ads',
                  f'{base}/config/hello_config.gpr',
                  f'{base}/config/hello_config.h',
                  f'{base}/hello.gpr',
+                 f'{base}/obj',
                  f'{base}/src',
                  f'{base}/src/hello.adb'])
 


### PR DESCRIPTION
This is necessary because build dir hashes depend on crate configurations being complete, and this is only required at the time of building. So this PR is in preparation of adding the crate configuration to the build hash computation.