### PR TITLE
Remove spurious -g causing excess rebuilds when building `alr`

### DIFF
--- a/alire_common.gpr
+++ b/alire_common.gpr
@@ -81,12 +81,18 @@ abstract project Alire_Common is
    end Compiler;
 
    package Builder is
-      for Switches ("Ada") use ("-s", "-j0", "-g");
+      for Switches ("Ada") use
+        ("-s", -- Recompile if switches changed
+         "-j0" -- Full parallelism
+        );
    end Builder;
 
    package Binder is
       for Switches ("Ada") use
-        ( "-Es", "-g", "-static");
+        ("-Es",    -- Symbolic tracebacks
+         "-g",     -- Keep binder generated files (for debugging?)
+         "-static" -- Static linking
+        );
    end Binder;
 
    package Ide is


### PR DESCRIPTION
Passing `-g` to gprbuild via the `Builder` package resulted in `-g` being passed to all dependencies, which in turn caused `alr build` to always rebuild some dependencies because they saw different switches when compiled by themselves and in the context of `alr.gpr`.

We can always force a full debug build if wanted by adding `-g` to gprbuild, so removing this from `alr.gpr` to get rid of those rebuilds is preferable. Also, Alire itself is always build with `-g` (via the `Compiler` package in `alire_common.gpr`), so this removal changes nothing in Alire's regard.