### PR TITLE
Diagnose missing executable when running an action

### DIFF
--- a/src/alire/alire-os_lib.adb
+++ b/src/alire/alire-os_lib.adb
@@ -61,4 +61,21 @@ package body Alire.OS_Lib is
       GNAT.OS_Lib.Setenv (Name, Value);
    end Setenv;
 
+   -------------------------
+   -- Locate_Exec_On_Path --
+   -------------------------
+
+   function Locate_Exec_On_Path (Exec_Name : String) return String is
+      Located : GNAT.OS_Lib.String_Access :=
+                  GNAT.OS_Lib.Locate_Exec_On_Path (Exec_Name);
+   begin
+      if Located not in null then
+         return Result : constant String := Located.all do
+            GNAT.OS_Lib.Free (Located);
+         end return;
+      else
+         return "";
+      end if;
+   end Locate_Exec_On_Path;
+
 end Alire.OS_Lib;

--- a/src/alire/alire-os_lib.ads
+++ b/src/alire/alire-os_lib.ads
@@ -16,4 +16,7 @@ package Alire.OS_Lib with Preelaborate is
 
    procedure Setenv (Name : String; Value : String);
 
+   function Locate_Exec_On_Path (Exec_Name : String) return String;
+   --  Return the location of an executable if found on PATH, or "" otherwise
+
 end Alire.OS_Lib;

--- a/src/alire/alire-properties-actions-runners.ads
+++ b/src/alire/alire-properties-actions-runners.ads
@@ -45,9 +45,8 @@ private
    function Image (This : Run) return String
    is (AAA.Strings.To_Mixed_Case (This.Moment'Img)
        & (if This.Name /= "" then " (" & This.Name & ")" else "")
-       & " run: ${CRATE_DIR}" &
-        (if This.Working_Folder /= "" then "/" else "") &
-        This.Working_Folder & "/" & This.Relative_Command_Line.Flatten);
+       & " run: " & This.Relative_Command_Line.Flatten
+       & " (from ${CRATE_ROOT}/" & This.Working_Folder & ")");
 
    overriding
    function To_YAML (This : Run) return String

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -493,7 +493,7 @@ def alr_with(dep="", path="", url="", commit="", branch="",
             return run_alr(*args, force=force)
 
 
-def add_action(type, command, name="", directory=""):
+def add_action(type: str, command: [str], name="", directory=""):
     """
     Add an action to the manifest in the current directory.
     :param str type: "pre-build", etc

--- a/testsuite/drivers/asserts.py
+++ b/testsuite/drivers/asserts.py
@@ -134,3 +134,11 @@ def match_deploy_dir(crate : str, path_fragment : str):
     assert_match(f".*[: ]{crate.upper()}_ALIRE_PREFIX=[^\\n]*"
                  f"{re.escape(path_fragment)}[^\\n]*{crate}_.*",
                  p.out)
+
+
+def assert_substring(target: str, text: str):
+    """
+    Check that a string is contained in another string
+    """
+    assert target in text, \
+        f"Missing expected string '{target}' in text:\n{text}"

--- a/testsuite/tests/action/conditional/test.py
+++ b/testsuite/tests/action/conditional/test.py
@@ -35,14 +35,14 @@ command = ["echo", "4"]
 
 # Verify actions are there
 assert_match(".*" +
-             re.escape("""   Pre_Build run: ${CRATE_DIR}/./echo 1
+             re.escape("""   Pre_Build run: echo 1 (from ${CRATE_ROOT}/.)
    case OS is
-      when others => Pre_Build run: ${CRATE_DIR}/./echo 2
+      when others => Pre_Build run: echo 2 (from ${CRATE_ROOT}/.)
    case OS is
-      when others => Pre_Build run: ${CRATE_DIR}/./echo 3
-   Pre_Build run: ${CRATE_DIR}/./echo 4
+      when others => Pre_Build run: echo 3 (from ${CRATE_ROOT}/.)
+   Pre_Build run: echo 4 (from ${CRATE_ROOT}/.)
    case OS is
-      when others => Pre_Build run: ${CRATE_DIR}/./echo 5
+      when others => Pre_Build run: echo 5 (from ${CRATE_ROOT}/.)
 """) + ".*",
              run_alr("show").out)
 

--- a/testsuite/tests/action/list/test.py
+++ b/testsuite/tests/action/list/test.py
@@ -9,7 +9,7 @@ from drivers.asserts import assert_eq, assert_match
 from glob import glob
 
 expected_output = """main=1.0.0:
-   Post_Fetch run: ${CRATE_DIR}/./echo POST-FETCH MAIN
+   Post_Fetch run: echo POST-FETCH MAIN (from ${CRATE_ROOT}/.)
 """
 
 # First test, list action in a root crate

--- a/testsuite/tests/action/missing-exec/test.py
+++ b/testsuite/tests/action/missing-exec/test.py
@@ -1,0 +1,17 @@
+"""
+Check that an action trying to run a missing executable reports such an error.
+"""
+
+from drivers.alr import run_alr, add_action, init_local_crate
+from drivers.asserts import assert_substring
+
+init_local_crate()
+
+add_action('pre-build', ['fake-missing-exec'])
+
+p = run_alr("build", complain_on_error=False)
+
+assert_substring("Command not found  [fake-missing-exec]",
+                 p.out)
+
+print('SUCCESS')

--- a/testsuite/tests/action/missing-exec/test.yaml
+++ b/testsuite/tests/action/missing-exec/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+build_mode: both
+indexes: {}

--- a/testsuite/tests/build/incremental/test.py
+++ b/testsuite/tests/build/incremental/test.py
@@ -49,7 +49,7 @@ alr_with("root", path="..")
 
 p = run_alr("build", complain_on_error=False)
 assert p.status != 0, "Command should have failed"
-assert 'Command ["fake_alr_test_exec"] exited with code' in p.out, \
+assert 'Command not found  [fake_alr_test_exec]' in p.out, \
     "Output does not contain expected error, but: " + p.out
 
 print('SUCCESS')

--- a/testsuite/tests/index/custom-action/test.py
+++ b/testsuite/tests/index/custom-action/test.py
@@ -26,13 +26,13 @@ init_local_crate()
 # Add a proper custom action and verify its loading
 add_action(type="on-demand", name="my-action", command=["ls"])
 p = run_alr("show")
-assert_match(".*" + re.escape("On_Demand (my-action) run: ${CRATE_DIR}/./ls"),
+assert_match(".*" + re.escape("On_Demand (my-action) run: ls (from ${CRATE_ROOT}/.)"),
              p.out)
 
 # Verify that regular action can also have a name
 add_action(type="post-fetch", name="action-2", command=["ls"])
 p = run_alr("show")
-assert_match(".*" + re.escape("Post_Fetch (action-2) run: ${CRATE_DIR}/./ls"),
+assert_match(".*" + re.escape("Post_Fetch (action-2) run: ls (from ${CRATE_ROOT}/.)"),
              p.out)
 
 # Add an on-demand action without name and see it fails


### PR DESCRIPTION
Fixes #1373

Otherwise, the action failed with an obscure error message indicating an output code that induced to thing that the missing executable was the one returning that code.