### PR TITLE
Move To_Portable to body and make it a regular function

### DIFF
--- a/src/alire/alire-vfs.adb
+++ b/src/alire/alire-vfs.adb
@@ -11,8 +11,8 @@ package body Alire.VFS is
                               return String
    is
       Relative : constant Any_Path :=
-                   Directories.Find_Relative_Path (Parent => From,
-                                                   Child  => Path);
+         Directories.Find_Relative_Path (Parent => From,
+                                         Child  => Path);
    begin
       if Check_Absolute_Path (Relative) then
          return Path;
@@ -20,6 +20,21 @@ package body Alire.VFS is
          return String (To_Portable (Relative));
       end if;
    end Attempt_Portable;
+
+   -----------------
+   -- To_Portable --
+   -----------------
+
+   function To_Portable (Path : Relative_Path) return Portable_Path
+   is
+   begin
+      case GNATCOLL.OS.Constants.OS is
+         when MacOS | Unix =>
+            return Portable_Path (Path);
+         when Windows      =>
+            return Portable_Path (Replace (Path, "\", "/"));
+      end case;
+   end To_Portable;
 
    --------------
    -- Read_Dir --

--- a/src/alire/alire-vfs.ads
+++ b/src/alire/alire-vfs.ads
@@ -96,15 +96,6 @@ private
        and then
        not Check_Absolute_Path (Path));
 
-   -----------------
-   -- To_Portable --
-   -----------------
-
-   function To_Portable (Path : Relative_Path) return Portable_Path
-   is (case GNATCOLL.OS.Constants.OS is
-          when MacOS | Unix => Portable_Path (Path),
-          when Windows      => Portable_Path (Replace (Path, "\", "/")));
-
    ---------------
    -- To_Native --
    ---------------


### PR DESCRIPTION
This works around an issue I was encountering when using pins on an arm64 architecture. Truthfully, I don't know why this fixes the issue but it does. I didn't take the time to go back to the reference manual to fully understand why this would address the issue. Regardless, using a regular function as opposed to an expression fixed it (for now...). This closes #1498.