### PR TITLE
Build appimage on Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci-appimage.yml
+++ b/.github/workflows/ci-appimage.yml
@@ -18,7 +18,7 @@ jobs:
 
     # Oldest supported by Alire+GitHub to increase AppImage back-compatibility
     # Unfortunately we depend on the static elaboration model of recent GNATs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out repository
@@ -27,7 +27,12 @@ jobs:
         submodules: true
 
     - name: Install FSF toolchain
-      run: sudo apt-get install -y gnat gprbuild
+      run: sudo apt-get install -y gnat-10 gprbuild
+
+    - name: Set up gcc on the PATH to be gcc-10
+      run: |
+        mkdir -p $HOME/.local/bin
+        ln -s /usr/bin/gcc-10 $HOME/.local/bin/gcc
 
     - name: Install Python 3.x (required for the testsuite)
       uses: actions/setup-python@v2


### PR DESCRIPTION
Besides changing the versions of Ubuntu and GNAT, the only other change is to get the build to use GCC 10 instead of GCC 9. The `$HOME/.local/bin` directory is already in the `PATH` environment variable before the `/usr/bin` directory. The changes create the `$HOME/.local/bin` directory and create a `gcc` symbolic, in that directory, that points to gcc-10.

Fixes #1511.