### PR TITLE
Remove ".git" after cloning, with option to disable

### DIFF
--- a/src/alire/alire-config-builtins.ads
+++ b/src/alire/alire-config-builtins.ads
@@ -6,6 +6,15 @@ package Alire.Config.Builtins is
    -- Builtins --
    --------------
 
+   --  DEPENDENCIES
+
+   Dependencies_Git_Keep_Repository : constant Builtin := New_Builtin
+     (Key  => "dependencies.git.keep_repository",
+      Def  => False,
+      Help =>
+        "When true, git origins are a proper git repository after deployment. "
+      & "Otherwise they are deployed as a plain directory.");
+
    Dependencies_Shared : constant Builtin := New_Builtin
      (Key  => "dependencies.shared",
       Def  => False,

--- a/src/alire/alire-origins-deployers-git.adb
+++ b/src/alire/alire-origins-deployers-git.adb
@@ -1,6 +1,10 @@
+with Alire.Config.Builtins;
+with Alire.Directories;
 with Alire.VCSs.Git;
 
 package body Alire.Origins.Deployers.Git is
+
+   use Directories.Operators;
 
    ------------
    -- Deploy --
@@ -9,7 +13,20 @@ package body Alire.Origins.Deployers.Git is
    overriding
    function Deploy (This : Deployer; Folder : String) return Outcome is
    begin
-      return VCSs.Git.Handler.Clone (This.Base.URL_With_Commit, Folder);
+      VCSs.Git.Handler.Clone (This.Base.URL_With_Commit, Folder).Assert;
+
+      if Config.Builtins.Dependencies_Git_Keep_Repository.Get then
+
+         Trace.Debug ("Keeping git repo from " & This.Base.TTY_URL_With_Commit
+                      & " at " & TTY.URL (Folder));
+
+      else
+
+         Directories.Delete_Tree (Folder / VCSs.Git.Git_Dir);
+
+      end if;
+
+      return Outcome_Success;
    end Deploy;
 
    -----------

--- a/src/alire/alire-publish-submit.adb
+++ b/src/alire/alire-publish-submit.adb
@@ -248,7 +248,9 @@ package body Alire.Publish.Submit is
         (From   => Index.Community_Host
          / User_Info.User_GitHub_Login
          / Index.Community_Repo_Name,
-         Into   => Local_Repo_Path).Assert;
+         Into   => Local_Repo_Path,
+         Branch => "",
+         Depth  => 1).Assert;
 
       --  We can reuse the pull logic now to set up the local branch
       Pull;

--- a/src/alire/alire-vcss-git.adb
+++ b/src/alire/alire-vcss-git.adb
@@ -129,7 +129,7 @@ package body Alire.VCSs.Git is
                    From : URL;
                    Into : Directory_Path)
                    return Outcome
-   is (This.Clone (From, Into, Branch => ""));
+   is (This.Clone (From, Into, Branch => "", Depth => 1));
 
    -----------
    -- Clone --
@@ -731,6 +731,14 @@ package body Alire.VCSs.Git is
          Data.Branch   := +Tail (Output (3), ' ');
       end return;
    end Worktree;
+
+   -------------
+   -- Git_Dir --
+   -------------
+
+   function Git_Dir return Any_Path
+   is (OS_Lib.Getenv (Name    => "GIT_DIR",
+                      Default => ".git"));
 
    -----------------
    -- Head_Commit --

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -19,6 +19,9 @@ package Alire.VCSs.Git is
    --  This is actually returned by e.g. `git worktree`, even if it could be a
    --  real commit. I guess the chances are deemed too low.
 
+   function Git_Dir return Any_Path;
+   --  ".git" unless overridden by GIT_DIR
+
    type VCS (<>) is new VCSs.VCS with private;
 
    function Handler return VCS;
@@ -44,6 +47,8 @@ package Alire.VCSs.Git is
                    From : URL;
                    Into : Directory_Path)
                    return Outcome;
+   --  Make a shallow clone of the given URL (that may include '#commit). For
+   --  more precise control, use the following Clone signature.
 
    not overriding
    function Clone (This   : VCS;

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -531,6 +531,13 @@ def alr_builds_dir() -> str:
     return os.path.join(alr_config_dir(), "cache", "builds")
 
 
+def crate_dirname(crate):
+    """
+    Return the deployment dir of a crate, obtained with `alr get --dirname`
+    """
+    return run_alr("get", "--dirname", crate).out.strip()
+
+
 def external_compiler_version() -> str:
     """
     Return the version of the external compiler

--- a/testsuite/drivers/asserts.py
+++ b/testsuite/drivers/asserts.py
@@ -104,11 +104,14 @@ def assert_installed(prefix : str, milestones : List[str]):
               p.out)
 
 
-def assert_file_exists(path : str):
+def assert_file_exists(path : str, wanted : bool = True):
     """
     Check that a file exists
     """
-    assert os.path.exists(path), f"Missing expected file {path}"
+    if wanted:
+        assert os.path.exists(path), f"Missing expected file {path}"
+    else:
+        assert not os.path.exists(path), f"Unexpected file {path}"
 
 
 def assert_in_file(path : str, expected : str):

--- a/testsuite/tests/get/git-local/test.py
+++ b/testsuite/tests/get/git-local/test.py
@@ -2,10 +2,7 @@
 Retrieve a release from a local git repository
 """
 
-from glob import glob
-
-from drivers.alr import run_alr
-from drivers.asserts import assert_match
+from drivers.alr import alr_with, init_local_crate, run_alr
 from drivers.helpers import compare, contents
 
 # Get the release
@@ -35,6 +32,11 @@ compare(list(filter
          'libfoo_1.0.0_9ddda32b/config/libfoo_config.gpr',
          'libfoo_1.0.0_9ddda32b/config/libfoo_config.h'
          ])
+
+
+# Use release as dependency
+init_local_crate()
+alr_with("libfoo") # Should succeed
 
 
 print('SUCCESS')

--- a/testsuite/tests/misc/git-ungit/test.py
+++ b/testsuite/tests/misc/git-ungit/test.py
@@ -1,0 +1,27 @@
+"""
+Verify the proper "ungitting" of git origins
+"""
+
+import os
+import shutil
+from glob import glob
+
+from drivers.alr import crate_dirname, run_alr
+from drivers.asserts import assert_file_exists
+
+# By default, git deployments are shallow and see their .git directory removed
+# Check that and that enabling legacy behavior works
+
+cwd = os.getcwd()
+
+run_alr("get", "hello")
+os.chdir(crate_dirname("hello"))
+
+# Check root gotten crate
+assert_file_exists(".git", wanted=False)
+
+# Check dependency
+os.chdir(os.path.join("alire", "cache", "dependencies"))
+assert_file_exists(os.path.join(glob("libhello*")[0], ".git"), wanted=False)
+
+print('SUCCESS')

--- a/testsuite/tests/misc/git-ungit/test.py
+++ b/testsuite/tests/misc/git-ungit/test.py
@@ -4,24 +4,40 @@ Verify the proper "ungitting" of git origins
 
 import os
 import shutil
-from glob import glob
 
-from drivers.alr import crate_dirname, run_alr
+from drivers.alr import alr_with, crate_dirname, init_local_crate, run_alr
 from drivers.asserts import assert_file_exists
 
 # By default, git deployments are shallow and see their .git directory removed
 # Check that and that enabling legacy behavior works
 
 cwd = os.getcwd()
+foo_dir = crate_dirname("libfoo")
 
-run_alr("get", "hello")
-os.chdir(crate_dirname("hello"))
+# By default .git should not be there
+for wanted in [False, True]:
+    run_alr("get", "libfoo")
 
-# Check root gotten crate
-assert_file_exists(".git", wanted=False)
+    # Check root gotten crate
+    assert_file_exists(os.path.join(foo_dir, ".git"),
+                       wanted=wanted)
 
-# Check dependency
-os.chdir(os.path.join("alire", "cache", "dependencies"))
-assert_file_exists(os.path.join(glob("libhello*")[0], ".git"), wanted=False)
+    # Check as dependency
+    init_local_crate()
+    alr_with("libfoo")
+
+    assert_file_exists(os.path.join("alire", "cache", "dependencies",
+                                    foo_dir, ".git"),
+                       wanted=wanted)
+
+    if not wanted:
+        # Enable for next round
+        run_alr("config", "--global", "--set",
+                "dependencies.git.keep_repository", "true")
+
+        # Cleanup for next round
+        os.chdir(cwd)
+        shutil.rmtree(crate_dirname("libfoo"))
+        shutil.rmtree("xxx")
 
 print('SUCCESS')

--- a/testsuite/tests/misc/git-ungit/test.yaml
+++ b/testsuite/tests/misc/git-ungit/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}

--- a/testsuite/tests/misc/git-ungit/test.yaml
+++ b/testsuite/tests/misc/git-ungit/test.yaml
@@ -1,3 +1,3 @@
 driver: python-script
 indexes:
-    basic_index: {}
+    git_index: {}


### PR DESCRIPTION
Also make clones shallow (they already were for pins).