### PR TITLE
Include hash of dependencies in build hash

### DIFF
--- a/testsuite/drivers/builds.py
+++ b/testsuite/drivers/builds.py
@@ -6,7 +6,7 @@ from glob import glob
 import os
 from shutil import rmtree
 import subprocess
-from drivers.alr import alr_builds_dir, run_alr
+from drivers.alr import alr_builds_dir
 
 
 def clear_builds_dir() -> None:

--- a/testsuite/tests/build/hashes/compiler-input/test.py
+++ b/testsuite/tests/build/hashes/compiler-input/test.py
@@ -38,7 +38,7 @@ check_hash(f"version:gnat_external={external_compiler_version()}")
 # Next, check that selecting a compiler results in it being used
 
 # Select the default preferred compiler, in this index is gnat_native=8888
-run_alr("toolchain", "--select", "gnat_native")
+run_alr("toolchain", "--select", "gnat_native", "gprbuild")
 # Clear the build cache so we are able to locate the new hash
 clear_builds_dir()
 builds.sync()

--- a/testsuite/tests/build/hashes/config-types/test.py
+++ b/testsuite/tests/build/hashes/config-types/test.py
@@ -3,7 +3,7 @@ Check the different config types in the hash inputs
 """
 
 from drivers.alr import alr_with, external_compiler_version, init_local_crate, run_alr
-from drivers.builds import hash_input
+from drivers.builds import find_hash, hash_input
 from drivers.asserts import assert_eq
 from drivers import builds
 
@@ -13,8 +13,8 @@ init_local_crate()
 alr_with("hello=1.0.1")
 builds.sync()
 
-# Chech that the hash inputs contains exactly what we expect it to contain
-
+# Chech that the hash inputs contains exactly what we expect it to contain.
+# We cannot know the dependency hash in advance as it depends on the compiler.
 assert_eq(
     'config:hello.var1=true\n'
     'config:hello.var2=str\n'
@@ -23,6 +23,7 @@ assert_eq(
     'config:hello.var5=0\n'
     'config:hello.var6=0.00000000000000E+00\n'
     'config:hello.var7=0.00000000000000E+00\n'
+    f'dependency:libhello=1.0.0={find_hash("libhello")}\n'
     'profile:hello=RELEASE\n'
     f'version:gnat_external={external_compiler_version()}\n',
     hash_input("hello"))

--- a/testsuite/tests/crate_config/no-rebuilds/test.py
+++ b/testsuite/tests/crate_config/no-rebuilds/test.py
@@ -16,7 +16,7 @@ assert_match('.*gprbuild: "xxx.*" up to date', p.out)
 
 # Switch to another profile and build must happen
 p = run_alr("build", "--validation", quiet=False)
-assert_match('.*\[link\]         xxx.adb', p.out)
+assert_match('.*\[Ada\]\s+xxx.adb', p.out)
 
 # Use same profile, nothing should be recompiled
 p = run_alr("build", "--validation", quiet=False)


### PR DESCRIPTION
Since a dependency may use different specs based on config values, environment variables, GPR externals... we include the hash of dependencies in dependents' hash inputs. It shouldn't be a factor for most crates that don't use such things.