### PR TITLE
Cleanup after shared releases impl

### DIFF
--- a/.github/workflows/ci-toolchain.yml
+++ b/.github/workflows/ci-toolchain.yml
@@ -50,8 +50,8 @@ jobs:
     - name: Show dependencies/pins
       run: ./bin/alr -n -q with --solve || ./bin/alr -n -v -d with --solve
 
-    - name: Show build environment
-      run: ./bin/alr -n printenv
+    - name: Show build environment, with debug fallback
+      run: ./bin/alr -n printenv || ./bin/alr -n -v -d printenv
 
     - shell: bash
       run: mv ./bin ./bin-old

--- a/src/alire/alire-builds-hashes.adb
+++ b/src/alire/alire-builds-hashes.adb
@@ -1,6 +1,7 @@
 with Alire.Crate_Configuration.Hashes;
 with Alire.Directories;
 with Alire.Environment;
+with Alire.Errors;
 with Alire.GPR;
 with Alire.Hashes.SHA256_Impl;
 with Alire.Paths;
@@ -193,9 +194,16 @@ package body Alire.Builds.Hashes is
                   if Target.Origin.Requires_Build
                     and then Target.Satisfies (Dep)
                   then
-                     Add ("dependency",
-                          Target.Milestone.Image,
-                          This.Hashes (Target.Name));
+                     if This.Contains (Target.Name) then
+                        Add ("dependency",
+                             Target.Milestone.Image,
+                             This.Hashes (Target.Name));
+                     else
+                        raise Program_Error with Errors.Set
+                          (Rel.Milestone.Image & " depends on "
+                           & Target.Milestone.Image
+                           & " but hash is not yet computed?");
+                     end if;
                   end if;
                end loop;
             end loop;

--- a/src/alire/alire-builds-hashes.ads
+++ b/src/alire/alire-builds-hashes.ads
@@ -10,6 +10,8 @@ package Alire.Builds.Hashes is
    procedure Clear (This : in out Hasher);
    --  Remove any cached hashes
 
+   function Contains (This : in out Hasher; Name : Crate_Name) return Boolean;
+
    function Is_Empty (This : Hasher) return Boolean;
    --  Says if the Hasher has been used or not
 
@@ -56,5 +58,12 @@ private
       Hashes : Crate_Hash_Maps.Map;
       Inputs : Crate_Input_Maps.Map;
    end record;
+
+   --------------
+   -- Contains --
+   --------------
+
+   function Contains (This : in out Hasher; Name : Crate_Name) return Boolean
+   is (This.Hashes.Contains (Name));
 
 end Alire.Builds.Hashes;

--- a/src/alire/alire-config-builtins.ads
+++ b/src/alire/alire-config-builtins.ads
@@ -11,7 +11,7 @@ package Alire.Config.Builtins is
       Def  => False,
       Help =>
         "When true, dependencies are downloaded and built in a shared "
-      & "location inside the global cache. When false (default), "
+      & "location inside the global cache. When false, "
       & "dependencies are sandboxed in each workspace.");
 
    Distribution_Disable_Detection : constant Builtin := New_Builtin

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -255,7 +255,6 @@ package Alire.Roots is
 
    function Build (This             : in out Root;
                    Cmd_Args         : AAA.Strings.Vector;
-                   Export_Build_Env : Boolean;
                    Build_All_Deps   : Boolean := False;
                    Saved_Profiles   : Boolean := True)
                    return Boolean;
@@ -287,7 +286,6 @@ package Alire.Roots is
      (This           : in out Root;
       Prefix         : Absolute_Path;
       Build          : Boolean := True;
-      Export_Env     : Boolean := True;
       Print_Solution : Boolean := True);
    --  Call gprinstall on the releases in solution using --prefix=Prefix
 

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -190,12 +190,9 @@ package body Alr.Commands.Get is
                  (Crate   =>  Cmd.Root.Name,
                   Profile =>  Alire.Utils.Switches.Release);
 
-               --  The complete build environment has been set up already by
-               --  Deploy_Dependencies, so we must not do it again.
                Build_OK := Cmd.Root.Build
                  (Cmd_Args         =>  AAA.Strings.Empty_Vector,
-                  Saved_Profiles   => False,
-                  Export_Build_Env => False);
+                  Saved_Profiles   => False);
             end if;
          else
             Build_OK := True;

--- a/src/alr/alr-commands-install.adb
+++ b/src/alr/alr-commands-install.adb
@@ -63,8 +63,7 @@ package body Alr.Commands.Install is
                   & " is already installed, use " & TTY.Terminal ("--force")
                   & " to reinstall");
             when New_Install | Reinstall | Replace =>
-               Cmd.Root.Install (Prefix     => Prefix,
-                                 Export_Env => True);
+               Cmd.Root.Install (Prefix => Prefix);
          end case;
 
       else

--- a/testsuite/drivers/helpers.py
+++ b/testsuite/drivers/helpers.py
@@ -256,6 +256,12 @@ def replace_in_file(filename : str, old : str, new : str):
         file.write(old_contents.replace(old, new))
 
 
+def neutral_path(path : str) -> str:
+    """
+    Return a path with all separators replaced by '/'.
+    """
+    return path.replace('\\', '/')
+
 class FileLock():
     """
     A filesystem-level lock for tests executed from different threads but

--- a/testsuite/tests/config/shared-deps/test.py
+++ b/testsuite/tests/config/shared-deps/test.py
@@ -9,7 +9,12 @@ from drivers import builds
 from drivers.alr import (alr_builds_dir, alr_vault_dir, alr_with,
                          alr_workspace_cache, init_local_crate, run_alr)
 from drivers.asserts import assert_contents, assert_file_exists
-from drivers.helpers import lines_of
+from drivers.helpers import contents, lines_of
+
+
+def check_in(file : str, expected : str) -> bool:
+    assert file in expected, f"Missing file '{file}' in\n{expected}"
+
 
 vault_dir = alr_vault_dir()
 build_dir = alr_builds_dir()
@@ -46,21 +51,11 @@ assert len(glob.glob(os.path.join(build_dir, "hello_1.0.1_filesystem_*"))) == 0,
 run_alr("build")
 base = builds.find_dir("hello_1.0.1_filesystem")
 
-assert_contents(base,
-                [f'{base}/alire',
-                 f'{base}/alire.toml',
-                 f'{base}/alire/build_hash_inputs',
-                 f'{base}/alire/flags',
-                 f'{base}/alire/flags/complete_copy',
-                 f'{base}/alire/flags/post_fetch_done',
-                 f'{base}/config',
-                 f'{base}/config/hello_config.ads',
-                 f'{base}/config/hello_config.gpr',
-                 f'{base}/config/hello_config.h',
-                 f'{base}/hello.gpr',
-                 f'{base}/obj',
-                 f'{base}/src',
-                 f'{base}/src/hello.adb'])
+# There's too much object files and the like, check a few critical files:
+files = contents(base)
+check_in(f'{base}/config/hello_config.ads', files)     # config wa generated
+check_in(f'{base}/alire/flags/post_fetch_done', files) # actions were run
+check_in(f'{base}/obj/b__hello.ads', files)            # build took place
 
 # And that the crate usual cache dir doesn't exist
 assert not os.path.exists(alr_workspace_cache())

--- a/testsuite/tests/config/shared-deps/test.py
+++ b/testsuite/tests/config/shared-deps/test.py
@@ -9,7 +9,7 @@ from drivers import builds
 from drivers.alr import (alr_builds_dir, alr_vault_dir, alr_with,
                          alr_workspace_cache, init_local_crate, run_alr)
 from drivers.asserts import assert_contents, assert_file_exists
-from drivers.helpers import contents, lines_of
+from drivers.helpers import contents, lines_of, neutral_path
 
 
 def check_in(file : str, expected : str) -> bool:
@@ -52,10 +52,11 @@ run_alr("build")
 base = builds.find_dir("hello_1.0.1_filesystem")
 
 # There's too much object files and the like, check a few critical files:
-files = contents(base)
-check_in(f'{base}/config/hello_config.ads', files)     # config wa generated
-check_in(f'{base}/alire/flags/post_fetch_done', files) # actions were run
-check_in(f'{base}/obj/b__hello.ads', files)            # build took place
+files = contents(base)  # This returns "normalized" paths (with '/' separators)
+nbase = neutral_path(base)
+check_in(f'{nbase}/config/hello_config.ads', files)     # config was generated
+check_in(f'{nbase}/alire/flags/post_fetch_done', files) # actions were run
+check_in(f'{nbase}/obj/b__hello.ads', files)            # build took place
 
 # And that the crate usual cache dir doesn't exist
 assert not os.path.exists(alr_workspace_cache())


### PR DESCRIPTION
We now always run actions no sooner than build time and that simplifies when we need to export the environment, which was somewhat scattered and hard to understand/maintain. This can now be removed.

Added also some extra checks that may come in handy if we get reports wrt the new shared dependencies (although the reason for these should fixed in #1445).