### PR TITLE
Fix regression when `alr with`ing a virtual crate without actual releases

### DIFF
--- a/src/alire/alire-dependencies.adb
+++ b/src/alire/alire-dependencies.adb
@@ -7,8 +7,6 @@ with Semantic_Versioning;
 
 package body Alire.Dependencies is
 
-   package Semver renames Semantic_Versioning;
-
    -----------------
    -- From_String --
    -----------------

--- a/src/alire/alire-dependencies.ads
+++ b/src/alire/alire-dependencies.ads
@@ -11,6 +11,8 @@ private with Alire.Utils.TTY;
 
 package Alire.Dependencies with Preelaborate is
 
+   package Semver renames Semantic_Versioning;
+
    --  A single dependency is a crate name plus a version set
 
    type Dependency (<>) is
@@ -22,7 +24,7 @@ package Alire.Dependencies with Preelaborate is
 
    function New_Dependency
      (Crate    : Crate_Name;
-      Versions : Semantic_Versioning.Extended.Version_Set)
+      Versions : Semver.Extended.Version_Set := Semver.Extended.Any)
       return Dependency;
 
    function New_Dependency
@@ -92,7 +94,7 @@ private
 
    function New_Dependency
      (Crate    : Crate_Name;
-      Versions : Semantic_Versioning.Extended.Version_Set)
+      Versions : Semver.Extended.Version_Set := Semver.Extended.Any)
       return Dependency
    is (Crate.Name'Length, Crate, Versions);
 

--- a/src/alire/alire-index.adb
+++ b/src/alire/alire-index.adb
@@ -386,7 +386,7 @@ package body Alire.Index is
 
    function Releases_Satisfying
      (Dep              : Dependencies.Dependency;
-      Env              : Properties.Vector;
+      Env              : Properties.Vector := Platforms.Current.Properties;
       Opts             : Query_Options := Query_Defaults;
       Use_Equivalences : Boolean := True;
       Available_Only   : Boolean := True;
@@ -425,5 +425,25 @@ package body Alire.Index is
 
       return Result;
    end Releases_Satisfying;
+
+   ------------------------
+   -- Releases_For_Crate --
+   ------------------------
+
+   function Releases_For_Crate
+     (Crate            : Crate_Name;
+      Env              : Properties.Vector := Platforms.Current.Properties;
+      Opts             : Query_Options := Query_Defaults;
+      Use_Equivalences : Boolean := True;
+      Available_Only   : Boolean := True;
+      With_Origin      : Origins.Kinds_Set := (others => True))
+      return Releases.Containers.Release_Set
+   is (Releases_Satisfying
+         (Dep              => Dependencies.New_Dependency (Crate),
+          Env              => Env,
+          Opts             => Opts,
+          Use_Equivalences => Use_Equivalences,
+          Available_Only   => Available_Only,
+          With_Origin      => With_Origin));
 
 end Alire.Index;

--- a/src/alire/alire-index.ads
+++ b/src/alire/alire-index.ads
@@ -5,6 +5,7 @@ with Alire.Config.Builtins;
 with Alire.Crates.Containers;
 with Alire.Dependencies;
 with Alire.Origins;
+with Alire.Platforms.Current;
 with Alire.Policies;
 with Alire.Properties;
 with Alire.Provides;
@@ -124,7 +125,7 @@ package Alire.Index is
 
    function Releases_Satisfying
      (Dep              : Dependencies.Dependency;
-      Env              : Properties.Vector;
+      Env              : Properties.Vector := Platforms.Current.Properties;
       Opts             : Query_Options := Query_Defaults;
       Use_Equivalences : Boolean := True;
       Available_Only   : Boolean := True;
@@ -134,6 +135,16 @@ package Alire.Index is
    --  Return all releases in the catalog able to provide this dependency,
    --  also optionally considering their "provides" equivalences, and also
    --  optionally including unavailable on the platform.
+
+   function Releases_For_Crate
+     (Crate            : Crate_Name;
+      Env              : Properties.Vector := Platforms.Current.Properties;
+      Opts             : Query_Options := Query_Defaults;
+      Use_Equivalences : Boolean := True;
+      Available_Only   : Boolean := True;
+      With_Origin      : Origins.Kinds_Set := (others => True))
+      return Releases.Containers.Release_Set;
+   --  A simplified form of Releases_Satisfying for crate* and
 
    function Find (Name    : Crate_Name;
                   Version : Semantic_Versioning.Version;

--- a/src/alire/alire-roots-editable.adb
+++ b/src/alire/alire-roots-editable.adb
@@ -129,7 +129,10 @@ package body Alire.Roots.Editable is
 
       --  Reject if unknown
 
-      if not Allow_Unknown and then not Index.Exists (Dep.Crate) then
+      if not Allow_Unknown
+        and then not Index.Exists (Dep.Crate)
+        and then Index.Releases_For_Crate (Dep.Crate).Is_Empty
+      then
          Alire.Recoverable_Error
            ("Cannot add crate '" & Alire.Utils.TTY.Name (Dep.Crate)
             & "' not found in index.");

--- a/testsuite/fixtures/gnat_toolchain_index/gn/gnat_cross/gnat_cross-1.0.0.toml
+++ b/testsuite/fixtures/gnat_toolchain_index/gn/gnat_cross/gnat_cross-1.0.0.toml
@@ -1,0 +1,10 @@
+description = ""
+name = "gnat_cross"
+provides = ["gnat=1.0"]
+version = "1.0.0"
+licenses = "GPL-3.0-only OR MIT"
+maintainers = ["some@bo.dy"]
+maintainers-logins = ["mylogin"]
+
+[origin]
+url = "file:."

--- a/testsuite/fixtures/gnat_toolchain_index/gn/gnat_external/gnat_external-external.toml
+++ b/testsuite/fixtures/gnat_toolchain_index/gn/gnat_external/gnat_external-external.toml
@@ -1,0 +1,11 @@
+description = "GNAT is a compiler for the Ada programming language"
+name = "gnat_external"
+
+maintainers = ["alejandro@mosteo.com"]
+maintainers-logins = ["mosteo"]
+
+[[external]]
+kind = "version-output"
+version-command = ["echo", "1.0"]
+version-regexp = "([\\d\\.]+).*"
+provides = "gnat"

--- a/testsuite/fixtures/gnat_toolchain_index/gn/gnat_native/gnat_native-1.0.0.toml
+++ b/testsuite/fixtures/gnat_toolchain_index/gn/gnat_native/gnat_native-1.0.0.toml
@@ -1,0 +1,10 @@
+description = ""
+name = "gnat_native"
+provides = ["gnat=1.0"]
+version = "1.0.0"
+licenses = "GPL-3.0-only OR MIT"
+maintainers = ["some@bo.dy"]
+maintainers-logins = ["mylogin"]
+
+[origin]
+url = "file:."

--- a/testsuite/fixtures/gnat_toolchain_index/gp/gprbuild/gprbuild-1.0.0.toml
+++ b/testsuite/fixtures/gnat_toolchain_index/gp/gprbuild/gprbuild-1.0.0.toml
@@ -1,0 +1,9 @@
+description = ""
+name = "gprbuild"
+version = "1.0.0"
+licenses = "GPL-3.0-only OR MIT"
+maintainers = ["some@bo.dy"]
+maintainers-logins = ["mylogin"]
+
+[origin]
+url = "file:."

--- a/testsuite/fixtures/gnat_toolchain_index/gp/gprbuild/gprbuild-external.toml
+++ b/testsuite/fixtures/gnat_toolchain_index/gp/gprbuild/gprbuild-external.toml
@@ -1,0 +1,10 @@
+description = "Fake gprbuild external"
+name = "gprbuild"
+
+maintainers = ["alejandro@mosteo.com"]
+maintainers-logins = ["mosteo"]
+
+[[external]]
+kind = "version-output"
+version-command = ["echo", "1.0"]
+version-regexp = "([\\d\\.]+).*"

--- a/testsuite/fixtures/gnat_toolchain_index/index.toml
+++ b/testsuite/fixtures/gnat_toolchain_index/index.toml
@@ -1,0 +1,4 @@
+# This index describes a mock GNAT toolchain, with native and cross compiler
+# providing the virtual gnat crate.
+
+version = "1.1"

--- a/testsuite/tests/with/virtual-crate/test.py
+++ b/testsuite/tests/with/virtual-crate/test.py
@@ -1,0 +1,19 @@
+"""
+Verify that 'withing' a virtual crate works. In particular, replicate the usual
+situation of `alr with gnat^1` where gnat is a virtual crate.
+"""
+
+from drivers.alr import run_alr, init_local_crate
+from drivers.asserts import match_solution
+
+init_local_crate()
+
+# Should not fail
+run_alr("with", "gnat^1")
+
+# Verify solution (as no compiler was selected, external takes precedence)
+match_solution("""Dependencies (solution):
+   gnat=1.0.0 (gnat_external)"""
+               , escape=True)
+
+print("SUCCESS")

--- a/testsuite/tests/with/virtual-crate/test.yaml
+++ b/testsuite/tests/with/virtual-crate/test.yaml
@@ -1,0 +1,5 @@
+driver: python-script
+build_mode: both
+indexes:
+    gnat_toolchain_index:
+        in_fixtures: true


### PR DESCRIPTION
This is the particular case of `alr with gnat`.

This was introduced in #1489, and no test covered that particular case at the time.