### PR TITLE
Report the name of an unreadable directory.

### DIFF
--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -173,7 +173,7 @@ package body Alire.Index_On_Disk is
          Dir : constant Virtual_File := Create (+Path);
       begin
          if not Dir.Is_Directory then
-            Result := Outcome_Failure ("Not a readable directory");
+            Result := Outcome_Failure ("Not a readable directory: " & Path);
             return New_Invalid_Index;
          end if;
 

--- a/testsuite/tests/index/local-index-not-found/test.py
+++ b/testsuite/tests/index/local-index-not-found/test.py
@@ -3,13 +3,13 @@ Test that Alire properly reports an invalid index URL.
 """
 
 import os
+import os.path
 import re
 
 from e3.fs import rm
 
 from drivers.alr import prepare_indexes, run_alr
 from drivers.asserts import assert_match
-
 
 for d in ('no-such-directory',
           'file://no-such-directory', ):
@@ -21,9 +21,9 @@ for d in ('no-such-directory',
     path_excerpt = os.path.join('alr-config', 'indexes', 'bad_index',
                                 'index.toml')
     assert_match('ERROR: Cannot load metadata from .*{}:'
-                 ' Not a readable directory'
+                 ' Not a readable directory: .{}{}'
                  '\n'
-                 .format(re.escape(path_excerpt)),
+                 .format(re.escape(path_excerpt), os.path.sep, d),
                  p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/index/local-index-not-found/test.py
+++ b/testsuite/tests/index/local-index-not-found/test.py
@@ -20,10 +20,11 @@ for d in ('no-such-directory',
 
     path_excerpt = os.path.join('alr-config', 'indexes', 'bad_index',
                                 'index.toml')
+    separator = re.escape(os.path.sep)
     assert_match('ERROR: Cannot load metadata from .*{}:'
                  ' Not a readable directory: .{}{}'
                  '\n'
-                 .format(re.escape(path_excerpt), os.path.sep, d),
+                 .format(re.escape(path_excerpt), separator, d),
                  p.out)
 
 print('SUCCESS')


### PR DESCRIPTION
  While working on a new external, I tried adding my local alire-index before the community index for testing. The error reported was "Not a readable directory". After 2 hours investigation (gdb ...) I realised that I’d been trying to add alr-index rather than alire-index.

This patch (which is in the style of other Outcome_Failure messages) would probably have saved that time!

Apologies for creating a new PR having closed #1522 - I’ve squashed the 'test' commits, including one last one that passes all but Windows tests. I can’t see what’s wrong with the Windows tests - there are obvious differences in the number of backslashes, but they’re in a part I haven’t changed! 

[Test log in my repo](https://github.com/simonjwright/alire/actions/runs/7376794642/job/20069996083#step:8:1085)
