### PR TITLE
Explain how to use printenv more safely

### DIFF
--- a/src/alr/alr-commands-printenv.adb
+++ b/src/alr/alr-commands-printenv.adb
@@ -65,9 +65,17 @@ package body Alr.Commands.Printenv is
                  " This command can be used to setup a build environment," &
                  " for instance before starting an IDE.")
       .New_Line
+      .Append ("When using " & TTY.Terminal ("alr printenv") & " in scripts, "
+        & "to ensure no unwanted output is intermixed with the environment "
+        & "definitions, the recommendation is to run it twice and and use the "
+        & "output of the second run in quiet non-interactive mode. This is "
+        & "because running " & TTY.Terminal ("alr printenv") & " after "
+        & "manifest editions may trigger an automatic synchronization that "
+        & "could produce extra output not intended as environment variables.")
+      .New_line
       .Append ("Examples:")
-      .Append ("  - eval $(alr printenv --unix)")
-      .Append ("  - alr printenv --powershell | Invoke-Expression")
+      .Append ("  - eval $(alr -n -q printenv --unix)")
+      .Append ("  - alr -n -q printenv --powershell | Invoke-Expression")
      );
 
    --------------------

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -315,9 +315,11 @@ package body Alr.Commands is
       end if;
 
       --  Unless the command is precisely to configure the toolchain, ask the
-      --  user for its preference at this time.
+      --  user for its preference at this time. We also don't ask during `alr
+      --  printenv`, whose output is likely being redirected.
 
       if Cmd not in Commands.Toolchain.Command'Class and then
+        Cmd not in Commands.Printenv.Command'Class and then
         Alire.Toolchains.Assistant_Enabled
       then
          Alire.Toolchains.Assistant (Conf.Global, First_Run => True);


### PR DESCRIPTION
With the new shared builds, `alr printenv` won't trigger `post-fetch` in any case, but just to err on the safe side.

Fixes #989 .