### PR TITLE
Tag manual builds with commit in version

### DIFF
--- a/.github/workflows/ci-toolchain.yml
+++ b/.github/workflows/ci-toolchain.yml
@@ -37,6 +37,11 @@ jobs:
       with:
         submodules: true
 
+    - name: Install Python 3.x # required by testsuite and scripts
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
     # Use a stock alr to make the latest toolchain available
 
     - name: Install FSF toolchain
@@ -71,11 +76,6 @@ jobs:
 
     # Run the testsuite with the just build alr. The testsuite picks the proper
     # alr in the ./bin/alr location.
-
-    - name: Install Python 3.x # required by testsuite
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
 
     - name: Install e3
       run: pip install --upgrade -r testsuite/requirements.txt

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -27,10 +27,19 @@ jobs:
       with:
         submodules: true
 
+
+    - name: Install Python 3.x (required for the testsuite)
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
     - name: Install FSF toolchain
       uses: alire-project/alr-install@v1
       with:
         crates: gnat_native gprbuild
+
+    - name: Fingerprint build
+      run: python3 scripts/version-patcher.py
 
     - name: Build alr
       run: gprbuild -j0 -p -P alr_env
@@ -40,11 +49,6 @@ jobs:
 
     - name: install tar from msys2 (Git tar in Actions VM does not seem to work)
       run: C:\Users\runneradmin\AppData\Local\alire\msys64\usr\bin\pacman --noconfirm -S tar
-
-    - name: Install Python 3.x (required for the testsuite)
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
 
     - name: Run test script
       run: scripts/ci-github.sh

--- a/alire.toml
+++ b/alire.toml
@@ -59,13 +59,15 @@ simple_logging = { url = "https://github.com/alire-project/simple_logging", comm
 si_units = { url = "https://github.com/mosteo/si_units", branch = "alire" }
 stopwatch = { url = "https://github.com/mosteo/stopwatch", commit = "f607a63b714f09bbf6126de9851cbc21cf8666c9" }
 
+# To disable version updating, export ALR_VERSION_DONT_PATCH with any value (even empty)
+
 # Before building, we add the commit to the version, for unique identification:
 [[actions]]
 type = "pre-build"
 command = ["python3", "scripts/version-patcher.py"]
 
-# Afterwards we leave it as unknown, so people manually building don't use a
+# Afterwards we leave an extra note, so people manually building don't use a
 # misleading commit.
 [[actions]]
 type = "post-build"
-command = ["python3", "scripts/version-patcher.py", "unknown_commit"]
+command = ["python3", "scripts/version-patcher.py", "_or_later"]

--- a/alire.toml
+++ b/alire.toml
@@ -58,3 +58,14 @@ semantic_versioning = { url = "https://github.com/alire-project/semantic_version
 simple_logging = { url = "https://github.com/alire-project/simple_logging", commit = "3505dc645f3eef6799a486aae223d37e88cfc4d5" }
 si_units = { url = "https://github.com/mosteo/si_units", branch = "alire" }
 stopwatch = { url = "https://github.com/mosteo/stopwatch", commit = "f607a63b714f09bbf6126de9851cbc21cf8666c9" }
+
+# Before building, we add the commit to the version, for unique identification:
+[[actions]]
+type = "pre-build"
+command = ["python3", "scripts/version-patcher.py"]
+
+# Afterwards we leave it as unknown, so people manually building don't use a
+# misleading commit.
+[[actions]]
+type = "post-build"
+command = ["python3", "scripts/version-patcher.py", "unknown_commit"]

--- a/scripts/ci-github.sh
+++ b/scripts/ci-github.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# To be run from the repository root
+
 trap 'echo "ERROR at line ${LINENO} (code: $?)" >&2' ERR
 trap 'echo "Interrupted" >&2 ; exit 1' INT
 
@@ -12,6 +14,10 @@ export PATH+=:${PWD}/bin
 pushd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
     . ../dev/functions.sh
 popd
+
+# Fingerprint the build. The commit ID will appear as the version build part.
+echo "Building from commit: $(git rev-parse HEAD)"
+python3 scripts/version-patcher.py
 
 # Build alr
 export ALIRE_OS=$(get_OS)

--- a/scripts/version-patcher.py
+++ b/scripts/version-patcher.py
@@ -5,8 +5,13 @@ import sys
 
 def replace_version(filename, new_text):
     pattern = r'(Current : constant String := "[^+]+\+)([^"]*)(";)'
-    with open(filename, 'r') as file:
+    with open(filename, 'rb') as file:
         content = file.read()
+
+    # Depending on the context in which this is run, there may be mix-ups with
+    # line terminators between the environment detected, github runner, etc...
+    # So just keep them as they are and that should always work.
+    content = content.decode()
 
     new_content = re.sub(pattern, r'\g<1>' + new_text + r'\3', content)
 
@@ -16,8 +21,10 @@ def replace_version(filename, new_text):
         else:
             print(f"WARNING: failed to update version in {filename}")
     else:
-        with open(filename, 'w') as file:
-            file.write(new_content)
+        # Ensure the content line terminators are not changed
+        with open(filename, 'wb') as file:
+            file.write(new_content.encode())
+
 
 # If a flag exists, skip any updating, just print a message and exit
 if "ALR_VERSION_DONT_PATCH" in os.environ:

--- a/scripts/version-patcher.py
+++ b/scripts/version-patcher.py
@@ -1,0 +1,25 @@
+import re
+import subprocess
+import sys
+
+def replace_version(filename, new_text):
+    pattern = r'(Current : constant String := "[^+]+\+)([^"]*)(";)'
+    with open(filename, 'r') as file:
+        content = file.read()
+
+    new_content = re.sub(pattern, r'\g<1>' + new_text + r'\3', content)
+
+    with open(filename, 'w') as file:
+        file.write(new_content)
+
+# If there is an argument to the script, retrieve it here and use it as the new
+# version
+if len(sys.argv) > 1:
+    commit = sys.argv[1]
+else:
+    # Find the short git commit of the repository in the current directory
+    commit = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('utf-8').strip()
+
+# Replace the build version part with the short commit hash
+print(f"Updating version in src/alire/alire-version.ads to commit {commit}...")
+replace_version('src/alire/alire-version.ads', commit)

--- a/src/alire/alire-version.ads
+++ b/src/alire/alire-version.ads
@@ -2,7 +2,11 @@ package Alire.Version with Preelaborate is
 
    --  Remember to update Alire.Index branch if needed too
 
-   Current : constant String := "2.0-dev+beta2";
+   --  NOTE: in the following version string, "unknown_commit" will be replaced
+   --  by `alr build` with the current commit, and reverted to "unknown_commit"
+   --  after build.
+
+   Current : constant String := "2.0-beta2+unknown_commit";
    --  2.0.0-b1:  first public release on the 2.0 branch
    --  1.2.1:     build switches fix and other minor assorted fixes
    --  1.2.0:     rpm speed-up, silence propagation warning, early switch parse

--- a/src/alire/alire-version.ads
+++ b/src/alire/alire-version.ads
@@ -2,11 +2,11 @@ package Alire.Version with Preelaborate is
 
    --  Remember to update Alire.Index branch if needed too
 
-   --  NOTE: in the following version string, "unknown_commit" will be replaced
-   --  by `alr build` with the current commit, and reverted to "unknown_commit"
-   --  after build.
+   --  NOTE: in the following version string, the build part (after '+') will
+   --  be replaced by `alr build` with the current commit, and appended with
+   --  "_or_later" after build.
 
-   Current : constant String := "2.0-beta2+unknown_commit";
+   Current : constant String := "2.0-beta2+92896bd3_or_later";
    --  2.0.0-b1:  first public release on the 2.0 branch
    --  1.2.1:     build switches fix and other minor assorted fixes
    --  1.2.0:     rpm speed-up, silence propagation warning, early switch parse

--- a/src/alire/alire-version.ads
+++ b/src/alire/alire-version.ads
@@ -6,7 +6,7 @@ package Alire.Version with Preelaborate is
    --  be replaced by `alr build` with the current commit, and appended with
    --  "_or_later" after build.
 
-   Current : constant String := "2.0-beta2+92896bd3_or_later";
+   Current : constant String := "2.0-beta2+277e6a52_dirty";
    --  2.0.0-b1:  first public release on the 2.0 branch
    --  1.2.1:     build switches fix and other minor assorted fixes
    --  1.2.0:     rpm speed-up, silence propagation warning, early switch parse


### PR DESCRIPTION
For builds that eventually become available for download, make the git commit appear in the version build.

Goes on top of #1530