### PR TITLE
Report the name of an unreadable directory.

### DIFF
--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -173,7 +173,7 @@ package body Alire.Index_On_Disk is
          Dir : constant Virtual_File := Create (+Path);
       begin
          if not Dir.Is_Directory then
-            Result := Outcome_Failure ("Not a readable directory");
+            Result := Outcome_Failure ("Not a readable directory: " & Path);
             return New_Invalid_Index;
          end if;
 

--- a/testsuite/tests/index/local-index-not-found/test.py
+++ b/testsuite/tests/index/local-index-not-found/test.py
@@ -10,8 +10,13 @@ from e3.fs import rm
 from drivers.alr import prepare_indexes, run_alr
 from drivers.asserts import assert_match
 
+def comparator(param):
+    """If the test value (in d) is 'no-such-directory', the value tested for
+    is './no-such-directory'; if not, it's left as it is."""
+    if param == 'no-such-directory': return './no-such-directory'
+    return param
 
-for d in ('./no-such-directory',
+for d in ('no-such-directory',
           'file://no-such-directory', ):
     rm('alr-config', recursive=True)
     prepare_indexes('alr-config', '.',
@@ -23,7 +28,7 @@ for d in ('./no-such-directory',
     assert_match('ERROR: Cannot load metadata from .*{}:'
                  ' Not a readable directory: {}'
                  '\n'
-                 .format(re.escape(path_excerpt), d),
+                 .format(re.escape(path_excerpt), comparator(d)),
                  p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/local-index-not-found/test.py
+++ b/testsuite/tests/index/local-index-not-found/test.py
@@ -21,9 +21,9 @@ for d in ('no-such-directory',
     path_excerpt = os.path.join('alr-config', 'indexes', 'bad_index',
                                 'index.toml')
     assert_match('ERROR: Cannot load metadata from .*{}:'
-                 ' Not a readable directory: ./no-such-directory'
+                 ' Not a readable directory: {}'
                  '\n'
-                 .format(re.escape(path_excerpt)),
+                 .format(re.escape(path_excerpt), d),
                  p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/local-index-not-found/test.py
+++ b/testsuite/tests/index/local-index-not-found/test.py
@@ -21,7 +21,7 @@ for d in ('no-such-directory',
     path_excerpt = os.path.join('alr-config', 'indexes', 'bad_index',
                                 'index.toml')
     assert_match('ERROR: Cannot load metadata from .*{}:'
-                 ' Not a readable directory'
+                 ' Not a readable directory: ./no-such-directory'
                  '\n'
                  .format(re.escape(path_excerpt)),
                  p.out)

--- a/testsuite/tests/index/local-index-not-found/test.py
+++ b/testsuite/tests/index/local-index-not-found/test.py
@@ -11,7 +11,7 @@ from drivers.alr import prepare_indexes, run_alr
 from drivers.asserts import assert_match
 
 
-for d in ('no-such-directory',
+for d in ('./no-such-directory',
           'file://no-such-directory', ):
     rm('alr-config', recursive=True)
     prepare_indexes('alr-config', '.',


### PR DESCRIPTION
While working on a new external, I tried adding my local alire-index before the community index for testing. The error reported was "Not a readable directory". After 2 hours investigation (gdb ...) I realised that I’d been trying to add `alr-index` rather than `alire-index`.

This patch (which is in the style of other `Outcome_Failure` messages) would probably have saved that time!