### PR TITLE
Bugfix: exception when trying to select a tool without the assistant while the configured one is missing

### DIFF
--- a/src/alire/alire-solutions-diffs.adb
+++ b/src/alire/alire-solutions-diffs.adb
@@ -431,7 +431,10 @@ package body Alire.Solutions.Diffs is
               and then Toolchains.Tool_Is_Configured (GNAT_Crate)
               and then Toolchains.Tool_Milestone (GNAT_Crate).Crate
                        = GNAT_External_Crate
-              and then not Toolchains.Tool_Release (GNAT_Crate).Satisfies (Dep)
+              and then
+                (Toolchains.Tool_Is_Missing (GNAT_Crate)
+                 or else
+                   not Toolchains.Tool_Release (GNAT_Crate).Satisfies (Dep))
             then
                Trace.Log (Prefix, Level);
                Trace.Log (Prefix & Icon (Missing)

--- a/src/alire/alire-toolchains.ads
+++ b/src/alire/alire-toolchains.ads
@@ -71,6 +71,10 @@ package Alire.Toolchains is
    --  Use the stored config to check if the tool is external without having to
    --  detect it. Defaults to True if unset or tool is not configured.
 
+   function Tool_Is_Missing (Crate : Crate_Name) return Boolean
+     with Pre => Tool_Is_Configured (Crate);
+   --  Says is the configured tool is not ready for use and must be downloaded
+
    function Tool_Milestone (Crate : Crate_Name) return Milestones.Milestone;
 
    function Tool_Release (Crate : Crate_Name) return Releases.Release;
@@ -131,6 +135,9 @@ package Alire.Toolchains is
    procedure Deploy (Release  : Releases.Release;
                      Location : Any_Path := Path);
    --  Deploy a release in the specified location
+
+   procedure Deploy_Missing;
+   --  Deploy any configured tool that is not found where expected on disk
 
    procedure Remove
      (Release : Releases.Release;

--- a/src/alr/alr-commands-toolchain.adb
+++ b/src/alr/alr-commands-toolchain.adb
@@ -124,6 +124,7 @@ package body Alr.Commands.Toolchain is
             --  command-line, will impose an origin compatibility constraint
 
             if Toolchains.Tool_Is_Configured (Tool)
+              and then not Toolchains.Tool_Is_Missing (Tool)
               and then not
                 (for some P of Pending =>
                    Toolchains.Tool_Release (Tool).Provides (P) or else

--- a/testsuite/tests/toolchain/select-while-missing/test.py
+++ b/testsuite/tests/toolchain/select-while-missing/test.py
@@ -1,0 +1,18 @@
+"""
+Check a particular error in which selecting a compiler via `alr toolchain
+--select <compiler>` fails if the previously configured compiler is missing on
+disk.
+"""
+
+from drivers.alr import run_alr
+
+# Configure a valid compiler
+run_alr("toolchain", "--select", "gnat_native", "gprbuild")
+
+# Configure an invalid compiler
+run_alr("config", "--global", "--set", "toolchain.use.gnat", "gnat_nono=1.2.3")
+
+# This must succeed
+run_alr("toolchain", "--select", "gnat_native=1.0")
+
+print("SUCCESS")

--- a/testsuite/tests/toolchain/select-while-missing/test.yaml
+++ b/testsuite/tests/toolchain/select-while-missing/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+build_mode: both
+indexes:
+    gnat_toolchain_index: {}


### PR DESCRIPTION
As seen in https://github.com/alire-project/alire-index/pull/978