### PR TITLE
Fix deployment over pre-existing dependency dir

### DIFF
--- a/src/alire/alire-origins-deployers.adb
+++ b/src/alire/alire-origins-deployers.adb
@@ -128,6 +128,12 @@ package body Alire.Origins.Deployers is
       --  as some deployers may not need one (like system packages).
       Temp_Dir.Keep;
       if Ada.Directories.Exists (Temp_Dir.Filename) then
+         --  First, remove any vestigial folder that may remain
+         if Ada.Directories.Exists (Folder) then
+            Trace.Debug ("Removing spurious pre-existing dir: " & Folder);
+            Directories.Force_Delete (Folder);
+         end if;
+
          Trace.Debug ("Renaming into place " & TTY.URL (Temp_Dir.Filename)
                       & " as " & TTY.URL (Folder));
          Ada.Directories.Rename (Old_Name => Temp_Dir.Filename,

--- a/testsuite/tests/issues/1517/test.py
+++ b/testsuite/tests/issues/1517/test.py
@@ -1,0 +1,26 @@
+"""
+In certain circumstances, deploying a dependency when its folder already exists
+(?) causes a failure.
+"""
+
+from glob import glob
+import os
+import shutil
+from drivers.alr import run_alr, crate_dirname
+
+run_alr("get", "hello")
+os.chdir(glob("hello_*")[0])
+
+# Remove contens of the libhello dependency folder. The bug only happens if the
+# top-level folder is not removed, so we need to iterate over its contents.
+for dirpath, dirnames, filenames in \
+    os.walk(f"alire/cache/dependencies/{crate_dirname('libhello')}"):
+    for filename in filenames:
+        os.remove(os.path.join(dirpath, filename))
+    for dirname in dirnames:
+        shutil.rmtree(os.path.join(dirpath, dirname))
+
+# This should not fail after the bugfix
+run_alr("build")
+
+print("SUCCESS")

--- a/testsuite/tests/issues/1517/test.yaml
+++ b/testsuite/tests/issues/1517/test.yaml
@@ -1,0 +1,5 @@
+driver: python-script
+build_mode: sandboxed
+indexes:
+    basic_index:
+        in_fixtures: true


### PR DESCRIPTION
Fixes #1517 

I'm not sure how this can happen through normal workflows (it's happened to me too when switching versions), but I was able to reproduce it consistently in a test, so fixed.