### PR TITLE
Add missing with statements for Ada.Directories

### DIFF
--- a/src/alire/alire-roots-editable.adb
+++ b/src/alire/alire-roots-editable.adb
@@ -1,3 +1,5 @@
+with Ada.Directories;
+
 with Alire.Conditional;
 with Alire.Dependencies.Diffs;
 with Alire.Directories;

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -1,3 +1,4 @@
+with Ada.Directories;
 with Ada.Unchecked_Deallocation;
 
 with Alire.Builds;


### PR DESCRIPTION
Adds two with statements for Alire.Directories.

A compiler bug was giving visibility of some packages in cases where it shouldn't have. After the bug is fixed in a future version, Alire will fail to compile without these with statements.