### PR TITLE
Fix corner case related to git+file:// URLs in lockfiles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,30 @@
             ],
             "console": "integratedTerminal",
             "justMyCode": false
+        },
+        {
+            "name": "(gdb) Launch alr at /tmp/a/xxx",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/bin/alr",
+            "args": ["-d", "-vv", "with", "libfoo"],
+            "stopAtEntry": true,
+            "cwd": "/tmp/a/xxx",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
         }
     ]
 }

--- a/src/alire/alire-origins.adb
+++ b/src/alire/alire-origins.adb
@@ -402,8 +402,10 @@ package body Alire.Origins is
       Scheme      : constant URI.Schemes := URI.Scheme (URL);
       Transformed : constant Alire.URL := VCSs.Git.Transform_To_Public (URL);
       VCS_URL : constant String :=
-                  (if Contains (URL, "file:") then
-                      Tail (URL, ':') -- Remove file: that confuses git
+                  (if Contains (URL, "+file://") then
+                      Tail (URL, '+') -- strip the VCS proto only
+                   elsif Contains (URL, "+file:") then
+                      Tail (URL, ':') -- Remove file: w.o. // that confuses git
                    elsif Has_Prefix (URL, "git@") and then
                       Transformed /= URL -- known and transformable
                    then

--- a/testsuite/tests/get/git-local/test.py
+++ b/testsuite/tests/get/git-local/test.py
@@ -4,7 +4,7 @@ Retrieve a release from a local git repository
 
 from glob import glob
 
-from drivers.alr import run_alr
+from drivers.alr import init_local_crate, run_alr
 from drivers.asserts import assert_match
 from drivers.helpers import compare, contents
 
@@ -36,5 +36,8 @@ compare(list(filter
          'libfoo_1.0.0_9ddda32b/config/libfoo_config.h'
          ])
 
+# Check as dependency
+init_local_crate()
+run_alr("with", "libfoo")  # should succeed
 
 print('SUCCESS')

--- a/testsuite/tests/publish/bad-arguments/test.py
+++ b/testsuite/tests/publish/bad-arguments/test.py
@@ -11,7 +11,7 @@ assert_match(".*The origin must be a definitive remote location.*", p.out)
 
 # Bad combo, explicit file + commit
 p = run_alr("publish", "file:/fake.zip", "deadbeef", complain_on_error=False)
-assert_match(".*Expected a VCS origin but got.*", p.out)
+assert_match(".*unknown VCS URL", p.out)
 
 # Bad combo, implicit file + commit
 p = run_alr("publish", "fake.zip", "deadbeef", complain_on_error=False)


### PR DESCRIPTION
During load from lockfiles only, these resulted in `///path/to/file` bad paths that worked by chance on Linux but break on Windows, and we had never used such an origin as a dependency in our testsuite, so no lockfile was written that could make this problem evident.