### PR TITLE
Omit global switches in subcommand-specific help

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -49,7 +49,7 @@ windows = { ALIRE_OS = "windows" }
 [[pins]]
 aaa = { url = "https://github.com/mosteo/aaa", commit = "ecc38772bd4a6b469b54c62363766ea1c0e9f912" }
 ada_toml = { url = "https://github.com/mosteo/ada-toml", commit = "da4e59c382ceb0de6733d571ecbab7ea4919b33d" }
-clic = { url = "https://github.com/alire-project/clic", commit = "a6bea52a98602fb93dadee8332738f5ff6207a16" }
+clic = { url = "https://github.com/alire-project/clic", commit = "b40b170b1561adfa99910c69e3897cc2ca441730" }
 dirty_booleans = { url = "https://github.com/mosteo/dirty_booleans", branch = "main" }
 diskflags = { url = "https://github.com/mosteo/diskflags", branch = "main" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "4e663b87a028252e7e074f054f8f453661397166" }

--- a/alire.toml
+++ b/alire.toml
@@ -49,7 +49,7 @@ windows = { ALIRE_OS = "windows" }
 [[pins]]
 aaa = { url = "https://github.com/mosteo/aaa", commit = "ecc38772bd4a6b469b54c62363766ea1c0e9f912" }
 ada_toml = { url = "https://github.com/mosteo/ada-toml", commit = "da4e59c382ceb0de6733d571ecbab7ea4919b33d" }
-clic = { url = "https://github.com/alire-project/clic", commit = "6879b90876a1c918b4e112f59c6db0e25b713f52" }
+clic = { url = "https://github.com/alire-project/clic", commit = "a6bea52a98602fb93dadee8332738f5ff6207a16" }
 dirty_booleans = { url = "https://github.com/mosteo/dirty_booleans", branch = "main" }
 diskflags = { url = "https://github.com/mosteo/diskflags", branch = "main" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "4e663b87a028252e7e074f054f8f453661397166" }

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -147,7 +147,8 @@ private
       TTY_Description     => Alire.TTY.Description,
       TTY_Version         => Alire.TTY.Version,
       TTY_Underline       => Alire.TTY.Underline,
-      TTY_Emph            => Alire.TTY.Emph);
+      TTY_Emph            => Alire.TTY.Emph,
+      Global_Options_In_Subcommand_Help => False);
 
    Unset : constant String := "unset";
    --  Canary for when a string switch is given without value


### PR DESCRIPTION
I find that the section on global switches is always causing the useful info I want to see to scroll away. Global switches are shown as expected with `alr help` or `alr -h`.