### PR TITLE
Harmonize and document test modifier variables

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -36,8 +36,28 @@ $ ./run.py
 ```
 
 # Creating tests
-All tests are based on running a Python script. There are three test drivers:
+All tests are based on running a Python script. There are these test drivers:
 
 - `python-script`: run in host in both sandboxed and shared build mode.
     - The build mode can be narrowed down with the `build_mode` attribute.
 - `docker-wrapper`: run in a pristine docker Ubuntu image in shared build mode.
+
+# Environment variables
+The following variables can be used to modify test/testsuite behavior.
+
+For `ALIRE_DISABLE_*` variables, their mere existence activates their function,
+no matter their value, or lack of one.
+
+- `ALIRE_DISABLE_DISTRO`: when defined, `alr` will be configured
+ to not detect the system distribution and fall back to unknown distribution.
+
+- `ALIRE_DISABLE_DOCKER`: when defined, `alr` will skip tests that
+  require Docker (which are enabled by default if Docker is detected).
+
+- `ALIRE_DISABLE_NETWORK_TESTS`: when defined, tests that
+  require non-local network use will be skipped.
+
+Example disabling Docker tests for a single run on Bash:
+```Bash
+$ ALIRE_DISABLE_DOCKER= ./run.sh
+```

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -72,9 +72,8 @@ def prepare_env(config_dir, env):
 
     # If distro detection is disabled via environment, configure so in alr
     if "ALIRE_DISABLE_DISTRO" in env:
-        if env["ALIRE_DISABLE_DISTRO"] == "true":
-            run_alr("-c", config_dir, "config", "--global",
-                    "--set", "distribution.disable_detection", "true")
+        run_alr("-c", config_dir, "config", "--global",
+                "--set", "distribution.disable_detection", "true")
 
 
 def run_alr(*args, **kwargs):

--- a/testsuite/drivers/driver/docker_nested.py
+++ b/testsuite/drivers/driver/docker_nested.py
@@ -10,6 +10,7 @@ import sys
 
 from drivers import alr
 from drivers.alr import run_alr
+from drivers.helpers import MODIFIERS
 
 
 def main():
@@ -33,6 +34,10 @@ def main():
     os.mkdir(work_dir)
 
     # Set up the environment
+
+    # Copy any received modifiers
+    for modifier in [m for m in MODIFIERS if m in test_env]:
+        os.environ[modifier] = test_env[modifier]
 
     # alr path
     os.environ["ALR_PATH"] = "/usr/bin/alr" # Must match docker volume mount

--- a/testsuite/drivers/helpers.py
+++ b/testsuite/drivers/helpers.py
@@ -11,6 +11,12 @@ import stat
 from subprocess import run
 from zipfile import ZipFile
 
+# Environment variables that can be used to modify the testsuite behavior
+MODIFIERS : list = [
+      'ALIRE_DISABLE_DISTRO'
+    , 'ALIRE_DISABLE_DOCKER'
+    , 'ALIRE_DISABLE_NETWORK_TESTS'
+]
 
 # Return the entries (sorted) under a given folder, both folders and files
 # Optionally, return only those matching regex. Uses '/' always as separator.
@@ -77,7 +83,7 @@ def on_windows():
 
 def distribution():
 
-    if os.environ.get('ALIRE_DISABLE_DISTRO') == 'true':
+    if 'ALIRE_DISABLE_DISTRO' in os.environ:
         return 'DISTRO_UNKNOWN'
 
     known_distro = ["debian", "ubuntu", "msys2", "arch", "rhel", "centos", "fedora"]


### PR DESCRIPTION
A bit of messiness was starting to creep in. This way all environment variables follow the same convention.

Also the docker wrapper was not forwarding them to the wrapped test.