### PR TITLE
Load configuration earlier from proper location

### DIFF
--- a/src/alire/alire-config-edit-early_load.adb
+++ b/src/alire/alire-config-edit-early_load.adb
@@ -1,0 +1,12 @@
+package body Alire.Config.Edit.Early_Load is
+
+   -----------------
+   -- Load_Config --
+   -----------------
+
+   procedure Load_Config is
+   begin
+      Alire.Config.Edit.Load_Config;
+   end Load_Config;
+
+end Alire.Config.Edit.Early_Load;

--- a/src/alire/alire-config-edit-early_load.ads
+++ b/src/alire/alire-config-edit-early_load.ads
@@ -1,0 +1,7 @@
+package Alire.Config.Edit.Early_Load is
+
+   procedure Load_Config;
+   --  For internal use of Alire_Early_Elaboration, DO NOT CALL otherwise.
+   --  This should be hidden but that would require a non-trivial refactoring.
+
+end Alire.Config.Edit.Early_Load;

--- a/src/alire/alire-config-edit.adb
+++ b/src/alire/alire-config-edit.adb
@@ -138,16 +138,18 @@ package body Alire.Config.Edit is
 
    procedure Load_Config is
    begin
-      DB.Clear;
+      DB_Instance.Clear;
 
       for Lvl in Level loop
          if Lvl /= Local or else Directories.Detect_Root_Path /= "" then
-            CLIC.Config.Load.From_TOML (C      => DB,
+            CLIC.Config.Load.From_TOML (C      => DB_Instance,
                                         Origin => Lvl'Img,
                                         Path   => Filepath (Lvl),
                                         Check  => Valid_Builtin'Access);
          end if;
       end loop;
+
+      Config_Loaded := True;
 
       --  Set variables elsewhere
 
@@ -156,7 +158,6 @@ package body Alire.Config.Edit is
       if Platforms.Current.Disable_Distribution_Detection then
          Trace.Debug ("Distribution detection disabled by configuration");
       end if;
-
    end Load_Config;
 
    Default_Config_Path : constant Absolute_Path := Platforms.Folders.Config;
@@ -313,8 +314,5 @@ package body Alire.Config.Edit is
          New_Line;
       end loop;
    end Print_Builtins_Doc;
-
-begin
-   Load_Config;
 
 end Alire.Config.Edit;

--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -79,11 +79,12 @@ package Alire.Config.Edit is
                            return Boolean;
    --  Check that the combination satisfies builtin rules
 
+private
+
    procedure Load_Config;
    --  Clear and reload all configuration. Also set some values elsewhere
    --  used to break circularities. Bottom line, this procedure must leave
    --  the program-wide configuration ready. This is done during startup from
-   --  Alire_Early_Elaboration so config is available ASAP; regular clients of
-   --  libalire shouldn't need to call this explicitly.
+   --  Alire_Early_Elaboration so config is available ASAP.
 
 end Alire.Config.Edit;

--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -79,11 +79,11 @@ package Alire.Config.Edit is
                            return Boolean;
    --  Check that the combination satisfies builtin rules
 
-private
-
    procedure Load_Config;
    --  Clear and reload all configuration. Also set some values elsewhere
    --  used to break circularities. Bottom line, this procedure must leave
-   --  the program-wide configuration ready.
+   --  the program-wide configuration ready. This is done during startup from
+   --  Alire_Early_Elaboration so config is available ASAP; regular clients of
+   --  libalire shouldn't need to call this explicitly.
 
 end Alire.Config.Edit;

--- a/src/alire/alire-config.adb
+++ b/src/alire/alire-config.adb
@@ -2,6 +2,20 @@ with Alire.Config.Edit;
 
 package body Alire.Config is
 
+   --------
+   -- DB --
+   --------
+
+   function DB return access constant CLIC.Config.Instance
+   is
+   begin
+      if Config_Loaded then
+         return DB_Instance'Access;
+      else
+         raise Program_Error with "Attempt to use config database too early";
+      end if;
+   end DB;
+
    ---------
    -- Get --
    ---------

--- a/src/alire/alire-config.ads
+++ b/src/alire/alire-config.ads
@@ -8,8 +8,7 @@ with CLIC.Config;
 
 package Alire.Config is
 
-   DB : CLIC.Config.Instance;
-   --  The Alire user configuration database
+   function DB return access constant CLIC.Config.Instance;
 
    type Level is (Global, Local);
    --  Ordering is important, as Globals are loaded first and overridden by any
@@ -82,6 +81,11 @@ package Alire.Config is
      with Pre => Help /= "" or not Public;
 
 private
+
+   Config_Loaded : Boolean := False;
+
+   DB_Instance : aliased CLIC.Config.Instance;
+   --  The Alire user configuration database
 
    type Builtin_Option is tagged record
       Key     : Ada.Strings.Unbounded.Unbounded_String;

--- a/src/alire/alire-index.ads
+++ b/src/alire/alire-index.ads
@@ -1,4 +1,5 @@
 private with Alire_Early_Elaboration;
+pragma Elaborate_All (Alire_Early_Elaboration);
 pragma Unreferenced (Alire_Early_Elaboration);
 
 with Alire.Config.Builtins;

--- a/src/alire/alire-toolchains.adb
+++ b/src/alire/alire-toolchains.adb
@@ -459,7 +459,7 @@ package body Alire.Toolchains is
                           Level         : Config.Level;
                           Fail_If_Unset : Boolean := True) is
    begin
-      if CLIC.Config.Defined (Config.DB, Tool_Key (Crate)) and then
+      if CLIC.Config.Defined (Config.DB.all, Tool_Key (Crate)) and then
         not CLIC.Config.Edit.Unset
           (Config.Edit.Filepath (Level),
            Tool_Key (Crate))

--- a/src/alire/alire_early_elaboration.adb
+++ b/src/alire/alire_early_elaboration.adb
@@ -2,7 +2,7 @@ with AAA.Strings;
 
 with Ada.Directories;
 
-with Alire.Config.Edit;
+with Alire.Config.Edit.Early_Load;
 
 with GNAT.Command_Line;
 with GNAT.OS_Lib;
@@ -180,7 +180,7 @@ package body Alire_Early_Elaboration is
       end if;
 
       --  Load config ASAP
-      Alire.Config.Edit.Load_Config;
+      Alire.Config.Edit.Early_Load.Load_Config;
    end Early_Switch_Detection;
 
    -------------------

--- a/src/alire/os_windows/alire-platforms-current__windows.adb
+++ b/src/alire/os_windows/alire-platforms-current__windows.adb
@@ -3,6 +3,9 @@ with GNAT.OS_Lib;
 
 with AAA.Strings;
 
+with Alire_Early_Elaboration;
+pragma Unreferenced (Alire_Early_Elaboration);
+
 with Alire.Environment;
 with Alire.OS_Lib;            use Alire.OS_Lib;
 with Alire.Config.Builtins.Windows;

--- a/src/alr/alr-commands-config.adb
+++ b/src/alr/alr-commands-config.adb
@@ -59,13 +59,13 @@ package body Alr.Commands.Config is
             when 0 =>
                Trace.Always
                  (CLIC.Config.Info.List
-                    (Alire.Config.DB,
+                    (Alire.Config.DB.all,
                      Filter => ".*",
                      Show_Origin => Cmd.Show_Origin).Flatten (ASCII.LF));
             when 1 =>
                Trace.Always
                  (CLIC.Config.Info.List
-                    (Alire.Config.DB,
+                    (Alire.Config.DB.all,
                      Filter => Args.First_Element,
                      Show_Origin => Cmd.Show_Origin).Flatten (ASCII.LF));
             when others =>

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -492,12 +492,15 @@ package body Alr.Commands is
       if Command_Line_Config_Path /= null and then
          Command_Line_Config_Path.all /= ""
       then
-         declare
-            Config_Path : constant Alire.Absolute_Path
-              := Ada.Directories.Full_Name (Command_Line_Config_Path.all);
-         begin
-            Alire.Config.Edit.Set_Path (Config_Path);
-         end;
+         --  Just verify that early processing catched it
+         pragma Assert
+           (Alire.Config.Edit.Path =
+              Ada.Directories.Full_Name (Command_Line_Config_Path.all),
+            "Unexpected mismatch of config paths:"
+            & Alire.New_Line
+            & "Early: " & Alire.Config.Edit.Path
+            & Alire.New_Line
+            & "Late : " & Command_Line_Config_Path.all);
       end if;
 
       --  chdir(2) if necessary.
@@ -514,7 +517,7 @@ package body Alr.Commands is
 
          Set_Builtin_Aliases;
 
-         Sub_Cmd.Load_Aliases (Alire.Config.DB);
+         Sub_Cmd.Load_Aliases (Alire.Config.DB.all);
 
          Sub_Cmd.Execute;
          Log ("alr " & Sub_Cmd.What_Command & " done", Detail);

--- a/testsuite/tests/config/early-loading/test.py
+++ b/testsuite/tests/config/early-loading/test.py
@@ -1,0 +1,29 @@
+"""
+Test for bug #1496, in which a configuration at a non-default location was
+loaded too late.
+"""
+
+import os
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq, assert_match
+
+# Create a custom configuration dir + file
+custom_config = "custom_config"
+os.mkdir(custom_config)
+with open(os.path.join(custom_config, "config.toml"), "w") as f:
+    f.write("test_value = 42\n")
+
+expected = "test_value=42\n"
+
+# Verify proper loading with both short and long config options
+assert_eq(expected,
+          run_alr("-c", custom_config, "config", "--global").out)
+assert_eq(expected,
+          run_alr(f"--config={custom_config}", "config", "--global").out)
+
+# Verify also when using environment variable
+os.environ["ALR_CONFIG"] = os.path.abspath(custom_config)
+assert_eq(expected,
+          run_alr("config", "--global").out)
+
+print('SUCCESS')

--- a/testsuite/tests/config/early-loading/test.yaml
+++ b/testsuite/tests/config/early-loading/test.yaml
@@ -1,0 +1,7 @@
+driver: python-script
+build_mode: both  # one of shared, sandboxed, both (default)
+indexes:
+    compiler_only_index: {}
+    # Note that shared builds require a detected compiler to be able to compute
+    # build hashes, which is needed for many subcommands: build, get, printenv,
+    # update...

--- a/testsuite/tests/config/relative_config_path/test.py
+++ b/testsuite/tests/config/relative_config_path/test.py
@@ -10,7 +10,7 @@ from drivers.alr import run_alr
 from drivers.asserts import assert_eq
 from drivers.helpers import lines_of
 
-run_alr("--config", ".", "config", "--global",
+run_alr("--config=.", "config", "--global",
         "--set", "some_config_key", "true")
 
 


### PR DESCRIPTION
Configuration could be loaded from the default location even when using `-c` because of elaboration order.

This fixes #1496 and ensures it can't happen again as program error would be raised if we reintroduce the problem.