### PR TITLE
New `build --stop-after`

### DIFF
--- a/.github/workflows/ci-toolchain.yml
+++ b/.github/workflows/ci-toolchain.yml
@@ -60,7 +60,7 @@ jobs:
       run: ./bin/alr -d -n printenv || ./bin/alr -n -v -d printenv
 
     - shell: bash
-      run: mv ./bin ./bin-old || { sleep 5s && sudo mv ./bin ./bin-old; }
+      run: mv ./bin ./bin-old || { sleep 5s && mv ./bin ./bin-old; }
       # Windows doesn't allow to replace a running exe so the next command
       # fails otherwise. Also, this mv fails sometimes so we try twice JIC.
 

--- a/alire.toml
+++ b/alire.toml
@@ -49,7 +49,7 @@ windows = { ALIRE_OS = "windows" }
 [[pins]]
 aaa = { url = "https://github.com/mosteo/aaa", commit = "dff61d2615cc6332fa6205267bae19b4d044b9da" }
 ada_toml = { url = "https://github.com/mosteo/ada-toml", commit = "da4e59c382ceb0de6733d571ecbab7ea4919b33d" }
-clic = { url = "https://github.com/alire-project/clic" }
+clic = { url = "https://github.com/alire-project/clic", commit = "56bbdc008e16996b6f76e443fd0165a240de1b13" }
 dirty_booleans = { url = "https://github.com/mosteo/dirty_booleans", branch = "alire" }
 diskflags = { url = "https://github.com/mosteo/diskflags", branch = "alire" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "4e663b87a028252e7e074f054f8f453661397166" }

--- a/alire.toml
+++ b/alire.toml
@@ -49,7 +49,7 @@ windows = { ALIRE_OS = "windows" }
 [[pins]]
 aaa = { url = "https://github.com/mosteo/aaa", commit = "dff61d2615cc6332fa6205267bae19b4d044b9da" }
 ada_toml = { url = "https://github.com/mosteo/ada-toml", commit = "da4e59c382ceb0de6733d571ecbab7ea4919b33d" }
-clic = { url = "https://github.com/alire-project/clic", commit = "de0330053584bad4dbb3dbd5e1ba939c4e8c6b55" }
+clic = { url = "https://github.com/alire-project/clic" }
 dirty_booleans = { url = "https://github.com/mosteo/dirty_booleans", branch = "alire" }
 diskflags = { url = "https://github.com/mosteo/diskflags", branch = "alire" }
 gnatcoll = { url = "https://github.com/alire-project/gnatcoll-core.git", commit = "4e663b87a028252e7e074f054f8f453661397166" }

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -8,8 +8,6 @@ stay on top of `alr` new features.
 
 ### New switch `alr build --stop-after=<build stage>`
 
-### Enable shared dependencies by default
-
 PR [#1573](https://github.com/alire-project/alire/pull/1573)
 
 From `alr help build`:
@@ -24,6 +22,37 @@ From `alr help build`:
    * pre-build: running of pre-build actions
    * build: actual building of sources
    * post-build: running of post-build actions
+
+### Enable shared dependencies by default
+
+PR [#1449](https://github.com/alire-project/alire/pull/1449)
+
+Pre-2.0, Alire worked always in "sandboxed" mode; that is, all source
+dependencies were found under `<workspace>/alire/cache`. This behavior can be
+now enabled with `alr config --set dependencies.shared false`, locally or
+globally.
+
+By default, post-2.0, Alire works in "shared" mode, where sources are
+downloaded once (to `~/.cache/alire/releases`) and unique builds are created
+(under `~/.cache/alire/builds`) for unique configurations. This should minimize
+rebuilds across crate configurations and workspaces, and eliminate risks of
+inconsistencies.
+
+Disk use is decreased by unique source downloads, but might be increased by
+unique build configurations. Cache management and cleanup will be provided down
+the road. The build cache can always be deleted to retrieve disk space, at the
+cost of triggering rebuilds.
+
+Unique builds are identified by a build hash which takes into account the
+following inputs for a given release:
+
+- Build profile
+- Environment variables modified in the manifest
+- GPR external variables declared or set
+- Configuration variables declared or set
+- Compiler version
+- Vaue of `LIBRARY_TYPE` and `<CRATE>_LIBRARY_TYPE` variables.
+- Hash of dependencies
 
 ### Automatic index updates
 

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -6,36 +6,24 @@ stay on top of `alr` new features.
 
 ## Release `2.0-dev`
 
+### New switch `alr build --stop-after=<build stage>`
+
 ### Enable shared dependencies by default
 
-PR [#1449](https://github.com/alire-project/alire/pull/1449)
+PR [#1573](https://github.com/alire-project/alire/pull/1573)
 
-Pre-2.0, Alire worked always in "sandboxed" mode; that is, all source
-dependencies were found under `<workspace>/alire/cache`. This behavior can be
-now enabled with `alr config --set dependencies.shared false`, locally or
-globally.
+From `alr help build`:
 
-By default, post-2.0, Alire works in "shared" mode, where sources are
-downloaded once (to `~/.cache/alire/releases`) and unique builds are created
-(under `~/.cache/alire/builds`) for unique configurations. This should minimize
-rebuilds across crate configurations and workspaces, and eliminate risks of
-inconsistencies.
+**Build stages**
 
-Disk use is decreased by unique source downloads, but might be increased by
-unique build configurations. Cache management and cleanup will be provided down
-the road. The build cache can always be deleted to retrieve disk space, at the
-cost of triggering rebuilds.
+   Instead of always doing a full build, the process can be stopped early using `--stop-after=<stage>`, where `<stage>` is one of:
 
-Unique builds are identified by a build hash which takes into account the
-following inputs for a given release:
-
-- Build profile
-- Environment variables modified in the manifest
-- GPR external variables declared or set
-- Configuration variables declared or set
-- Compiler version
-- Vaue of `LIBRARY_TYPE` and `<CRATE>_LIBRARY_TYPE` variables.
-- Hash of dependencies
+   * sync: sync pristine sources to build location
+   * generation: generate configuration-dependent files
+   * post-fetch: running of post-fetch actions
+   * pre-build: running of pre-build actions
+   * build: actual building of sources
+   * post-build: running of post-build actions
 
 ### Automatic index updates
 

--- a/src/alire/alire-builds.ads
+++ b/src/alire/alire-builds.ads
@@ -27,7 +27,10 @@ package Alire.Builds is
    --  many more shared releases in the vault, finding toolchains could take
    --  much more time, hence the separate storage.
 
-   type Build_Stages is
+   --  The following are moments during the build process after which we can
+   --  interrupt the process "safely", that is, some consistency is to be
+   --  expected: actions run as a whole, config files all generated, etc.
+   type Stop_Points is
      (Sync,
       --  Synchronization of pristine sources from the vault to the build dir.
       --  This stage does not exist when using sandboxed dependencies.

--- a/src/alire/alire-builds.ads
+++ b/src/alire/alire-builds.ads
@@ -27,6 +27,29 @@ package Alire.Builds is
    --  many more shared releases in the vault, finding toolchains could take
    --  much more time, hence the separate storage.
 
+   type Build_Stages is
+     (Sync,
+      --  Synchronization of pristine sources from the vault to the build dir.
+      --  This stage does not exist when using sandboxed dependencies.
+
+      Generation,
+      --  Generation of files based on profiles/configuration variables
+
+      Post_Fetch,
+      --  Running of the post-fetch actions, which happens only on the first
+      --  build after syncing to a new build location.
+
+      Pre_Build,
+      --  Running of the pre-build actions, which happens on every build
+
+      Build,
+      --  The actual building of sources
+
+      Post_Build
+      --  Running of the post-build actions
+
+     );
+
    function Sandboxed_Dependencies return Boolean;
    --  Queries config to see if dependencies should be sandboxed in workspace
 

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -267,9 +267,9 @@ package body Alire.Roots is
       end Build_Single_Release;
 
    begin
-
       This.Build_Prepare (Saved_Profiles => Saved_Profiles,
-                          Force_Regen    => False);
+                          Force_Regen    => False,
+                          Stop_After     => stop_after);
 
       if Stop_Build (Stop_After, Actual => Generation) then
          return True;

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -36,9 +36,9 @@ package body Alire.Roots is
    -- Stop_Build --
    ----------------
 
-   function Stop_Build (Wanted, Actual : Builds.Build_Stages) return Boolean
+   function Stop_Build (Wanted, Actual : Builds.Stop_Points) return Boolean
    is
-     use type Builds.Build_Stages;
+     use type Builds.Stop_Points;
    begin
       if Wanted <= Actual then
          Trace.Debug ("Stopping build as requested at stage: " & Wanted'Image);
@@ -55,10 +55,10 @@ package body Alire.Roots is
    procedure Build_Prepare (This           : in out Root;
                             Saved_Profiles : Boolean;
                             Force_Regen    : Boolean;
-                            Stop_After     : Builds.Build_Stages :=
-                              Builds.Build_Stages'Last)
+                            Stop_After     : Builds.Stop_Points :=
+                              Builds.Stop_Points'Last)
    is
-      use all type Builds.Build_Stages;
+      use all type Builds.Stop_Points;
    begin
       --  Check whether we should override configuration with the last one used
       --  and stored on disk. Since the first time the one from disk will be be
@@ -107,13 +107,13 @@ package body Alire.Roots is
                    Cmd_Args         : AAA.Strings.Vector;
                    Build_All_Deps   : Boolean := False;
                    Saved_Profiles   : Boolean := True;
-                   Stop_After       : Builds.Build_Stages :=
-                     Builds.Build_Stages'Last)
+                   Stop_After       : Builds.Stop_Points :=
+                     Builds.Stop_Points'Last)
                    return Boolean
    is
       Build_Failed : exception;
 
-      use all type Builds.Build_Stages;
+      use all type Builds.Stop_Points;
 
       --------------------------
       -- Build_Single_Release --

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -1,7 +1,6 @@
 with Ada.Directories;
 with Ada.Unchecked_Deallocation;
 
-with Alire.Builds;
 with Alire.Conditional;
 with Alire.Dependencies.Containers;
 with Alire.Environment.Loading;
@@ -33,13 +32,33 @@ package body Alire.Roots is
 
    use type UString;
 
+   ----------------
+   -- Stop_Build --
+   ----------------
+
+   function Stop_Build (Wanted, Actual : Builds.Build_Stages) return Boolean
+   is
+     use type Builds.Build_Stages;
+   begin
+      if Wanted <= Actual then
+         Trace.Debug ("Stopping build as requested at stage: " & Wanted'Image);
+         return True;
+      else
+         return False;
+      end if;
+   end Stop_Build;
+
    -------------------
    -- Build_Prepare --
    -------------------
 
    procedure Build_Prepare (This           : in out Root;
                             Saved_Profiles : Boolean;
-                            Force_Regen    : Boolean) is
+                            Force_Regen    : Boolean;
+                            Stop_After     : Builds.Build_Stages :=
+                              Builds.Build_Stages'Last)
+   is
+      use all type Builds.Build_Stages;
    begin
       --  Check whether we should override configuration with the last one used
       --  and stored on disk. Since the first time the one from disk will be be
@@ -68,6 +87,10 @@ package body Alire.Roots is
          --  Changes in configuration may require new build dirs.
       end if;
 
+      if Stop_Build (Stop_After, Actual => Sync) then
+         return;
+      end if;
+
       --  Ensure configurations are in place and up-to-date
 
       This.Generate_Configuration (Full => Force or else Force_Regen);
@@ -83,10 +106,14 @@ package body Alire.Roots is
    function Build (This             : in out Root;
                    Cmd_Args         : AAA.Strings.Vector;
                    Build_All_Deps   : Boolean := False;
-                   Saved_Profiles   : Boolean := True)
+                   Saved_Profiles   : Boolean := True;
+                   Stop_After       : Builds.Build_Stages :=
+                     Builds.Build_Stages'Last)
                    return Boolean
    is
       Build_Failed : exception;
+
+      use all type Builds.Build_Stages;
 
       --------------------------
       -- Build_Single_Release --
@@ -193,18 +220,29 @@ package body Alire.Roots is
             end if;
 
             --  Run post-fetch, it will be skipped if already ran
+
             Properties.Actions.Executor.Execute_Actions
               (This,
                State,
                Properties.Actions.Post_Fetch);
 
+            if Stop_Build (Stop_After, Actual => Post_Fetch) then
+               return;
+            end if;
+
             --  Pre-build must run always
+
             Properties.Actions.Executor.Execute_Actions
               (This,
                State,
                Properties.Actions.Pre_Build);
 
+            if Stop_Build (Stop_After, Actual => Pre_Build) then
+               return;
+            end if;
+
             --  Actual build
+
             if Release.Origin.Requires_Build then
                Call_Gprbuild (Release);
             else
@@ -213,7 +251,12 @@ package body Alire.Roots is
                   & ": release has no sources.", Detail);
             end if;
 
+            if Stop_Build (Stop_After, Actual => Build) then
+               return;
+            end if;
+
             --  Post-build must run always
+
             Properties.Actions.Executor.Execute_Actions
               (This,
                State,
@@ -227,6 +270,10 @@ package body Alire.Roots is
 
       This.Build_Prepare (Saved_Profiles => Saved_Profiles,
                           Force_Regen    => False);
+
+      if Stop_Build (Stop_After, Actual => Generation) then
+         return True;
+      end if;
 
       This.Export_Build_Environment;
 

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -3,6 +3,7 @@ private with Ada.Finalization;
 
 with AAA.Strings;
 
+with Alire.Builds;
 private with Alire.Builds.Hashes;
 with Alire.Containers;
 with Alire.Crate_Configuration;
@@ -264,7 +265,9 @@ package Alire.Roots is
    function Build (This             : in out Root;
                    Cmd_Args         : AAA.Strings.Vector;
                    Build_All_Deps   : Boolean := False;
-                   Saved_Profiles   : Boolean := True)
+                   Saved_Profiles   : Boolean := True;
+                   Stop_After       : Builds.Build_Stages :=
+                     Builds.Build_Stages'Last)
                    return Boolean;
    --  Recursively build all dependencies that declare executables, and finally
    --  the root release. Also executes all pre-build/post-build actions for
@@ -286,7 +289,9 @@ package Alire.Roots is
 
    procedure Build_Prepare (This           : in out Root;
                             Saved_Profiles : Boolean;
-                            Force_Regen    : Boolean);
+                            Force_Regen    : Boolean;
+                            Stop_After     : Builds.Build_Stages :=
+                              Builds.Build_Stages'Last);
    --  Perform all preparations but the building step itself. This will require
    --  complete configuration, and will leave all files on disk as if an actual
    --  build were attempted. May optionally use saved profiles from the command

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -266,8 +266,8 @@ package Alire.Roots is
                    Cmd_Args         : AAA.Strings.Vector;
                    Build_All_Deps   : Boolean := False;
                    Saved_Profiles   : Boolean := True;
-                   Stop_After       : Builds.Build_Stages :=
-                     Builds.Build_Stages'Last)
+                   Stop_After       : Builds.Stop_Points :=
+                     Builds.Stop_Points'Last)
                    return Boolean;
    --  Recursively build all dependencies that declare executables, and finally
    --  the root release. Also executes all pre-build/post-build actions for
@@ -290,8 +290,8 @@ package Alire.Roots is
    procedure Build_Prepare (This           : in out Root;
                             Saved_Profiles : Boolean;
                             Force_Regen    : Boolean;
-                            Stop_After     : Builds.Build_Stages :=
-                              Builds.Build_Stages'Last);
+                            Stop_After     : Builds.Stop_Points :=
+                              Builds.Stop_Points'Last);
    --  Perform all preparations but the building step itself. This will require
    --  complete configuration, and will leave all files on disk as if an actual
    --  build were attempted. May optionally use saved profiles from the command

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -230,6 +230,17 @@ package body Alr.Commands.Build is
         .Append (Stage (Pre_Build, " running of pre-build actions"))
         .Append (Stage (Building, "     actual building of sources"))
         .Append (Stage (Post_Build, "running of post-build actions"))
+        .New_Line
+        .Append ("These stages are always run in the given order. A premature"
+                 & " stop will likely not produce the complete build "
+                 & "artifacts, so it is intended for advanced usage when "
+                 & "debugging or testing specific build stages, or to ensure "
+                 & "generated files are up-to-date without launching a "
+                 & "costly build, for example.")
+        .New_Line
+        .Append ("After a partial build, to ensure a proper full build is"
+                 & " performed, just run a regular "
+                 & TTY.Terminal ("alr build") &  " without " & Switch_Stop)
       ;
    end Long_Description;
 

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -55,7 +55,7 @@ package body Alr.Commands.Build is
                       Args :        AAA.Strings.Vector)
    is
       function Is_Valid_Stage is
-        new AAA.Enum_Tools.Is_Valid (Alire.Builds.Build_Stages);
+        new AAA.Enum_Tools.Is_Valid (Alire.Builds.Stop_Points);
 
       use Alire.Utils.Switches;
       Profiles_Selected : constant Natural :=
@@ -63,7 +63,7 @@ package body Alr.Commands.Build is
                                                      Cmd.Validation_Mode,
                                                      Cmd.Dev_Mode));
       Profile : Profile_Kind;
-      Stop_After : Alire.Builds.Build_Stages := Alire.Builds.Build_Stages'Last;
+      Stop_After : Alire.Builds.Stop_Points := Alire.Builds.Stop_Points'Last;
    begin
       --  Validation
 
@@ -74,7 +74,7 @@ package body Alr.Commands.Build is
       if Cmd.Stop_After.all /= "" then
          if Is_Valid_Stage (Alire.TOML_Adapters.Adafy (Cmd.Stop_After.all))
          then
-            Stop_After := Alire.Builds.Build_Stages'Value
+            Stop_After := Alire.Builds.Stop_Points'Value
               (Alire.TOML_Adapters.Adafy (Cmd.Stop_After.all));
          else
             Reportaise_Wrong_Arguments
@@ -121,11 +121,11 @@ package body Alr.Commands.Build is
 
    function Execute (Cmd              : in out Commands.Command'Class;
                      Args             :        AAA.Strings.Vector;
-                     Stop             :        Alire.Builds.Build_Stages :=
-                       Alire.Builds.Build_Stages'Last)
+                     Stop             :        Alire.Builds.Stop_Points :=
+                       Alire.Builds.Stop_Points'Last)
                      return Boolean
    is
-      use type Alire.Builds.Build_Stages;
+      use type Alire.Builds.Stop_Points;
    begin
       --  Prevent premature update of dependencies, as the exact folders
       --  will depend on the build hashes, which are yet unknown until
@@ -136,7 +136,7 @@ package body Alr.Commands.Build is
       declare
          Timer : Stopwatch.Instance;
          Build_Kind : constant String :=
-                        (if Stop < Alire.Builds.Build_Stages'Last
+                        (if Stop < Alire.Builds.Stop_Points'Last
                          then TTY.Warn ("Partial") & " build"
                          else "Build");
       begin
@@ -150,7 +150,7 @@ package body Alr.Commands.Build is
             Alire.Put_Success (Build_Kind & " finished successfully in "
                                & TTY.Bold (Timer.Image) & " seconds.");
 
-            if Stop < Alire.Builds.Build_Stages'Last then
+            if Stop < Alire.Builds.Stop_Points'Last then
                Alire.Put_Info
                  ("Build was requested to stop after stage: "
                   & TTY.Emph (AAA.Strings.To_Lower_Case (Stop'Image))
@@ -177,20 +177,20 @@ package body Alr.Commands.Build is
    function Long_Description (Cmd : Command)
                               return AAA.Strings.Vector
    is
-      use all type Alire.Builds.Build_Stages;
+      use all type Alire.Builds.Stop_Points;
 
       -----------
       -- Stage --
       -----------
 
-      function Stage (Name        : Alire.Builds.Build_Stages;
+      function Stage (Name        : Alire.Builds.Stop_Points;
                       Description : String)
                       return String
       is ("* "
           & TTY.Emph (Alire.TOML_Adapters.Tomify (Name'Image))
           & ": " & Description);
 
-      function Building return Alire.Builds.Build_Stages
+      function Building return Alire.Builds.Stop_Points
       is (Alire.Builds.Build);
 
    begin
@@ -240,7 +240,8 @@ package body Alr.Commands.Build is
         .New_Line
         .Append ("After a partial build, to ensure a proper full build is"
                  & " performed, just run a regular "
-                 & TTY.Terminal ("alr build") &  " without " & Switch_Stop)
+                 & TTY.Terminal ("alr build") &  " without "
+                 & Switch_Stop & ".")
       ;
    end Long_Description;
 

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -1,6 +1,7 @@
 with AAA.Enum_Tools;
 
 with Alire.Crate_Configuration;
+with Alire.TOML_Adapters;
 with Alire.Utils.Switches;
 
 with Stopwatch;
@@ -71,8 +72,10 @@ package body Alr.Commands.Build is
       end if;
 
       if Cmd.Stop_After.all /= "" then
-         if Is_Valid_Stage (Cmd.Stop_After.all) then
-            Stop_After := Alire.Builds.Build_Stages'Value (Cmd.Stop_After.all);
+         if Is_Valid_Stage (Alire.TOML_Adapters.Adafy (Cmd.Stop_After.all))
+         then
+            Stop_After := Alire.Builds.Build_Stages'Value
+              (Alire.TOML_Adapters.Adafy (Cmd.Stop_After.all));
          else
             Reportaise_Wrong_Arguments
               ("Stopping stage is invalid: " & TTY.Error (Cmd.Stop_After.all)
@@ -184,7 +187,7 @@ package body Alr.Commands.Build is
                       Description : String)
                       return String
       is ("* "
-          & AAA.Strings.To_Lower_Case (TTY.Emph (Name'Image))
+          & TTY.Emph (Alire.TOML_Adapters.Tomify (Name'Image))
           & ": " & Description);
 
       function Building return Alire.Builds.Build_Stages

--- a/src/alr/alr-commands-build.ads
+++ b/src/alr/alr-commands-build.ads
@@ -24,8 +24,8 @@ package Alr.Commands.Build is
 
    function Execute (Cmd  : in out Commands.Command'Class;
                      Args :        AAA.Strings.Vector;
-                     Stop :        Alire.Builds.Build_Stages :=
-                       Alire.Builds.Build_Stages'Last)
+                     Stop :        Alire.Builds.Stop_Points :=
+                       Alire.Builds.Stop_Points'Last)
                      return Boolean;
    --  Returns True if compilation succeeded. For invocations after some other
    --  command that already has set up the build environment we need to avoid

--- a/src/alr/alr-commands-build.ads
+++ b/src/alr/alr-commands-build.ads
@@ -53,5 +53,6 @@ private
       Profiles        : aliased GNAT.OS_Lib.String_Access;
       --  A string of "crate:profile" values, with "*" meaning all crates and
       --  "%" meaning all crates without a previous setting in a manifest.
+      Stop_After      : aliased GNAT.OS_Lib.String_Access;
    end record;
 end Alr.Commands.Build;

--- a/src/alr/alr-commands-build.ads
+++ b/src/alr/alr-commands-build.ads
@@ -1,5 +1,7 @@
 with AAA.Strings;
 
+with Alire.Builds;
+
 private with GNAT.OS_Lib;
 
 package Alr.Commands.Build is
@@ -21,7 +23,9 @@ package Alr.Commands.Build is
                       Args :        AAA.Strings.Vector);
 
    function Execute (Cmd  : in out Commands.Command'Class;
-                     Args :        AAA.Strings.Vector)
+                     Args :        AAA.Strings.Vector;
+                     Stop :        Alire.Builds.Build_Stages :=
+                       Alire.Builds.Build_Stages'Last)
                      return Boolean;
    --  Returns True if compilation succeeded. For invocations after some other
    --  command that already has set up the build environment we need to avoid

--- a/testsuite/tests/build/stop-after/test.py
+++ b/testsuite/tests/build/stop-after/test.py
@@ -1,0 +1,69 @@
+"""
+Check the several stop points in the build process
+"""
+
+from enum import IntEnum
+import os
+import shutil
+from drivers.alr import run_alr, init_local_crate, add_action, alr_with
+from drivers import builds
+# from drivers.asserts import assert_eq, assert_match
+
+
+class StopStage(IntEnum):
+    sync       = 0
+    generation = 1
+    post_fetch = 2
+    pre_build  = 3
+    build      = 4
+    post_build = 5
+
+
+# A function that checks things are as they should be
+def check_stop(stop: StopStage):
+    # Run alr
+    out = run_alr("build", f"--stop-after={stop.name.replace('_', '-')}",
+                  quiet=False).out
+
+    # Sync should have happened
+    if builds.are_shared():
+        assert builds.find_dir("libhello"), "libhello build dir should exist"
+
+    # Check generation of config files
+    assert (stop >= StopStage.generation) == os.path.isfile("config/xxx_config.gpr"), \
+        f"config dir existence [un]expected: {idx}, {os.path.isfile('config/xxx_config.gpr')}"
+
+    # Check post-fetch, which should happen only once
+    assert (stop == StopStage.post_fetch) == ("post-fetch-triggered" in out), \
+        f"post-fetch-triggered should be in output: {out}"
+
+    # Check pre-build, which should happen in every build that goes beyond it
+    assert (stop >= StopStage.pre_build) == ("pre-build-triggered" in out), \
+        f"pre-build-triggered should be in output: {out}"
+
+    # Check build artifacts exist only after build
+    assert (stop >= StopStage.build) == os.path.isdir("obj"), \
+        f"obj dir existence [un]expected"
+
+    # Check post-build
+    assert (stop >= StopStage.post_build) == ("post-build-triggered" in out), \
+        f"post-build-triggered should be in output: {out}"
+
+
+# TEST BEGIN
+
+# Prepare the crate with actions and a dependency whose syncing we can test
+init_local_crate()
+add_action("post-fetch", ["echo", "post-fetch-triggered"])
+add_action("pre-build",  ["echo", "pre-build-triggered"])
+add_action("post-build", ["echo", "post-build-triggered"])
+alr_with("libhello")
+
+# Remove config dir which may have been generated during initialization
+shutil.rmtree("config")
+
+# Check that the stop points are honored
+for stop in StopStage:
+    check_stop(stop)
+
+print("SUCCESS")

--- a/testsuite/tests/build/stop-after/test.yaml
+++ b/testsuite/tests/build/stop-after/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+build_mode: both  # one of shared, sandboxed, both (default)
+indexes:
+    basic_index: {}


### PR DESCRIPTION
This allows stopping the build process at different points, which may help in debugging actions, ensuring up-to-date config without requiring updating dependencies nor building, etc.

Fixes #1544 