### PR TITLE
Support for markdown output in help messages

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -49,7 +49,7 @@ windows = { ALIRE_OS = "windows" }
 [[pins]]
 aaa = { url = "https://github.com/mosteo/aaa", commit = "ecc38772bd4a6b469b54c62363766ea1c0e9f912" }
 ada_toml = { url = "https://github.com/mosteo/ada-toml", commit = "da4e59c382ceb0de6733d571ecbab7ea4919b33d" }
-clic = { url = "https://github.com/alire-project/clic", commit = "6879b90876a1c918b4e112f59c6db0e25b713f52" }
+clic = { url = "https://github.com/alire-project/clic", commit = "5c936c1e65ec4f6ba5428433a36d9cb3ee06764d" }
 dirty_booleans = { url = "https://github.com/mosteo/dirty_booleans", branch = "main" }
 diskflags = { url = "https://github.com/mosteo/diskflags", branch = "main" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "4e663b87a028252e7e074f054f8f453661397166" }

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -79,6 +79,9 @@ package body Alr.Commands is
    No_TTY : aliased Boolean := False;
    --  Used to disable control characters in output
 
+   Markdown_Help : aliased Boolean := False;
+   --  Used to enable help display in markdown format
+
    Version_Only : aliased Boolean := False;
    --  Just display the current version and exit
 
@@ -156,6 +159,12 @@ package body Alr.Commands is
                      No_TTY'Access,
                      Long_Switch => "--no-tty",
                      Help        => "Disables control characters in output");
+
+      Define_Switch (Config,
+                     Markdown_Help'Access,
+                     Long_Switch => "--markdown",
+                     Help        =>
+                       "Enables output of markdown format for help");
 
       Define_Switch (Config,
                      Prefer_Oldest'Access,
@@ -452,7 +461,11 @@ package body Alr.Commands is
       end if;
 
       if No_TTY then
-         CLIC.TTY.Force_Disable_TTY;
+         CLIC.Formatter.Force_Disable_TTY;
+      end if;
+
+      if Markdown_Help then
+         CLIC.Formatter.Enable_Markdown;
       end if;
 
       --  Use CLIC.TTY selection/detection of TTY

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -6,6 +6,7 @@ with Alire.Solver;
 with Alire.Version;
 
 with CLIC.Subcommand;
+with CLIC.Formatter;
 
 private with GNAT.IO;
 private with CLIC.Subcommand.Instance;
@@ -143,11 +144,11 @@ private
       Put_Error           => Put_Error,
       Error_Exit          => OS_Lib.Bailout,
       Set_Global_Switches => Set_Global_Switches,
-      TTY_Chapter         => Alire.TTY.Bold,
-      TTY_Description     => Alire.TTY.Description,
-      TTY_Version         => Alire.TTY.Version,
-      TTY_Underline       => Alire.TTY.Underline,
-      TTY_Emph            => Alire.TTY.Emph);
+      TTY_Chapter         => CLIC.Formatter.Chapter,
+      TTY_Description     => CLIC.Formatter.Description,
+      TTY_Version         => CLIC.Formatter.Version,
+      TTY_Underline       => CLIC.Formatter.Underline,
+      TTY_Emph            => CLIC.Formatter.Emph);
 
    Unset : constant String := "unset";
    --  Canary for when a string switch is given without value


### PR DESCRIPTION
This functionality can be used to provide on-line versions of the help messages for alire.ada.dev.

It goes with https://github.com/alire-project/clic/pull/29