### PR TITLE
Fix bugs related to tmp file creation in corner cases

### DIFF
--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -662,7 +662,8 @@ package body Alire.Directories is
 
       end if;
 
-      Trace.Debug ("Selected name for tempfile: " & (+This.Name));
+      Trace.Debug ("Selected name for tempfile: " & (+This.Name)
+                   & " when at dir: " & Current);
 
       Temp_Registry.Add (+This.Name);
    end Initialize;

--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -750,10 +750,10 @@ package body Alire.Directories is
       end if;
 
       --  Remove temp dir if empty to keep things tidy, and avoid modifying
-      --  lots of tests.
+      --  lots of tests, but only when within <>/alire/tmp
 
-      if Ada.Directories.Simple_Name (Parent (This.Filename)) =
-        Paths.Temp_Folder_Inside_Working_Folder
+      if Ada.Directories.Simple_Name (Parent (Parent (This.Filename))) =
+        Paths.Working_Folder_Inside_Root
       then
          AAA.Directories.Remove_Folder_If_Empty (Parent (This.Filename));
       end if;

--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -662,6 +662,8 @@ package body Alire.Directories is
 
       end if;
 
+      Trace.Debug ("Selected name for tempfile: " & (+This.Name));
+
       Temp_Registry.Add (+This.Name);
    end Initialize;
 
@@ -673,6 +675,9 @@ package body Alire.Directories is
    is
    begin
       if This.FD in GNAT.OS_Lib.Invalid_FD then
+         --  Ensure parent location exists
+         Create_Tree (Parent (This.Filename));
+
          This.FD := GNAT.OS_Lib.Create_Output_Text_File (This.Filename);
       end if;
 


### PR DESCRIPTION
Found while trying to reproduce #1215 in half-broken msys2 installs.