### PR TITLE
Update list of supported platforms

### DIFF
--- a/doc/catalog-format-spec.md
+++ b/doc/catalog-format-spec.md
@@ -829,9 +829,10 @@ provides = "another_crate_name"
 
 Systems that have their own package manager (e.g. Linux) can readily provide
 many complex dependencies still unpackaged as source code in Alire. Alire can
-use these on supported platforms (at this time, Debian & Ubuntu. Do not
-hesitate to contact us if you would like to maintain other distributions)
-during resolution.
+use these on supported platforms during resolution. At this time, the supported
+platforms are Arch, CentOS, Debian, Fedora, Homebrew, MacPorts, MSYS2, RHEL,
+SUSE/openSUSE, and Ubuntu; do not hesitate to contact us if you would like to
+maintain other distributions.
 
 A system external gives a list of platform package names that supply the
 dependency natively. The platform package manager will be used to detect their


### PR DESCRIPTION
Update the documentation to show a list of the currently supported platforms rather than only Debian and Ubuntu.