### PR TITLE
New `alr printenv --last-build`

### DIFF
--- a/src/alr/alr-commands-config.adb
+++ b/src/alr/alr-commands-config.adb
@@ -1,5 +1,3 @@
-with AAA.Enum_Tools;
-
 with Alire.Config;
 with Alire.Config.Edit;
 with Alire.Root;
@@ -109,21 +107,17 @@ package body Alr.Commands.Config is
 
             --  Check explicitly for booleans to store the proper TOML type
             --  regardless of the capitalization used by the user.
-            declare
-               function Is_Boolean is new AAA.Enum_Tools.Is_Valid (Boolean);
-            begin
-               if Is_Boolean (Val) then
-                  Alire.Config.Edit.Set_Boolean
-                    (Lvl,
-                     Key, Boolean'Value (Val),
-                     Check => Alire.Config.Edit.Valid_Builtin'Access);
-               else
-                  Alire.Config.Edit.Set
-                    (Lvl,
-                     Key, Val,
-                     Check => Alire.Config.Edit.Valid_Builtin'Access);
-               end if;
-            end;
+            if Is_Boolean (Val) then
+               Alire.Config.Edit.Set_Boolean
+                 (Lvl,
+                  Key, Boolean'Value (Val),
+                  Check => Alire.Config.Edit.Valid_Builtin'Access);
+            else
+               Alire.Config.Edit.Set
+                 (Lvl,
+                  Key, Val,
+                  Check => Alire.Config.Edit.Valid_Builtin'Access);
+            end if;
          end;
 
       elsif Cmd.Unset then

--- a/src/alr/alr-commands-edit.adb
+++ b/src/alr/alr-commands-edit.adb
@@ -96,7 +96,6 @@ package body Alr.Commands.Edit is
                Reportaise_Command_Failed
                  ("'" & Exec & "' not available or not in PATH.");
             end if;
-            return;
          end if;
       end;
 

--- a/src/alr/alr-commands-index.adb
+++ b/src/alr/alr-commands-index.adb
@@ -53,7 +53,6 @@ package body Alr.Commands.Index is
    begin
       if not Result.Success then
          Reportaise_Command_Failed (Alire.Message (Result));
-         return;
       end if;
 
       --  Find matching index and delete
@@ -159,7 +158,6 @@ package body Alr.Commands.Index is
    begin
       if not Result.Success then
          Reportaise_Command_Failed (Alire.Message (Result));
-         return;
       end if;
 
       Table

--- a/src/alr/alr-commands-printenv.adb
+++ b/src/alr/alr-commands-printenv.adb
@@ -1,3 +1,4 @@
+with Alire.Crate_Configuration;
 with Alire.Environment;
 with Alire.Platforms;
 
@@ -28,6 +29,11 @@ package body Alr.Commands.Printenv is
       end if;
 
       Cmd.Requires_Workspace;
+
+      if Cmd.Last_Build then
+         Cmd.Root.Set_Build_Profiles
+           (Alire.Crate_Configuration.Last_Build_Profiles);
+      end if;
 
       declare
          Context : constant Alire.Environment.Context :=
@@ -89,6 +95,10 @@ package body Alr.Commands.Printenv is
                      Cmd.Cmd_Shell'Access,
                      "", "--wincmd",
                      "Use a Windows CMD shell format for the export");
+      Define_Switch (Config,
+                     Cmd.Last_Build'Access,
+                     "", "--last-build",
+                     "Use last build profiles instead of manifest profiles");
    end Setup_Switches;
 
 end Alr.Commands.Printenv;

--- a/src/alr/alr-commands-printenv.adb
+++ b/src/alr/alr-commands-printenv.adb
@@ -4,6 +4,8 @@ with Alire.Platforms;
 
 package body Alr.Commands.Printenv is
 
+   Last_Build_Switch : constant String := "--last-build";
+
    -------------
    -- Execute --
    -------------
@@ -30,7 +32,7 @@ package body Alr.Commands.Printenv is
 
       Cmd.Requires_Workspace;
 
-      if Cmd.Last_Build then
+      if To_Boolean (Cmd.Last_Build, "--last-build", True) then
          Cmd.Root.Set_Build_Profiles
            (Alire.Crate_Configuration.Last_Build_Profiles);
       end if;
@@ -97,8 +99,9 @@ package body Alr.Commands.Printenv is
                      "Use a Windows CMD shell format for the export");
       Define_Switch (Config,
                      Cmd.Last_Build'Access,
-                     "", "--last-build",
-                     "Use last build profiles instead of manifest profiles");
+                     "", Last_Build_Switch & "?",
+                     "Use last build profiles (default) or manifest profiles",
+                     Argument => "=BOOLEAN");
    end Setup_Switches;
 
 end Alr.Commands.Printenv;

--- a/src/alr/alr-commands-printenv.ads
+++ b/src/alr/alr-commands-printenv.ads
@@ -36,5 +36,6 @@ private
       Unix_Shell  : aliased Boolean := False;
       Power_Shell : aliased Boolean := False;
       Cmd_Shell   : aliased Boolean := False;
+      Last_Build  : aliased Boolean := False;
    end record;
 end Alr.Commands.Printenv;

--- a/src/alr/alr-commands-printenv.ads
+++ b/src/alr/alr-commands-printenv.ads
@@ -36,6 +36,6 @@ private
       Unix_Shell  : aliased Boolean := False;
       Power_Shell : aliased Boolean := False;
       Cmd_Shell   : aliased Boolean := False;
-      Last_Build  : aliased Boolean := False;
+      Last_Build  : aliased GNAT_String := new String'(Unset);
    end record;
 end Alr.Commands.Printenv;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -579,6 +579,31 @@ package body Alr.Commands is
       Cmd.Optional_Root := Alire.Roots.Optional.Outcome_Success (Root);
    end Set;
 
+   ----------------
+   -- To_Boolean --
+   ----------------
+
+   function To_Boolean (Image   : GNAT_String;
+                        Switch  : String;
+                        Default : Boolean)
+                        return Boolean
+   is
+   begin
+      if Image in null or else Image.all = "" or else Image.all = Unset then
+         return Default;
+      elsif Is_Boolean (Image.all) then
+         return Boolean'Value (Image.all);
+      elsif Image (Image'First) = '=' then
+         return To_Boolean (new String'(Image (Image'First + 1 .. Image'Last)),
+                            Switch  => Switch,
+                            Default => Default);
+      else
+         Reportaise_Wrong_Arguments
+           ("Value for switch " & Switch & " is not a proper boolean: "
+            & Image.all);
+      end if;
+   end To_Boolean;
+
 begin
 
    -- Commands --

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -1,3 +1,4 @@
+private with AAA.Enum_Tools;
 with AAA.Strings;
 
 with Alire.Directories;
@@ -8,6 +9,7 @@ with Alire.Version;
 with CLIC.Subcommand;
 
 private with GNAT.IO;
+private with GNAT.Strings;
 private with CLIC.Subcommand.Instance;
 
 private with Alr.OS_Lib; -- For the benefit of many child packages that use it
@@ -109,8 +111,8 @@ private
    --  Facilities for command/argument identification. These are available to
    --  commands.
 
-   procedure Reportaise_Command_Failed  (Message : String);
-   procedure Reportaise_Wrong_Arguments (Message : String);
+   procedure Reportaise_Command_Failed  (Message : String) with No_Return;
+   procedure Reportaise_Wrong_Arguments (Message : String) with No_Return;
    --  Report and Raise :P
 
    --  Folder guards conveniences for commands:
@@ -152,5 +154,21 @@ private
 
    Unset : constant String := "unset";
    --  Canary for when a string switch is given without value
+
+   subtype GNAT_String is GNAT.Strings.String_Access;
+   --  Convenience for commands that use string arguments
+
+   function Is_Boolean is new AAA.Enum_Tools.Is_Valid (Boolean);
+
+   function To_Boolean (Image   : GNAT_String;
+                        Switch  : String;
+                        Default : Boolean)
+                        return Boolean
+     with Post =>
+       (if Image in null or else Image.all = "" or else Image.all = Unset
+        then To_Boolean'Result = Default);
+   --  Convert a switch value to a boolean, if explicitly given, or use the
+   --  default otherwise. If not a valid boolean or empty, raise Checked_Error
+   --  with an appropriate error message.
 
 end Alr.Commands;

--- a/testsuite/drivers/builds.py
+++ b/testsuite/drivers/builds.py
@@ -9,6 +9,13 @@ import subprocess
 from drivers.alr import alr_builds_dir, run_alr
 
 
+def clear_builds_dir() -> None:
+    """
+    Clear the shared build directory
+    """
+    rmtree(path())
+
+
 def enable_shared() -> None:
     """
     Enable shared builds

--- a/testsuite/drivers/driver/python_script.py
+++ b/testsuite/drivers/driver/python_script.py
@@ -31,6 +31,9 @@ class PythonScriptDriver(ClassicTestDriver):
 
         env = dict(os.environ)
 
+        # disable traceback from parent environment if it existed
+        env.pop('ALR_TRACEBACK_ENABLED', None)
+
         config_dir = os.path.join(self.test_env['working_dir'],
                                   'alr-config')
         prepare_env(config_dir, env)

--- a/testsuite/tests/misc/env-traceback/test.py
+++ b/testsuite/tests/misc/env-traceback/test.py
@@ -23,6 +23,9 @@ def check_traceback():
 # By default (no `-d` or ALR_TRACEBACK_ENABLED) we don't get a backtrace
 
 check_no_traceback()
+
+# Explicit disable
+
 for val in ["", "0", "false", "no"]:
     os.environ['ALR_TRACEBACK_ENABLED'] = val
     check_no_traceback()

--- a/testsuite/tests/printenv/last-build/test.py
+++ b/testsuite/tests/printenv/last-build/test.py
@@ -23,12 +23,19 @@ hash_devel = builds.find_hash("libhello")
 
 assert hash_release != hash_devel, "Hashes should be different"
 
-# Check default printenv behavior
+# Check default printenv behavior, which is to repeat last build settings
 p = run_alr("printenv")
-assert_match(f".*LIBHELLO_ALIRE_PREFIX=[^\n]*{hash_release}", p.out)
+assert_match(f".*LIBHELLO_ALIRE_PREFIX=[^\n]*{hash_devel}", p.out)
 
-# Check printenv --last-build behavior
+# Check printenv --last-build behaviors
+
 p = run_alr("printenv", "--last-build")
 assert_match(f".*LIBHELLO_ALIRE_PREFIX=[^\n]*{hash_devel}", p.out)
+
+p = run_alr("printenv", "--last-build=true")
+assert_match(f".*LIBHELLO_ALIRE_PREFIX=[^\n]*{hash_devel}", p.out)
+
+p = run_alr("printenv", "--last-build=false")
+assert_match(f".*LIBHELLO_ALIRE_PREFIX=[^\n]*{hash_release}", p.out)
 
 print("SUCCESS")

--- a/testsuite/tests/printenv/last-build/test.py
+++ b/testsuite/tests/printenv/last-build/test.py
@@ -1,0 +1,34 @@
+"""
+Test that `alr printenv --last-build` works as expected.
+"""
+
+from drivers import builds
+from drivers.alr import alr_with, init_local_crate, run_alr
+from drivers.asserts import assert_match
+
+builds.enable_shared()
+
+init_local_crate()
+alr_with("libhello")
+run_alr("build")
+
+# After a default build, we obtain the hash of the build in release mode
+hash_release = builds.find_hash("libhello")
+
+builds.clear_builds_dir()
+
+# Now obtain the hash of the build in development mode
+run_alr("build", "--profiles=*=development")
+hash_devel = builds.find_hash("libhello")
+
+assert hash_release != hash_devel, "Hashes should be different"
+
+# Check default printenv behavior
+p = run_alr("printenv")
+assert_match(f".*LIBHELLO_ALIRE_PREFIX=[^\n]*{hash_release}", p.out)
+
+# Check printenv --last-build behavior
+p = run_alr("printenv", "--last-build")
+assert_match(f".*LIBHELLO_ALIRE_PREFIX=[^\n]*{hash_devel}", p.out)
+
+print("SUCCESS")

--- a/testsuite/tests/printenv/last-build/test.yaml
+++ b/testsuite/tests/printenv/last-build/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    build_hash_index: {}

--- a/testsuite/tests/printenv/with-external/test.py
+++ b/testsuite/tests/printenv/with-external/test.py
@@ -28,7 +28,7 @@ else:
     expected_gpr_path = '.*/libhello_0.9.0_filesystem'
 
 # Check the printenv output
-assert_match('warn: Generating possibly incomplete environment'
+assert_match('.*warn: Generating possibly incomplete environment'
              ' because of missing dependencies\n'
              # Note: this warning is via stderr so it's OK
              '.*'


### PR DESCRIPTION
This may be useful when no direct editing of manifests is convenient, as otherwise `printenv` will always use the manifest's configuration.