### PR TITLE
platforms: use $XDG_DATA_HOME for cache on linux/freebsd/macos

### DIFF
--- a/src/alire/alire-platforms-common.ads
+++ b/src/alire/alire-platforms-common.ads
@@ -32,13 +32,13 @@ private package Alire.Platforms.Common is
                                                 Default => ".")));
 
    ----------------------
-   -- XDG_Cache_Folder --
+   -- XDG_Data_Folder --
    ----------------------
 
-   function XDG_Cache_Folder return String
+   function XDG_Data_Folder return String
    is (OS_Lib.Getenv
-         ("XDG_CACHE_HOME",
-          Default => Unix_Home_Folder / ".cache")
+         ("XDG_DATA_HOME",
+          Default => Unix_Home_Folder / ".local" / "share")
        / "alire");
 
    -----------------------

--- a/src/alire/alire-platforms-folders.ads
+++ b/src/alire/alire-platforms-folders.ads
@@ -11,9 +11,13 @@ package Alire.Platforms.Folders is
 
    function Cache return Absolute_Path;
    --  Folder for dependencies, global toolchains, and any other info that is
-   --  not critical to lose. Can be deleted freely, it's repopulated on-demand.
-   --  On Linux/macOS it is ${XDG_CACHE_HOME:-$HOME/.cache}/alire
-   --  On Windows it is $UserProfile\.cache\alire
+   --  not critical to lose. Can be deleted freely, it's repopulated on-demand,
+   --  though is generally expected to be persistent. On Linux/macOS it is
+   --  ${XDG_DATA_HOME:-$HOME/.local/share}/alire. On Windows it is
+   --  $UserProfile\.cache\alire.
+   --
+   --  For Linux/macOS, $XDG_CACHE_HOME is intentionally not used, as some
+   --  distributions reccommend mounting it as a tmpfs. See #1502.
 
    function Home return Absolute_Path;
    --  $HOME (Linux/macOS) or $UserProfile (Windows)

--- a/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
+++ b/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
@@ -10,7 +10,7 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return Absolute_Path is (Common.XDG_Cache_Folder);
+   function Cache return Absolute_Path is (Common.XDG_Data_Folder);
 
    -----------
    -- Config--

--- a/src/alire/os_linux/alire-platforms-folders__linux.adb
+++ b/src/alire/os_linux/alire-platforms-folders__linux.adb
@@ -10,7 +10,7 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return Absolute_Path is (Common.XDG_Cache_Folder);
+   function Cache return Absolute_Path is (Common.XDG_Data_Folder);
 
    -----------
    -- Config--

--- a/src/alire/os_macos/alire-platforms-folders__macos.adb
+++ b/src/alire/os_macos/alire-platforms-folders__macos.adb
@@ -10,7 +10,7 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return Absolute_Path is (Common.XDG_Cache_Folder);
+   function Cache return Absolute_Path is (Common.XDG_Data_Folder);
 
    -----------
    -- Config--

--- a/testsuite/tests/dockerized/misc/default-cache/test.py
+++ b/testsuite/tests/dockerized/misc/default-cache/test.py
@@ -16,7 +16,7 @@ alr_with("gnat_native")
 
 home = os.environ["HOME"]
 
-base = f"{home}/.cache/alire"
+base = f"{home}/.local/share/alire"
 
 assert \
     os.path.isdir(f"{base}/toolchains/gnat_native_8888.0.0_99fa3a55"), \


### PR DESCRIPTION
$XDG_CACHE_HOME may be, in both specification and application, mounted on a tmpfs, removed frequently, &c. It generally appears to be used for small amounts of unimportant data, which is not what Alire expects of it. This commit switches things over to $XDG_DATA_HOME, which is generally more reliable.

Fixes #1502. (It looks discussion on that issue reached consensus; no worries if there's still debate/concern!)