### PR TITLE
New warning when external GNAT selected but another compiler version is needed

### DIFF
--- a/src/alire/alire-solver.adb
+++ b/src/alire/alire-solver.adb
@@ -886,7 +886,9 @@ package body Alire.Solver is
 
                Check_Version_Pin;
 
-            elsif Index.Exists (Dep.Crate, Index_Query_Options) or else
+            elsif Index.Exists (Dep.Crate, Index_Query_Options)
+              or else Index.All_Crate_Aliases.Contains (Dep.Crate)
+              or else
               not Index.Releases_Satisfying (Dep, Props,
                                              Index_Query_Options).Is_Empty
             then

--- a/testsuite/fixtures/compiler_only_index/gp/gprbuild/gprbuild-external.toml
+++ b/testsuite/fixtures/compiler_only_index/gp/gprbuild/gprbuild-external.toml
@@ -1,0 +1,11 @@
+description = "Fake gprbuild external"
+name = "gprbuild"
+
+maintainers = ["alejandro@mosteo.com"]
+maintainers-logins = ["mosteo"]
+
+[[external]]
+kind = "version-output"
+# We look for make instead, that should be always installed.
+version-command = ["make", "--version"]
+version-regexp = ".*Make ([\\d\\.]+).*"

--- a/testsuite/tests/solver/unsatisfying-external/test.py
+++ b/testsuite/tests/solver/unsatisfying-external/test.py
@@ -1,0 +1,25 @@
+"""
+When an external compiler is explicitly configured, no other compiler will be
+attempted to be added to the solution. This may be counterintuitive, so we emit
+an special warning in this case.
+"""
+
+from drivers.alr import run_alr, init_local_crate
+from drivers.asserts import assert_match
+
+
+init_local_crate()
+
+# Select the external compiler
+run_alr("toolchain", "--select", "gnat_external", "gprbuild")
+
+# Add a different version to the solution
+p = run_alr("with", "gnat^9999", force=True, quiet=False)
+
+# Check that the warning is emitted
+assert_match(".*The explicitly configured external compiler gnat_external=.*"
+            "cannot satisfy dependency in solution gnat\^9999",
+             p.out)
+
+
+print("SUCCESS")

--- a/testsuite/tests/solver/unsatisfying-external/test.yaml
+++ b/testsuite/tests/solver/unsatisfying-external/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+build_mode: both
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
Fixes #1233 

Minor tweak to the solver so in that case the GNAT dependency is reported as external rather than unknown.