### PR TITLE
New workflow to check GNAT CE builds

### DIFF
--- a/.github/workflows/ci-community.yml
+++ b/.github/workflows/ci-community.yml
@@ -1,0 +1,81 @@
+name: CI Community
+# Check proper build using the community edition of the AdaCore toolchain
+
+on:
+  pull_request:
+    paths-ignore:
+        - 'doc/**'
+        - '**.md'
+        - '**.rst'
+        - '**.txt'
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    name: ce${{matrix.version}} on ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false # Attempt to generate as many of them as possible
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+        version:
+          - 2020
+          - 2021
+        exclude:
+          - os: macos-latest
+            version: 2021 # it was never released for macOS
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    # Until some stable alr with `alr install` is available, we cannot rely on
+    # the alr-install action, as that introduces a circular dependency. If a
+    # nightly build were to fail, there's no way to do an `alr install` anymore
+    # TODO: replace with `alr-install` once alr 2.0 is out.
+
+    # We cannot use variable names in the action reference, so we need to make
+    # them explicit twice
+    - name: Install Community 2020 toolchain
+      uses: ada-actions/toolchain@ce2020
+      if: ${{ matrix.version == '2020' }}
+      with:
+        distrib: community
+
+    - name: Install Community 2021 toolchain
+      uses: ada-actions/toolchain@ce2021
+      if: ${{ matrix.version == '2021' }}
+      with:
+        distrib: community
+
+    - name: Install Python 3.x (required for the testsuite)
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Run test script
+      run: scripts/ci-github.sh
+      shell: bash
+
+    - name: Upload logs (if failed)
+      if: failure()
+      uses: actions/upload-artifact@master
+      with:
+        name: e3-log-linux.zip
+        path: testsuite/out
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: alr-bin-${{ matrix.os }}.zip
+        path: |
+          bin/alr*
+          LICENSE.txt

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,4 +1,5 @@
 name: CI Docker
+# Check builds on supported Linux distributions
 
 on:
   pull_request:

--- a/.github/workflows/tarball-full.yml
+++ b/.github/workflows/tarball-full.yml
@@ -1,4 +1,7 @@
 name: Full sources
+# Create a tarball that includes everything necessary for building,
+# particularly 3rd party dependencies in submodules which are not included in
+# GitHub automatic source tarballs.
 
 on:
   release:

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -591,10 +591,12 @@ package body Alr.Commands is
       end if;
 
       return R : constant Alire.Roots.Optional.Reference :=
-        (Ptr => Cmd.Optional_Root.Value.Ptr.all'Unchecked_Access);
+        (Ptr => Cmd.Optional_Root.Value.Ptr.all'Unrestricted_Access);
       --  Workaround for bug (?) in GNAT 11 about dangling pointers. It should
       --  simply be:
       --  return Cmd.Optional_Root.Value;
+      --  Also, the 'Unrestricted is needed by GNAT CE 2020, it can be simply
+      --  'Unchecked in later versions.
    end Root;
 
    ---------


### PR DESCRIPTION
We still rely on CE2020 to be able to bootstrap some `alr` builds on macOS, and there seems to be some differences with all the FSF versions indexed by Alire.