### PR TITLE
Explicitly check GCC versions

### DIFF
--- a/.github/workflows/ci-toolchain.yml
+++ b/.github/workflows/ci-toolchain.yml
@@ -14,7 +14,7 @@ jobs:
 
   build:
 
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }} gcc^${{ matrix.gcc_version }}
 
     runs-on: ${{ matrix.os }}
 
@@ -25,6 +25,11 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
+        gcc_version:
+          - 10
+          - 11
+          - 12
+          - 13
 
     steps:
     - name: Check out
@@ -37,7 +42,7 @@ jobs:
     - name: Install FSF toolchain
       uses: alire-project/alr-install@v1
       with:
-        crates: gnat_native gprbuild
+        crates: gnat_native^${{matrix.gcc_version}} gprbuild
 
     - name: Build alr with default toolchain
       shell: bash

--- a/src/alire/alire-dependencies-states.adb
+++ b/src/alire/alire-dependencies-states.adb
@@ -47,7 +47,7 @@ package body Alire.Dependencies.States is
                               Workspace : Any_Path)
                               return Stored_Release
    is
-      Opt_Root : constant Roots.Optional.Root :=
+      Opt_Root : Roots.Optional.Root :=
                    Roots.Optional.Detect_Root (Workspace);
    begin
       if Opt_Root.Is_Valid then

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -115,7 +115,7 @@ package body Alire.Publish is
          return +This.Path;
       else
          declare
-            Root : constant Roots.Optional.Root := Alire.Root.Current;
+            Root : Roots.Optional.Root := Alire.Root.Current;
          begin
             Check_Root_Status (+This.Path, Root, This.Options);
             return Root.Value.Path;
@@ -155,7 +155,7 @@ package body Alire.Publish is
    -- Generated_Filename --
    ------------------------
 
-   function Generated_Filename (This : Data) return String
+   function Generated_Filename (This : in out Data) return String
    is (TOML_Index.Manifest_File
        (This.Root.Value.Name,
           This.Root.Value.Release.Version));
@@ -164,7 +164,7 @@ package body Alire.Publish is
    -- Generated_Manifest --
    ------------------------
 
-   function Generated_Manifest (This : Data) return Absolute_Path
+   function Generated_Manifest (This : in out Data) return Absolute_Path
    is (This.Root.Value.Working_Folder
        / Paths.Release_Folder_Inside_Working_Folder
        / This.Generated_Filename);
@@ -395,7 +395,7 @@ package body Alire.Publish is
          --  Will have raised if the release is not loadable or incomplete
       else
          declare
-            Root : constant Roots.Optional.Root := Alire.Root.Current;
+            Root : Roots.Optional.Root := Alire.Root.Current;
          begin
             case Root.Status is
             when Outside =>
@@ -495,7 +495,7 @@ package body Alire.Publish is
 
    procedure Generate_Index_Manifest (Context : in out Data) is
       User_Manifest : constant Any_Path := Packaged_Manifest (Context);
-      Workspace     : constant Roots.Optional.Root := Root.Current;
+      Workspace     :          Roots.Optional.Root := Root.Current;
    begin
       if not GNAT.OS_Lib.Is_Read_Accessible_File (User_Manifest) then
          Raise_Checked_Error
@@ -1039,7 +1039,7 @@ package body Alire.Publish is
                                Revision : String   := "HEAD";
                                Options  : All_Options := New_Options)
    is
-      Root : constant Roots.Optional.Root := Roots.Optional.Search_Root (Path);
+      Root : Roots.Optional.Root   := Roots.Optional.Search_Root (Path);
       Git  : constant VCSs.Git.VCS := VCSs.Git.Handler;
 
       Subdir : Unbounded_Relative_Path;

--- a/src/alire/alire-publish.ads
+++ b/src/alire/alire-publish.ads
@@ -97,14 +97,14 @@ private
    -- Branch_Name --
    -----------------
 
-   function Branch_Name (This : Data) return String
+   function Branch_Name (This : in out Data) return String
    is (Branch_Name (This.Root.Value.Release.Milestone));
 
    -------------
    -- PR_Name --
    -------------
 
-   function PR_Name (This : Data) return String
+   function PR_Name (This : in out Data) return String
    is (This.Root.Value.Name.As_String & " "
        & This.Root.Value.Release.Version.Image);
 
@@ -112,12 +112,12 @@ private
    -- Generated_Filename --
    ------------------------
 
-   function Generated_Filename (This : Data) return String;
+   function Generated_Filename (This : in out Data) return String;
 
    ------------------------
    -- Generated_Manifest --
    ------------------------
 
-   function Generated_Manifest (This : Data) return Absolute_Path;
+   function Generated_Manifest (This : in out Data) return Absolute_Path;
 
 end Alire.Publish;

--- a/src/alire/alire-root.adb
+++ b/src/alire/alire-root.adb
@@ -14,6 +14,11 @@ package body Alire.Root is
    -------------
 
    function Current return Roots.Root
-   is (Roots.Optional.Detect_Root (Directories.Detect_Root_Path).Value);
+   is
+      Optional_Root : Roots.Optional.Root :=
+                   Roots.Optional.Detect_Root (Directories.Detect_Root_Path);
+   begin
+      return Optional_Root.Value;
+   end Current;
 
 end Alire.Root;

--- a/src/alire/alire-roots-editable.adb
+++ b/src/alire/alire-roots-editable.adb
@@ -248,7 +248,7 @@ package body Alire.Roots.Editable is
                                   Path  : Any_Path)
                                   return Crate_Name
    is
-      Pin_Root : constant Optional.Root := Optional.Detect_Root (Path);
+      Pin_Root : Optional.Root := Optional.Detect_Root (Path);
 
       -------------------------
       -- Pin_Is_Parent_Crate --

--- a/src/alire/alire-roots-editable.adb
+++ b/src/alire/alire-roots-editable.adb
@@ -255,7 +255,10 @@ package body Alire.Roots.Editable is
       -------------------------
 
       function Pin_Is_Parent_Crate return Boolean
-      is (Directories.Find_Relative_Path_To (Path) = "..");
+      is
+      begin
+         return Directories.Find_Relative_Path_To (Path) = "..";
+      end Pin_Is_Parent_Crate;
 
    begin
       --  When adding a pin from a folder other than the root, notify about it.
@@ -297,14 +300,28 @@ package body Alire.Roots.Editable is
          --  aesthetic, as pins will always override the version.
 
          if not This.Solution.Depends_On (Crate) then
-            This.Add_Dependency
-              (Dependencies.New_Dependency
-                 (Crate,
-                  (if Pin_Root.Is_Valid and then not Pin_Is_Parent_Crate
-                   then Pin_Root.Updatable_Dependency.Versions
-                   else Semver.Extended.Any)),
-               Allow_Unknown => True);
-            --  Pins to local paths are more likely not to be indexed
+            declare
+               --  This temporary is used to work around a bug in GNAT 13
+               Dep_Ver : Semver.Extended.Version_Set;
+            begin
+               if Pin_Root.Is_Valid and then not Pin_Is_Parent_Crate then
+                  declare
+                     --  This temporary is used to work around a bug in GNAT 13
+                     Updatable_Dep : constant Dependencies.Dependency
+                       := Pin_Root.Updatable_Dependency;
+                  begin
+                     Dep_Ver := Updatable_Dep.Versions;
+                  end;
+               else
+                  Dep_Ver := Semver.Extended.Any;
+               end if;
+
+               This.Add_Dependency
+                 (Dependencies.New_Dependency (Crate, Dep_Ver),
+                  Allow_Unknown => True);
+               --  Pins to local paths are more likely not to be indexed, so we
+               --  allow unknown dependencies here.
+            end;
          end if;
 
          --  Remove any previous pin for this crate

--- a/src/alire/alire-roots-optional.adb
+++ b/src/alire/alire-roots-optional.adb
@@ -125,13 +125,14 @@ package body Alire.Roots.Optional is
    -- Value --
    -----------
 
-   function Value (This : Root) return Reference
+   function Value (This : in out Root) return Reference
    is
    begin
       This.Assert;
       --  The following Unrestricted_Access cannot fail as we just asserted
       --  the value is stored.
-      return Reference'(Ptr => This.Data.Value'Unrestricted_Access);
+      return Ref : constant Reference :=
+        Reference'(Ptr => This.Data.Value'Unrestricted_Access);
    end Value;
 
    ---------------------
@@ -166,7 +167,7 @@ package body Alire.Roots.Optional is
    -- Updatable_Dependency --
    --------------------------
 
-   function Updatable_Dependency (This : Root)
+   function Updatable_Dependency (This : in out Root)
                                   return Dependencies.Dependency
    is (Dependencies.New_Dependency
        (This.Value.Release.Element.Name,

--- a/src/alire/alire-roots-optional.adb
+++ b/src/alire/alire-roots-optional.adb
@@ -125,7 +125,7 @@ package body Alire.Roots.Optional is
    -- Value --
    -----------
 
-   function Value (This : aliased Root) return Reference
+   function Value (This : Root) return Reference
    is
    begin
       This.Assert;

--- a/src/alire/alire-roots-optional.ads
+++ b/src/alire/alire-roots-optional.ads
@@ -39,7 +39,7 @@ package Alire.Roots.Optional is
    function Outside (This : Root) return Boolean;
    --  True when there is no root at all, broken or valid
 
-   function Value (This : Root) return Reference with
+   function Value (This : in out Root) return Reference with
      Pre => This.Is_Valid;
 
    function Brokenness (This : Root) return String with
@@ -55,7 +55,7 @@ package Alire.Roots.Optional is
 
    --  UTILITIES
 
-   function Updatable_Dependency (This : Root)
+   function Updatable_Dependency (This : in out Root)
                                   return Dependencies.Dependency
      with Pre => This.Is_Valid;
    --  If This.Is_Valid, get the corresponding updatable

--- a/src/alire/alire-roots-optional.ads
+++ b/src/alire/alire-roots-optional.ads
@@ -39,7 +39,7 @@ package Alire.Roots.Optional is
    function Outside (This : Root) return Boolean;
    --  True when there is no root at all, broken or valid
 
-   function Value (This : aliased Root) return Reference with
+   function Value (This : Root) return Reference with
      Pre => This.Is_Valid;
 
    function Brokenness (This : Root) return String with

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -997,7 +997,7 @@ package body Alire.Roots is
             declare
                use Containers.Crate_Name_Sets;
                use Semver.Extended;
-               Target : constant Optional.Root :=
+               Target : Optional.Root :=
                           Optional.Detect_Root (Pin.Path);
             begin
 
@@ -1139,7 +1139,11 @@ package body Alire.Roots is
    ---------------
 
    function Load_Root (Path : Any_Path) return Root
-   is (Roots.Optional.Detect_Root (Path).Value);
+   is
+      Optional_Root : Optional.Root := Optional.Detect_Root (Path);
+   begin
+      return Optional_Root.Value;
+   end Load_Root;
 
    ------------------------------
    -- Export_Build_Environment --
@@ -1187,7 +1191,7 @@ package body Alire.Roots is
          --  Try to detect a root in this folder
 
          declare
-            Opt : constant Optional.Root :=
+            Opt : Optional.Root :=
                     Optional.Detect_Root (Full_Name (Item));
          begin
             if Opt.Is_Valid then

--- a/src/alire/alire-user_pins.adb
+++ b/src/alire/alire-user_pins.adb
@@ -259,7 +259,7 @@ package body Alire.User_Pins is
       --  At this point, we have the sources at Destination. Last checks ensue.
 
       declare
-         Root : constant Roots.Optional.Root :=
+         Root : Roots.Optional.Root :=
                   Roots.Optional.Detect_Root (Destination);
       begin
 

--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -322,7 +322,7 @@ package body Alr.Commands.Init is
       ---------------------
 
       procedure Generate_Config is
-         Root : constant Alire.Roots.Optional.Root :=
+         Root : Alire.Roots.Optional.Root :=
                   Alire.Roots.Optional.Detect_Root (+Directory.Full_Name);
       begin
          Root.Value.Build_Prepare (Saved_Profiles => False,

--- a/src/alr/alr-commands-version.adb
+++ b/src/alr/alr-commands-version.adb
@@ -41,7 +41,7 @@ package body Alr.Commands.Version is
       Indexes : constant Alire.Index_On_Disk.Loading.Set :=
                   Alire.Index_On_Disk.Loading.Find_All
                     (Alire.Config.Edit.Indexes_Directory, Index_Outcome);
-      Root : constant Alire.Roots.Optional.Root :=
+      Root : Alire.Roots.Optional.Root :=
                Alire.Roots.Optional.Search_Root (Alire.Directories.Current);
 
       Build_Path : constant String :=

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -590,7 +590,11 @@ package body Alr.Commands is
          Cmd.Requires_Workspace;
       end if;
 
-      return Cmd.Optional_Root.Value;
+      return R : constant Alire.Roots.Optional.Reference :=
+        (Ptr => Cmd.Optional_Root.Value.Ptr.all'Unchecked_Access);
+      --  Workaround for bug (?) in GNAT 11 about dangling pointers. It should
+      --  simply be:
+      --  return Cmd.Optional_Root.Value;
    end Root;
 
    ---------

--- a/testsuite/fixtures/build_hash_index/gn/gnat_external/gnat_external-external.toml
+++ b/testsuite/fixtures/build_hash_index/gn/gnat_external/gnat_external-external.toml
@@ -6,7 +6,6 @@ maintainers-logins = ["mosteo"]
 
 [[external]]
 kind = "version-output"
-# We look for make instead that should be always installed.
-version-command = ["make", "--version"]
-version-regexp = ".*Make ([\\d\\.]+).*"
+version-command = ["echo", "1.0"]
+version-regexp = "([\\d\\.]+).*"
 provides = "gnat"


### PR DESCRIPTION
In order to maximize bootstrap-ability. The range of versions starts from the oldest Debian/Ubuntu stable packaged GNATs.

Also  a couple of workarounds for complaints from specific compiler versions, with no functional changes.