### PR TITLE
Update the supported values of the os and distribution parameters.

### DIFF
--- a/doc/catalog-format-spec.md
+++ b/doc/catalog-format-spec.md
@@ -856,11 +856,13 @@ available.'case(toolchain)'.user = false
 
 ## Parameters
 
- - `os`: name of the OS. Currently supported values are: `linux`, `macos` and
-   `windows`.
+ - `os`: name of the OS. Currently supported values are: `freebsd`, `linux`,
+   `macos`, `os-unknown`, and `windows`.
 
- - `distribution`: name of the Linux distribution, or `none` if running on a
-   different OS. Currently supported values are: `debian`, `ubuntu`.
+ - `distribution`: name of the Linux distribution or name of the software
+   distribution platform if running on a different OS. Currently supported
+   values are: `arch`, `centos`, `debian`, `distro-unknown`, `fedora`,
+   `homebrew`, `macports`, `msys2`, `rhel`, `suse`, and `ubuntu`.
 
  - `toolchain`: takes `system` value in distributions with the system Ada
    compiler first in PATH (GNAT FSF in Debian/Ubuntu), `user` otherwise (GNAT


### PR DESCRIPTION
Update the documentation to list all of the currently supported values of the `os` and `distribution` parameters.