### PR TITLE
Better location for cache

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,10 @@
+## Upgrading from 1.x to 2.x
+
+Changes in default storage locations mean that the following folders, if
+existing, can be safely deleted to retrieve disk space:
+
+- <userdir>/.cache/alire
+- <userdir>/.config/alire/cache
+
+On Windows, `<userdir>` stands for `%UserProfile%`, whereas for other OSes it
+stands for `$HOME`.

--- a/src/alire/alire-platforms-common.ads
+++ b/src/alire/alire-platforms-common.ads
@@ -31,21 +31,21 @@ private package Alire.Platforms.Common is
                       Default => OS_Lib.Getenv ("TMPDIR",
                                                 Default => ".")));
 
-   ----------------------
-   -- XDG_Cache_Folder --
-   ----------------------
+   -------------------
+   -- XDG_Data_Home --
+   -------------------
 
-   function XDG_Cache_Folder return String
+   function XDG_Data_Home return String
    is (OS_Lib.Getenv
-         ("XDG_CACHE_HOME",
-          Default => Unix_Home_Folder / ".cache")
+         ("XDG_DATA_HOME",
+          Default => Unix_Home_Folder / ".local/share")
        / "alire");
 
-   -----------------------
-   -- XDG_Config_Folder --
-   -----------------------
+   ---------------------
+   -- XDG_Config_Home --
+   ---------------------
 
-   function XDG_Config_Folder return String
+   function XDG_Config_Home return String
    is (OS_Lib.Getenv
          ("XDG_CONFIG_HOME",
           Default => Unix_Home_Folder / ".config")

--- a/src/alire/alire-platforms-folders.ads
+++ b/src/alire/alire-platforms-folders.ads
@@ -12,8 +12,10 @@ package Alire.Platforms.Folders is
    function Cache return Absolute_Path;
    --  Folder for dependencies, global toolchains, and any other info that is
    --  not critical to lose. Can be deleted freely, it's repopulated on-demand.
-   --  On Linux/macOS it is ${XDG_CACHE_HOME:-$HOME/.cache}/alire
-   --  On Windows it is $UserProfile\.cache\alire
+   --  See https://github.com/alire-project/alire/issues/1502 for why it is not
+   --  the OS cache dir but the data dir instead. So, in summary, it's located:
+   --  On Linux/macOS at ${XDG_DATA_HOME:-$HOME/.local/share}/alire
+   --  On Windows it is $LocalAppData\alire ($UserProfile\AppData\Local)
 
    function Home return Absolute_Path;
    --  $HOME (Linux/macOS) or $UserProfile (Windows)

--- a/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
+++ b/src/alire/os_freebsd/alire-platforms-folders__freebsd.adb
@@ -10,13 +10,13 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return Absolute_Path is (Common.XDG_Cache_Folder);
+   function Cache return Absolute_Path is (Common.XDG_Data_Home);
 
    -----------
    -- Config--
    -----------
 
-   function Config return Absolute_Path is (Common.XDG_Config_Folder);
+   function Config return Absolute_Path is (Common.XDG_Config_Home);
 
    ----------
    -- Home --

--- a/src/alire/os_linux/alire-platforms-folders__linux.adb
+++ b/src/alire/os_linux/alire-platforms-folders__linux.adb
@@ -10,13 +10,13 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return Absolute_Path is (Common.XDG_Cache_Folder);
+   function Cache return Absolute_Path is (Common.XDG_Data_Home);
 
    -----------
    -- Config--
    -----------
 
-   function Config return Absolute_Path is (Common.XDG_Config_Folder);
+   function Config return Absolute_Path is (Common.XDG_Config_Home);
 
    ----------
    -- Home --

--- a/src/alire/os_macos/alire-platforms-folders__macos.adb
+++ b/src/alire/os_macos/alire-platforms-folders__macos.adb
@@ -10,13 +10,13 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return Absolute_Path is (Common.XDG_Cache_Folder);
+   function Cache return Absolute_Path is (Common.XDG_Data_Home);
 
    -----------
    -- Config--
    -----------
 
-   function Config return Absolute_Path is (Common.XDG_Config_Folder);
+   function Config return Absolute_Path is (Common.XDG_Config_Home);
 
    ----------
    -- Home --

--- a/src/alire/os_windows/alire-platforms-folders__windows.adb
+++ b/src/alire/os_windows/alire-platforms-folders__windows.adb
@@ -17,7 +17,9 @@ package body Alire.Platforms.Folders is
    -- Cache --
    -----------
 
-   function Cache return Absolute_Path is (Home / ".cache" / "alire");
+   function Cache return Absolute_Path
+   is (OS_Lib.Getenv ("LocalAppData", Home / ".local" / "share")
+       / "alire");
 
    ------------
    -- Config --

--- a/testsuite/tests/dockerized/misc/default-cache/test.py
+++ b/testsuite/tests/dockerized/misc/default-cache/test.py
@@ -7,7 +7,7 @@ import os
 
 from drivers import builds
 from drivers.alr import alr_with, init_local_crate, run_alr
-from drivers.helpers import contents
+from drivers.helpers import contents, on_windows
 
 # Forcing the deployment of a binary crate triggers the use of the global
 # cache, which should be created at the expected location.
@@ -16,7 +16,10 @@ alr_with("gnat_native")
 
 home = os.environ["HOME"]
 
-base = f"{home}/.cache/alire"
+if on_windows():
+    base = f"{home}/AppData/Local/alire"
+else:
+    base = f"{home}/.local/share/alire"
 
 assert \
     os.path.isdir(f"{base}/toolchains/gnat_native_8888.0.0_99fa3a55"), \


### PR DESCRIPTION
Discard $XDG_CACHE_HOME in favor of $XDG_DATA_HOME, as some distro guidelines erroneously propose to mount the cache on tmpfs.

Also use %LocalAppData% on Windows which seems to be the closest equivalent.

Also rename a couple functions to match the XDG nomenclature.

Fixes #1502