### PR TITLE
Improvements to messages during dependency updates

### DIFF
--- a/alire_common.gpr
+++ b/alire_common.gpr
@@ -31,14 +31,7 @@ abstract project Alire_Common is
             "-gnatyu",   -- no unnecessary blank lines
             "-gnatyx",   -- no extra parens around conditionals
             "-gnaty-s"); -- relax fwd decl
-      when "disabled" => Style_Check_Switches :=
-           ("-gnat2022",
-            "-gnatx",
-            -- When no style checks are enforced, we are likely debugging,
-            -- commenting blocks, moving things around, etc. At these times we
-            -- may also benefit from some Ada 2022 features like Any_Type'Image.
-            "-gnatwJ" -- Disable warnings about obsolescent "()"
-           );
+      when "disabled" => Style_Check_Switches := ();
    end case;
 
    type Any_Experimental_Ada_Features is ("enabled", "disabled");

--- a/alire_common.gpr
+++ b/alire_common.gpr
@@ -31,7 +31,14 @@ abstract project Alire_Common is
             "-gnatyu",   -- no unnecessary blank lines
             "-gnatyx",   -- no extra parens around conditionals
             "-gnaty-s"); -- relax fwd decl
-      when "disabled" => Style_Check_Switches := ();
+      when "disabled" => Style_Check_Switches :=
+           ("-gnat2022",
+            "-gnatx",
+            -- When no style checks are enforced, we are likely debugging,
+            -- commenting blocks, moving things around, etc. At these times we
+            -- may also benefit from some Ada 2022 features like Any_Type'Image.
+            "-gnatwJ" -- Disable warnings about obsolescent "()"
+           );
    end case;
 
    type Any_Experimental_Ada_Features is ("enabled", "disabled");

--- a/src/alire/alire-origins-deployers-system.ads
+++ b/src/alire/alire-origins-deployers-system.ads
@@ -68,6 +68,11 @@ package Alire.Origins.Deployers.System is
    function Platform_Deployer (Package_Name : String) return Deployer'Class is
      (Platform_Deployer (Origins.New_System (Package_Name)));
 
+   --  Classwide facilities
+
+   function Already_Installed (This : Origins.Origin) return Boolean
+     with Pre => This.Is_System;
+
    function Executable_Name return String;
    --  Returns the simple name of the executable package manager on the system
 
@@ -80,5 +85,12 @@ private
    type Deployer is abstract new Deployers.Deployer with record
       Ask_Permission : Boolean := True;
    end record;
+
+   -----------------------
+   -- Already_Installed --
+   -----------------------
+
+   function Already_Installed (This : Origins.Origin) return Boolean
+   is (Platform_Deployer (This).Already_Installed);
 
 end Alire.Origins.Deployers.System;

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -7,7 +7,7 @@ with Alire.Directories;
 with Alire.Defaults;
 with Alire.Errors;
 with Alire.Flags;
-with Alire.Origins.Deployers;
+with Alire.Origins.Deployers.System;
 with Alire.Paths;
 with Alire.Properties.Bool;
 with Alire.Properties.Scenarios;
@@ -314,6 +314,18 @@ package body Alire.Releases is
       if This.Origin.Is_Index_Provided and then Completed.Exists then
          Was_There := True;
          Trace.Detail ("Skipping checkout of already available " &
+                         This.Milestone.Image);
+
+      elsif This.Origin.Kind not in Origins.Deployable_Kinds then
+         Was_There := True;
+         Trace.Detail ("External requires no deployment for " &
+                         This.Milestone.Image);
+
+      elsif This.Origin.Is_System
+        and then Origins.Deployers.System.Already_Installed (This.Origin)
+      then
+         Was_There := True;
+         Trace.Detail ("Skipping install of already available system origin " &
                          This.Milestone.Image);
 
       else

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -332,19 +332,18 @@ package body Alire.Releases is
          Was_There := False;
          Put_Info ("Deploying " & This.Milestone.TTY_Image & "...");
          Alire.Origins.Deployers.Deploy (This, Folder).Assert;
-
-         --  For deployers that do nothing, we ensure the folder exists so all
-         --  dependencies leave a trace in the cache/dependencies folder, and
-         --  a place from where to run their actions by default.
-
-         Ada.Directories.Create_Path (Folder);
-
-         --  Backup a potentially packaged manifest, so our authoritative
-         --  manifest from the index is always used.
-
-         Backup_Upstream_Manifest;
-
       end if;
+
+      --  For deployers that do nothing, we ensure the folder exists so all
+      --  dependencies leave a trace in the cache/dependencies folder, and
+      --  a place from where to run their actions by default.
+
+      Ada.Directories.Create_Path (Folder);
+
+      --  Backup a potentially packaged manifest, so our authoritative
+      --  manifest from the index is always used.
+
+      Backup_Upstream_Manifest;
 
       --  Create manifest if requested
 

--- a/src/alire/alire-user_pins.adb
+++ b/src/alire/alire-user_pins.adb
@@ -158,6 +158,14 @@ package body Alire.User_Pins is
 
          --  Check out the branch or commit
 
+         Put_Info ("Deploying " & Utils.TTY.Name (Crate)
+                   & (if Commit /= ""
+                     then " commit " & TTY.URL (VCSs.Git.Short_Commit (Commit))
+                     elsif Branch /= ""
+                     then  " branch " & TTY.URL (Branch)
+                     else " default branch")
+                   & "...");
+
          if not
            VCSs.Git.Handler.Clone
              (From   => URL (This) & (if Commit /= ""
@@ -206,6 +214,9 @@ package body Alire.User_Pins is
          --  Finally update. In case the branch has just been changed by the
          --  user in the manifest, the following call will also take care of
          --  it.
+
+         Put_Info ("Pulling " & Utils.TTY.Name (Crate)
+                   & " branch " & TTY.URL (Branch) & "...");
 
          if not VCSs.Git.Handler.Update (Destination, Branch).Success then
             Raise_Checked_Error

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -22,6 +22,9 @@ package Alire.VCSs.Git is
    function Git_Dir return Any_Path;
    --  ".git" unless overridden by GIT_DIR
 
+   function Short_Commit (Commit : Git_Commit) return String
+   is (Commit (Commit'First .. Commit'First + 7));
+
    type VCS (<>) is new VCSs.VCS with private;
 
    function Handler return VCS;

--- a/testsuite/fixtures/system_index/gn/gnat_external/gnat_external-external.toml
+++ b/testsuite/fixtures/system_index/gn/gnat_external/gnat_external-external.toml
@@ -6,7 +6,6 @@ maintainers-logins = ["mosteo"]
 
 [[external]]
 kind = "version-output"
-# We look for make instead that should be always installed.
-version-command = ["make", "--version"]
-version-regexp = ".*Make ([\\d\\.]+).*"
+version-command = ["echo", "1.0"]
+version-regexp = "([\\d\\.]+).*"
 provides = "gnat"


### PR DESCRIPTION
- Do not emit unnecessary message for installed system crates
- Do emit message when going online to clone/pull pins

This homogenizes the output wrt standard dependencies operations.