### PR TITLE
Amend style switches (expand -gnatyg).

### DIFF
--- a/alire_common.gpr
+++ b/alire_common.gpr
@@ -24,9 +24,12 @@ abstract project Alire_Common is
    case Style_Check_Mode is
       when "enabled"  => Style_Check_Switches :=
            ("-gnatwe",   -- Warnings as errors
-            "-gnatyg",   -- Standard checks
+            "-gnatyd",   -- no DOS line terminators
             "-gnatyI",   -- no IN mode
             "-gnatyO",   -- all overrides
+            "-gnatyS",   -- separate lines after THEN/ELSE
+            "-gnatyu",   -- no unnecessary blank lines
+            "-gnatyx",   -- no extra parens around conditionals
             "-gnaty-s"); -- relax fwd decl
       when "disabled" => Style_Check_Switches := ();
    end case;


### PR DESCRIPTION
`-gnatyg` is (GCC <= 13) "check standard GNAT style rules, same as ydISux".  Long-term, it would be better to use that set of rules explicitly rather than depending on a set of style rules outside our control.

In GCC 14 `-gnatyg` will include a new switch, `-gnatyz` (check parentheses not required by operator precedence rules); refer GCC Bugzilla PR 112466.

This change to `-gnatyg` will mean that use of extra parens to clarify intent for readers who don’t have deep knowledge of the precedence rules will trigger warnings, fatal given `-gnatwe`; for example in alire-conditional_trees.adb
```
   function Contains_ORs (This : Tree) return Boolean is
      ((not This.Is_Empty) and then This.Root.Contains_ORs);
       ^-----------------^
```

  * alire_common.gpr (Style_Check_Switches): Remove -gnatyg and replace by the pre-GCC 14 equivalent.