### PR TITLE
Remove blue background setting from Windows shortcut

### DIFF
--- a/scripts/installer/qt-ifw/packages/com.alire.root/meta/installscript.js
+++ b/scripts/installer/qt-ifw/packages/com.alire.root/meta/installscript.js
@@ -21,7 +21,7 @@ function createShortcuts()
 	var shortcuts = ["@StartMenuDir@/Alire.lnk", "@DesktopDir@/Alire.lnk"];
 	for (shortcut of shortcuts) {
 		component.addOperation("CreateShortcut", "powershell", shortcut,
-                               "-NoExit -Command \"$env:Path += \"\"\";@TargetDir@\\bin\"\"\"; \"$host.UI.RawUI.BackgroundColor = \"\"\"DarkBlue\"\"\"; clear-host\"",
+                               "-NoExit -Command \"$env:Path += \"\"\";@TargetDir@\\bin\"\"\"; clear-host\"",
                                "workingDirectory=@HomeDir@",
 	                           "iconPath=@TargetDir@/share/alire/alr_icon.ico",
 	                           "description=Start App");


### PR DESCRIPTION
The shortcut from the Windows installer was setting a background color for PowerShell command prompt. The idea was to match the look of the PowerShell you would normally start, and avoid confusion with the CMD prompt which has a black background. But that didn't work very well as the background color just disappeared when running commands. Also it seems like Windows now uses a black background for the PowerShell anyway.