### PR TITLE
Print UTF-8 strings using `GNAT.IO` in `Alr.Commands` subsystem

### DIFF
--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -368,7 +368,7 @@ package body Alr.Commands.Init is
                      Info.Name := To_Unbounded_String (Tentative_Name);
                      exit;
                   else
-                     Ada.Text_IO.Put_Line
+                     Put_Line
                        ("Invalid crate name '"
                         & Tentative_Name & "': "
                         & Alire.Error_In_Name (Tentative_Name));
@@ -406,13 +406,13 @@ package body Alr.Commands.Init is
       if SPDX.Valid (SP) then
          return True;
       else
-         Ada.Text_IO.Put_Line
+         Put_Line
            ("Invalid SPDX license expression '" & Str
             & "': " & SPDX.Error (SP));
-         Ada.Text_IO.Put_Line
+         Put_Line
            ("SPDX expression expected (https://spdx.org/licenses/).");
-         Ada.Text_IO.Put_Line ("(Use 'custom-' prefix for custom"
-                               & " license identifier)");
+         Put_Line ("(Use 'custom-' prefix for custom"
+                   & " license identifier)");
 
          return False;
       end if;
@@ -487,9 +487,9 @@ package body Alr.Commands.Init is
    function Description_Validation (Str : String) return Boolean is
    begin
       if Str'Length > Alire.Max_Description_Length then
-         Ada.Text_IO.Put_Line ("Description too long:"
-                               & Str'Length'Img & " (max"
-                               & Alire.Max_Description_Length'Img & ")");
+         Put_Line ("Description too long:"
+                   & Str'Length'Img & " (max"
+                   & Alire.Max_Description_Length'Img & ")");
          return False;
       else
          return True;
@@ -527,7 +527,7 @@ package body Alr.Commands.Init is
                Tag_Error : constant String := Alire.Utils.Error_In_Tag (Elt);
             begin
                if Tag_Error /= "" then
-                  Ada.Text_IO.Put_Line (Tag_Error);
+                  Put_Line (Tag_Error);
                   Tags_Ok := False;
                end if;
             end;

--- a/src/alr/alr-commands-run.adb
+++ b/src/alr/alr-commands-run.adb
@@ -24,7 +24,6 @@ package body Alr.Commands.Run is
 
    procedure Check_Report (Cmd      : in out Command;
                            Exe_Name : String) is
-      use Ada.Text_IO;
 
       Found_At : constant AAA.Strings.Vector :=
         Files.Locate_File_Under (Cmd.Root.Path,

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -2,7 +2,6 @@ with Ada.Characters.Handling; use Ada.Characters.Handling;
 with Ada.Command_Line;
 with Ada.Directories;
 with Ada.Environment_Variables;
-with Ada.Text_IO; use Ada.Text_IO;
 
 with CLIC.TTY;
 with CLIC.User_Input;

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -7,7 +7,7 @@ with Alire.Version;
 
 with CLIC.Subcommand;
 
-private with Ada.Text_IO;
+private with GNAT.IO;
 private with CLIC.Subcommand.Instance;
 
 private with Alr.OS_Lib; -- For the benefit of many child packages that use it
@@ -122,11 +122,14 @@ private
 
    --  Common generalities
 
-   procedure New_Line (Spacing : Ada.Text_IO.Positive_Count := 1)
-   renames Ada.Text_IO.New_Line;
+   procedure New_Line (Spacing : Positive := 1)
+   renames GNAT.IO.New_Line;
 
    procedure Put_Line (S : String)
-   renames Ada.Text_IO.Put_Line;
+   renames GNAT.IO.Put_Line;
+
+   procedure Put (S : String)
+   renames GNAT.IO.Put;
 
    procedure Put_Error (Str : String);
    procedure Set_Global_Switches
@@ -135,8 +138,8 @@ private
    package Sub_Cmd is new CLIC.Subcommand.Instance
      (Main_Command_Name   => "alr",
       Version             => Alire.Version.Current,
-      Put                 => Ada.Text_IO.Put,
-      Put_Line            => Ada.Text_IO.Put_Line,
+      Put                 => GNAT.IO.Put,
+      Put_Line            => GNAT.IO.Put_Line,
       Put_Error           => Put_Error,
       Error_Exit          => OS_Lib.Bailout,
       Set_Global_Switches => Set_Global_Switches,


### PR DESCRIPTION
Supersedes #1457

Fixes #1456