### PR TITLE
Generate crate config on demand for shared dependencies

### DIFF
--- a/src/alire/alire-builds.adb
+++ b/src/alire/alire-builds.adb
@@ -62,6 +62,9 @@ package body Alire.Builds is
                  "Could not sync build dir from " & Src & " to " & Dst);
       end;
 
+      --  At this point we can generate the final crate configuration
+      Root.Configuration.Generate_Config_Files (Root, Release);
+
       declare
          use Directories;
          Work_Dir : Guard (Enter (Dst)) with Unreferenced;

--- a/src/alire/alire-crate_configuration.ads
+++ b/src/alire/alire-crate_configuration.ads
@@ -2,6 +2,7 @@ with TOML;
 
 with Alire.Utils.Switches;
 with Alire.Properties.Configurations;
+with Alire.Releases;
 limited with Alire.Roots;
 
 private with Ada.Strings.Unbounded;
@@ -55,6 +56,11 @@ package Alire.Crate_Configuration is
 
    procedure Generate_Config_Files (This : Global_Config;
                                     Root : in out Alire.Roots.Root);
+
+   procedure Generate_Config_Files (This : Global_Config;
+                                    Root : in out Alire.Roots.Root;
+                                    Rel  : Releases.Release);
+   --  Generate config files only for the given release
 
    procedure Save_Last_Build_Profiles (This : Global_Config);
    --  Record in local user configuration the last profiles used in crate

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -210,6 +210,10 @@ package body Alire.Roots is
          This.Deploy_Dependencies;
          This.Sync_Builds;
          --  Changes in configuration may require new build dirs
+         This.Configuration.Generate_Config_Files (This, Release (This));
+         --  Generate the config for the root crate.
+         --  TODO: generate only when changed (same optimization as for
+         --  sandboxed dependencies).
       end if;
 
       if Export_Build_Env or else not Builds.Sandboxed_Dependencies then
@@ -868,12 +872,6 @@ package body Alire.Roots is
 
       --  Visit dependencies in safe order
       This.Traverse (Doing => Sync_Release'Access);
-
-      --  Update/Create configuration files
-      This.Generate_Configuration;
-      --  TODO: this should be made more granular to only generate
-      --  configurations of newly synced build sources, since with the
-      --  new shared builds system configs do not change once created.
    end Sync_Builds;
 
    -----------------------------


### PR DESCRIPTION
We needn't to generate it more than once, when the unique build folder is created.

The diff isn't very clear but this is mostly moving stuff around.