### PR TITLE
Fix bugs for corner cases with shared dependencies

### DIFF
--- a/.github/workflows/ci-toolchain.yml
+++ b/.github/workflows/ci-toolchain.yml
@@ -45,23 +45,23 @@ jobs:
     # We can start using the alr we just built
 
     - name: Update dependencies
-      run: ./bin/alr -n update
+      run: ./bin/alr -d -n update
 
     - name: Show dependencies/pins
-      run: ./bin/alr -n -q with --solve || ./bin/alr -n -v -d with --solve
+      run: ./bin/alr -d -n -q with --solve || ./bin/alr -n -v -d with --solve
 
     - name: Show build environment, with debug fallback
-      run: ./bin/alr -n printenv || ./bin/alr -n -v -d printenv
+      run: ./bin/alr -d -n printenv || ./bin/alr -n -v -d printenv
 
     - shell: bash
       run: mv ./bin ./bin-old
       # Windows doesn't allow to replace a running exe so the next command fails otherwise
 
     - name: SELF-BUILD
-      run: ./bin-old/alr -n build
+      run: ./bin-old/alr -d -n build
 
     - name: Show built version
-      run: ./bin/alr -n version
+      run: ./bin/alr -d -n version
 
     # Run the testsuite with the just build alr. The testsuite picks the proper
     # alr in the ./bin/alr location.

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -130,8 +130,8 @@ package body Alire.Roots is
       begin
 
          if not State.Has_Release then
-            Put_Info (State.As_Dependency.TTY_Image
-                      & " has no release, build skipped.", Detail);
+            Put_Info ("Skipping build of " & State.As_Dependency.TTY_Image
+                      & ": not a release", Detail);
             return;
          end if;
 
@@ -198,24 +198,15 @@ package body Alire.Roots is
 
       if not Builds.Sandboxed_Dependencies then
          This.Sync_Builds;
-         --  Changes in configuration may require new build dirs
-
-         This.Configuration.Generate_Config_Files (This,
-                                                   Release (This),
-                                                   Full => Force);
-         --  Generate the config for the root crate only, the previous sync
-         --  takes care of the rest.
-
-         This.Build_Hasher.Write_Inputs (This);
-         --  Now, after the corresponding config files are in place
+         --  Changes in configuration may require new build dirs.
       end if;
 
-      --  Ensure configurations are written to disk
+      --  Ensure configurations are in place and up-to-date
 
       This.Generate_Configuration (Full => Force);
-      --  Will regenerate on demand only those changed. This is needed even
-      --  for shared builds, as linked dependencies don't require a sync, but
-      --  require config generation.
+      --  Will regenerate on demand only those changed. For shared
+      --  dependencies, will also generate any missing configs not generated
+      --  during sync, such as for linked releases and the root release.
 
       This.Export_Build_Environment;
 
@@ -838,9 +829,6 @@ package body Alire.Roots is
             end if;
          end;
       end Sync_Release;
-
-      Unused_Root_Hash : constant String := This.Build_Hash (This.Name);
-      --  Force build hash compu
 
    begin
       --  If no dependency exists, or is "regular" (has a hash), the root might

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -431,4 +431,7 @@ private
    procedure Sync_Builds (This : in out Root);
    --  Sync from vault to final build location, and generate config
 
+   procedure Compute_Build_Hashes (This : in out Root);
+   --  Trigger computation of build hashes
+
 end Alire.Roots;

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -142,7 +142,9 @@ package Alire.Roots is
    function Requires_Build_Sync (This : in out Root;
                                  Rel  : Releases.Release)
                                  return Boolean
-     with Pre => This.Solution.Contains_Release (Rel.Name);
+     with Pre =>
+       This.Solution.Contains_Release (Rel.Name) or else
+       raise Program_Error with "Release not in solution: " & Rel.Name_Str;
    --  Says if the release requires a build copy taking into account everything
 
    function Nonabstract_Crates (This : in out Root)

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -56,7 +56,7 @@ package body Alire.Solutions is
 
    function Contains_Release (This  : Solution;
                               Crate : Crate_Name) return Boolean
-   is (This.Depends_On (Crate) and then This.State (Crate).Is_Solved);
+   is (This.Depends_On (Crate) and then This.State (Crate).Has_Release);
 
    ----------------
    -- Dependency --

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -188,8 +188,8 @@ package Alire.Solutions is
 
    function Contains_Release (This  : Solution;
                               Crate : Crate_Name) return Boolean;
-   --  Say if Crate is among the solved releases for this solution. It will
-   --  return False if the solution does not even depend on Crate.
+   --  Say if Crate is among the releases (solved or linked) for this solution.
+   --  It will return False if the solution does not even depend on Crate.
 
    function Crates (This : Solution) return Name_Set;
    --  Dependency name closure, independent of the status in the solution, as

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -88,9 +88,7 @@ package body Alr.Commands.Build is
 
       --  And redirect to actual execution procedure
 
-      if not Execute (Cmd, Args,
-                      Export_Build_Env => True)
-      then
+      if not Execute (Cmd, Args) then
          Reportaise_Command_Failed ("Compilation failed.");
       end if;
    end Execute;
@@ -100,8 +98,7 @@ package body Alr.Commands.Build is
    -------------
 
    function Execute (Cmd              : in out Commands.Command'Class;
-                     Args             :        AAA.Strings.Vector;
-                     Export_Build_Env :        Boolean)
+                     Args             :        AAA.Strings.Vector)
                      return Boolean
    is
    begin
@@ -115,7 +112,6 @@ package body Alr.Commands.Build is
          Timer : Stopwatch.Instance;
       begin
          if Cmd.Root.Build (Args,
-                            Export_Build_Env,
                             Saved_Profiles => Cmd not in Build.Command'Class)
            --  That is, we apply the saved profiles unless the user is
            --  explicitly invoking `alr build`.

--- a/src/alr/alr-commands-build.ads
+++ b/src/alr/alr-commands-build.ads
@@ -20,9 +20,8 @@ package Alr.Commands.Build is
    procedure Execute (Cmd  : in out Command;
                       Args :        AAA.Strings.Vector);
 
-   function Execute (Cmd              : in out Commands.Command'Class;
-                     Args             :        AAA.Strings.Vector;
-                     Export_Build_Env :        Boolean)
+   function Execute (Cmd  : in out Commands.Command'Class;
+                     Args :        AAA.Strings.Vector)
                      return Boolean;
    --  Returns True if compilation succeeded. For invocations after some other
    --  command that already has set up the build environment we need to avoid

--- a/src/alr/alr-commands-run.adb
+++ b/src/alr/alr-commands-run.adb
@@ -134,8 +134,7 @@ package body Alr.Commands.Run is
          --  COMPILATION  --
          if not Cmd.No_Compile then
             if not Commands.Build.Execute (Cmd,
-                                           Args => AAA.Strings.Empty_Vector,
-                                           Export_Build_Env => True)
+                                           Args => AAA.Strings.Empty_Vector)
             then
                Reportaise_Command_Failed ("Build failed");
             end if;

--- a/testsuite/drivers/builds.py
+++ b/testsuite/drivers/builds.py
@@ -6,7 +6,14 @@ from glob import glob
 import os
 from shutil import rmtree
 import subprocess
-from drivers.alr import alr_builds_dir
+from drivers.alr import alr_builds_dir, run_alr
+
+
+def enable_shared() -> None:
+    """
+    Enable shared builds
+    """
+    run_alr("config", "--global", "--set", "dependencies.shared", "true")
 
 
 def clear_builds_dir() -> None:

--- a/testsuite/tests/build/hashes/linked-dependency/test.py
+++ b/testsuite/tests/build/hashes/linked-dependency/test.py
@@ -1,0 +1,17 @@
+"""
+check that a linked dependency causes no trouble in shared builds
+"""
+
+from drivers.alr import alr_with, init_local_crate, run_alr
+from drivers import builds
+# from drivers.asserts import assert_eq, assert_match
+
+builds.enable_shared()
+
+init_local_crate()
+init_local_crate("dep", enter=False)
+alr_with("dep", path="dep")
+
+run_alr("build")  # Should succeed
+
+print('SUCCESS')

--- a/testsuite/tests/build/hashes/linked-dependency/test.yaml
+++ b/testsuite/tests/build/hashes/linked-dependency/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    build_hash_index: {}

--- a/testsuite/tests/config/shared-deps/test.py
+++ b/testsuite/tests/config/shared-deps/test.py
@@ -56,7 +56,10 @@ files = contents(base)  # This returns "normalized" paths (with '/' separators)
 nbase = neutral_path(base)
 check_in(f'{nbase}/config/hello_config.ads', files)     # config was generated
 check_in(f'{nbase}/alire/flags/post_fetch_done', files) # actions were run
-check_in(f'{nbase}/obj/b__hello.ads', files)            # build took place
+# check_in(f'{nbase}/obj/b__hello.ads', files)          # build took place
+# The build actually doesn't take place because the dependency is not used.
+# Due to a former bug, where all deps were built, the previous check succeeded.
+# The line is left in case this bug reappears, so it's easier to re-understand.
 
 # And that the crate usual cache dir doesn't exist
 assert not os.path.exists(alr_workspace_cache())


### PR DESCRIPTION
Linked dependencies on their own were giving trouble if no other regular dependencies forced config generation. Also the selfbuild of `alr` by itself uncovered another corner case with linked dependencies. Test included.

Also I introduced a bug in #1448 because I removed one of two consecutive arguments with boolean defaults, which made calls passing only the first boolean to unsuspectedly use it for the second. Note to self: don't use boolean parameters with defaults in such a way.