### PR TITLE
Clearer identification of missing dependencies

### DIFF
--- a/src/alire/alire-dependencies-states.ads
+++ b/src/alire/alire-dependencies-states.ads
@@ -113,6 +113,13 @@ package Alire.Dependencies.States is
    --  From the POV of users, pinning to version or linking to dir is a pin
 
    function Is_Solved (This : State) return Boolean;
+   --  With a regular release from the index
+
+   function Is_Fulfilled (This : State) return Boolean;
+   --  Either solved or linked
+
+   function Is_Unfulfilled (This : State) return Boolean;
+   --  Neither solved nor linked
 
    --  Case-specific info
 
@@ -332,6 +339,16 @@ private
 
    function Is_Direct (This : State) return Boolean
    is (This.Transitivity = Direct);
+
+   function Is_Fulfilled (This : State) return Boolean
+   is (case This.Fulfilment is
+          when Solved | Linked => True,
+          when Hinted | Missed => False);
+
+   function Is_Unfulfilled (This : State) return Boolean
+   is (case This.Fulfilment is
+          when Solved | Linked => False,
+          when Hinted | Missed => True);
 
    function Is_Hinted (This : State) return Boolean
    is (This.Fulfilled.Fulfillment = Hinted);

--- a/src/alire/alire-solutions-diffs.adb
+++ b/src/alire/alire-solutions-diffs.adb
@@ -16,7 +16,6 @@ package body Alire.Solutions.Diffs is
    type Changes is
      (Added,      -- A new release
       Removed,    -- A removed dependency of any kind
-      Hinted,     -- An undetected external dependency
       Upgraded,   -- An upgraded release
       Downgraded, -- A downgraded release
       Pinned,     -- A release being pinned
@@ -27,6 +26,8 @@ package body Alire.Solutions.Diffs is
       Info        -- General info icon
      );
 
+   Missing_Flag : constant String := "missing";
+
    ----------
    -- Icon --
    ----------
@@ -36,7 +37,6 @@ package body Alire.Solutions.Diffs is
          (case Change is
              when Added      => TTY.OK    (U ("+")),
              when Removed    => TTY.Emph  (U ("✗")),
-             when Hinted     => TTY.Warn  (U ("🔎")), -- alts: 💡🔍🔎
              when Upgraded   => TTY.OK    (U ("⭧")),
              when Downgraded => TTY.Warn  (U ("⭨")),
              when Pinned     => TTY.OK    (U ("📌")), -- alts: ⊙📍📌
@@ -49,7 +49,6 @@ package body Alire.Solutions.Diffs is
          (case Change is
              when Added      => U ("+"),
              when Removed    => U ("-"),
-             when Hinted     => U ("~"),
              when Upgraded   => U ("^"),
              when Downgraded => U ("v"),
              when Pinned     => U ("·"),
@@ -151,12 +150,8 @@ package body Alire.Solutions.Diffs is
          use type Alire.User_Pins.Pin;
 
       begin
-         --  New hint
-         if Gains_State (Hinted) then
-            Add_Change (Chg, Icon (Hinted), TTY.Warn ("external"));
-
          --  Changed linked dir
-         elsif Has_Latter and then Latter.Is_Linked and then
+         if Has_Latter and then Latter.Is_Linked and then
            (not Has_Former or else not Former.Is_Linked or else
             Former.Link /= Latter.Link)
          then
@@ -166,7 +161,7 @@ package body Alire.Solutions.Diffs is
          --  New unsolvable
          elsif Gains_State (Missed) then
             Add_Change (Chg, Icon (Missing),
-                        TTY.Error ("missing") & ":"
+                        TTY.Error (Missing_Flag) & ":"
                         & TTY.Warn (To_Lower_Case (Latter.Reason'Image)));
 
          --  From hint to proper release
@@ -237,7 +232,12 @@ package body Alire.Solutions.Diffs is
 
       procedure Provider_Change is
       begin
-         if Has_Latter and then Latter.Is_Provided then
+         if Has_Latter and then Latter.Is_Provided
+           and then
+             (not Has_Former or else
+                (Former.Has_Release and Then
+                 Former.Release.Name_Str /= Latter.Release.Name_Str))
+         then
             Add_Change (Chg, "", TTY.Italic (Latter.Release.Name.As_String));
          end if;
       end Provider_Change;
@@ -317,11 +317,14 @@ package body Alire.Solutions.Diffs is
          subtype Report_Kinds is Origins.Kinds with Static_Predicate =>
            Report_Kinds in Binary_Archive | External | System;
       begin
-         --  For "special" releases, show extra info: binaries that can
-         --  be very large, or releases that are not from sources (so
-         --  harder to audit, intrinsically shared, ...)
+         --  For "special" releases, show extra info: binaries that can be very
+         --  large, or releases that are not from sources (so harder to audit,
+         --  intrinsically shared, ...), but only if they were going to be
+         --  shown already.
 
-         if not Has_Latter or else not Latter.Has_Release then
+         if not Has_Latter or else not Latter.Has_Release or else
+           Chg.Detail.Is_Empty
+         then
             return;
          end if;
 
@@ -340,6 +343,26 @@ package body Alire.Solutions.Diffs is
             end if;
          end;
       end Releases_Without_Sources;
+
+      ----------------------
+      -- Missing_Releases --
+      ----------------------
+
+      procedure Missing_Releases is
+      begin
+         if not Contains (Chg.Detail.Flatten, Missing_Flag) and then
+           Has_Latter and then
+           Latter.Is_Unfulfilled
+         then
+            Add_Change (Chg, Icon (Missing),
+                        TTY.Error (Missing_Flag)
+                        & (if Latter.Is_Missing -- Has a reason
+                          then ":"
+                          & TTY.Warn (To_Lower_Case (Latter.Reason'Image))
+                          else "" -- hinted don't have a reason
+                         ));
+         end if;
+      end Missing_Releases;
 
    begin
 
@@ -360,8 +383,10 @@ package body Alire.Solutions.Diffs is
       Determine_Relevant_Version;
 
       Releases_Without_Sources;
+      --  This one must go after the rest, as it only appends info if the
+      --  release was going to be shown anyway.
 
-      --  Final fill-in for no changes
+      --  Final fill-in for no changes and missing (always reported)
 
       if Length (Chg.Icon) = 0 then
          Add_Change (Chg, Icon (Unchanged), "");
@@ -370,6 +395,8 @@ package body Alire.Solutions.Diffs is
       if Chg.Detail.Is_Empty then
          Add_Change (Chg, "", "unchanged");
       end if;
+
+      Missing_Releases;
 
       return Chg;
 
@@ -454,6 +481,9 @@ package body Alire.Solutions.Diffs is
          end loop;
       end Warn_Unsatisfiable_GNAT_External;
 
+      type Passes is (Fulfilled, Missing);
+      Missing_Header_Added : Boolean := False;
+
    begin
 
       --  Start with an empty line to separate from previous output
@@ -468,38 +498,56 @@ package body Alire.Solutions.Diffs is
                     Level);
       end if;
 
-      --  Detailed changes otherwise
+      --  Detailed changes, showing separately missing dependencies
 
-      for Crate of This.Former.Crates.Union (This.Latter.Crates) loop
-         declare
-            Changes : constant Crate_Changes := Find_Changes (This, Crate);
-         begin
+      for Pass in Passes'Range loop
+         for Crate of This.Former.Crates.Union (This.Latter.Crates) loop
+            declare
+               Changes : constant Crate_Changes := Find_Changes (This, Crate);
+            begin
 
-            if not Changed_Only or else
-              Changes.Detail.Flatten /= "unchanged"
-            then
-               Changed := Changed or True;
+               if not Changed_Only or else
+                 Changes.Detail.Flatten /= "unchanged" or else
+                 Pass = Missing -- Always show missing ones to raise awareness
+               then
 
-               --  Show icon of change
+                  if (Pass = Fulfilled and then
+                        not Contains (Changes.Detail.Flatten, Missing_Flag))
+                    or else
+                      (Pass = Missing and then
+                       Contains (Changes.Detail.Flatten, Missing_Flag))
+                  then
+                     Changed := Changed or True;
 
-               Table.Append (Prefix & (+Changes.Icon));
+                     --  Header for missing section on first missing
 
-               --  Always show crate name
+                     if Pass = Missing and then not Missing_Header_Added then
+                        Missing_Header_Added := True;
+                        Table.Append (Prefix & TTY.Warn ("Missing:")).New_Row;
+                     end if;
 
-               Table.Append (Utils.TTY.Name (Crate));
+                     --  Show icon of change
 
-               --  Show most precise version available
+                     Table.Append (Prefix & (+Changes.Icon));
 
-               Table.Append (+Changes.Best_Version);
+                     --  Always show crate name
 
-               --  Show an explanation of the change depending on
-               --  status changes.
+                     Table.Append (Utils.TTY.Name (Crate));
 
-               Table.Append ("(" & Changes.Detail.Flatten (",") & ")");
+                     --  Show most precise version available
 
-               Table.New_Row;
-            end if;
-         end;
+                     Table.Append (+Changes.Best_Version);
+
+                     --  Show an explanation of the change depending on
+                     --  status changes.
+
+                     Table.Append ("(" & Changes.Detail.Flatten (",") & ")");
+
+                     Table.New_Row;
+                  end if;
+               end if;
+            end;
+         end loop;
       end loop;
 
       if Changed then

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -201,7 +201,7 @@ package Alire.Solutions is
    function Dependencies_That
      (This  : Solution;
       Check : not null access function (Dep : Dependency_State) return Boolean)
-      return Dependency_Map;
+      return State_Map;
    --  Retrieve all states that pass a boolean check
 
    function Dependency (This  : Solution;
@@ -266,7 +266,7 @@ package Alire.Solutions is
    --  Return releases already in the solution that are equivalent to Release
    --  (may be empty).
 
-   function Hints (This : Solution) return Dependency_Map;
+   function Hints (This : Solution) return State_Map;
    --  Return undetected externals in the solution
 
    function Is_Attempted (This : Solution) return Boolean with
@@ -281,13 +281,13 @@ package Alire.Solutions is
    --  A solution is complete when it fulfills all dependencies via regular
    --  releases, detected externals, or linked directories.
 
-   function Links (This : Solution) return Dependency_Map;
+   function Links (This : Solution) return State_Map;
    --  Return crates that are solved with a softlink
 
    function Link_Pins (This : Solution) return Conditional.Dependencies;
    --  Return dependencies of linked crates in the solution
 
-   function Misses (This : Solution) return Dependency_Map;
+   function Misses (This : Solution) return State_Map;
    --  Return crates for which there is neither hint nor proper versions
 
    function Pins (This : Solution) return Conditional.Dependencies;
@@ -295,7 +295,7 @@ package Alire.Solutions is
    --  exact versions. NOTE that the original dependency is thus lost in this
    --  info.
 
-   function Pins (This : Solution) return Dependency_Map;
+   function Pins (This : Solution) return dependency_Map;
    --  return all version-pinned dependencies as plain dependencies for a exact
    --  version. NOTE that the original dependency is thus lost.
 

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -236,6 +236,14 @@ package Alire with Preelaborate is
    --  When Recover, emit a warning and return normally. When not Recover call
    --  Raise_Checked_Error instead.
 
+   procedure Report_Program_Error (Explanation : String  := "";
+                                   Survivable  : Boolean := True) is null;
+   --  For unexpected situations where normally a Program_Error would be
+   --  adecuate, but we do not want to bomb on the user because continuing is
+   --  acceptable. We log a stack trace, print a warning and continue, so
+   --  a motivated user can report an issue, but we don't needlessly raise. If
+   --  not Survivable, then do raise a Program_Error.
+
    ---------------
    --  LOGGING  --
    ---------------

--- a/testsuite/tests/get/missing-deps/test.py
+++ b/testsuite/tests/get/missing-deps/test.py
@@ -14,9 +14,9 @@ from glob import glob
 run_alr('get', 'hello=3', force=True)
 os.chdir(glob('hello*')[0])
 
-# Check missing dependency is shown as external
+# Check missing dependency is properly identified
 p = run_alr('with', '--solve')
-assert_match('.*Dependencies \(external\):\n'
+assert_match('.*Dependencies \(missing\):\n'
              '   libhello\^3\.0.*',
              p.out, flags=re.S)
 

--- a/testsuite/tests/index/external-hint/test.py
+++ b/testsuite/tests/index/external-hint/test.py
@@ -40,7 +40,7 @@ assert_match
 p = run_alr('show', 'crate_master', '--solve', '--system', quiet=False)
 
 assert_match(".*"   # Skip previous crate info
-             "Dependencies \(external\):\n"
+             "Dependencies \(missing\):\n"
              "   crate\* \(direct,hinted\)\n"
              "      Hint: This is a custom hint\n"
              "Dependencies \(graph\):\n"

--- a/testsuite/tests/pin/change-type/test.py
+++ b/testsuite/tests/pin/change-type/test.py
@@ -33,7 +33,7 @@ alr_pin('libhello', path='../crates/libhello_1.0.0')
 
 # Check that it shows as such in the solution
 p = run_alr('show', '--solve')
-assert_match('.*Dependencies \(external\):.*'
+assert_match('.*Dependencies \(solution\):.*'
              'libhello.*\^1.*\(direct,linked'
              ',path=../crates/libhello_1.0.0\).*',
              p.out, flags=re.S)

--- a/testsuite/tests/pin/missing-version/test.py
+++ b/testsuite/tests/pin/missing-version/test.py
@@ -25,7 +25,7 @@ alr_pin('hello', version='3')
 p = run_alr('with', '--solve')
 assert_match('.*Dependencies \(solution\):\n'
              '   hello=3\.0\.0 \(pinned\).*\n'  # skip irrelevant origin info
-             '.*Dependencies \(external\):\n'
+             '.*Dependencies \(missing\):\n'
              '   libhello\^3\.0.*',
              p.out, flags=re.S)
 
@@ -38,7 +38,7 @@ alr_pin('hello', version='5')
 # optimizations, this may show as hello=5.0.0 or hello(=5.0.0&>0), hence the
 # permissive regex
 p = run_alr('with', '--solve')
-assert_match('.*Dependencies \(external\):\n'
+assert_match('.*Dependencies \(missing\):\n'
              '   hello.*=5\.0\.0.*',
              p.out, flags=re.S)
 

--- a/testsuite/tests/pin/pin-dir-with-regular/test.py
+++ b/testsuite/tests/pin/pin-dir-with-regular/test.py
@@ -27,7 +27,6 @@ p = run_alr('with', '--solve')
 # over some parts of the output
 assert_match('.*Dependencies \(solution\):.*'
              'libhello=1\.0\.0.*'
-             'Dependencies \(external\):.*'
              'unobtanium\* \(direct,linked,.*',
              p.out, flags=re.S)
 

--- a/testsuite/tests/pin/pin-dir/test.py
+++ b/testsuite/tests/pin/pin-dir/test.py
@@ -29,7 +29,7 @@ run_alr('build')
 p = run_alr('with', '--solve')
 # For this match we don't know where the test is temporarily put, so we skip
 # over some parts of the output
-assert_match('.*Dependencies \(external\):.*'
+assert_match('.*Dependencies \(solution\):.*'
              'libhello\^1.0.0 \(direct,linked'
              ',path=../crates/libhello_1.0.0\).*',  # relative, always fwd slash
              p.out, flags=re.S)

--- a/testsuite/tests/pin/version/test.py
+++ b/testsuite/tests/pin/version/test.py
@@ -36,7 +36,7 @@ Dependencies (direct):
    hello*
 Pins (direct):
    hello = { version='7.7.7' }
-Dependencies (external):
+Dependencies (missing):
    hello=7.7.7 (direct,missed:unavailable,pin=7.7.7) (pinned)
 Dependencies (graph):
    xxx=0.1.0-dev --> hello*

--- a/testsuite/tests/show/system-hint/test.py
+++ b/testsuite/tests/show/system-hint/test.py
@@ -1,6 +1,5 @@
 """
 Test that hinted native dependencies appear correctly in 'alr show'.
-More precisely, a "Dependencies (native)" section is added to list them.
 """
 
 from glob import glob
@@ -14,7 +13,7 @@ p = run_alr('show', 'libhello=0.9-test-unav-native', '--solve',
             complain_on_error=True)
 
 assert_match('.*'
-             'Dependencies \(external\):\n'
+             'Dependencies \(missing\):\n'
              '   make\*'
              '.*',
              p.out, flags=re.S)

--- a/testsuite/tests/solver/missing-reasons/test.py
+++ b/testsuite/tests/solver/missing-reasons/test.py
@@ -24,7 +24,7 @@ alr_with("unobtanium")    # Unindexed crate
 alr_pin("dep", path="dep")  # Establish the conflict with this local dep
 
 match_solution(
-    """Dependencies (external):
+    """Dependencies (missing):
    hello(=1.0.1) & (=1.0.0) (direct,missed:conflict)
    libhello=777 (direct,missed:unavailable)
    unobtanium* (direct,missed:unknown)""",

--- a/testsuite/tests/update/missing-deps/test.py
+++ b/testsuite/tests/update/missing-deps/test.py
@@ -24,7 +24,7 @@ run_alr('update')
 # dependency is included in the restrictions
 p = run_alr('with', '--solve')
 assert_match(
-    '.*Dependencies \(external\):\n'
+    '.*Dependencies \(missing\):\n'
     '   ' +
     re.escape('libhello(=3.0.0) & (^2.0.0) '
               '(direct,missed:conflict,pin=3.0.0)') + '.*',

--- a/testsuite/tests/with/changes-info/test.py
+++ b/testsuite/tests/with/changes-info/test.py
@@ -7,7 +7,6 @@ import re
 
 from drivers.alr import run_alr
 from drivers.asserts import assert_match
-from drivers.helpers import path_separator, with_project
 
 # Initialize a workspace for the test
 run_alr('init', '--bin', 'xxx')
@@ -30,14 +29,17 @@ Changes to dependency solution:
 # Check adding a missing crate (with forcing)
 p = run_alr('with', 'unobtanium', quiet=False, force=True)
 assert_match(".*" +
-             re.escape("""Requested changes:
+             re.escape("""\
+Requested changes:
 
    + unobtanium * (add)
 
 Changes to dependency solution:
 
    New solution is incomplete.
-   +! unobtanium * (new,missing:unknown)""") + ".*",
+   Missing:
+   +!       unobtanium * (new,missing:unknown)\
+""") + ".*",
              p.out, flags=re.S)
 
 # Remove the missing crate for following tests

--- a/testsuite/tests/with/external/test.py
+++ b/testsuite/tests/with/external/test.py
@@ -22,7 +22,7 @@ run_alr('with', 'make', force=True)
 p = run_alr('with', '--solve')
 assert_match('Dependencies \(direct\):\n'
              '   make\*\n'
-             'Dependencies \(external\):\n'
+             'Dependencies \(missing\):\n'
              '   make\* \(direct,hinted\)\n'
              'Dependencies \(graph\):\n'
              '   xxx=0.1.0-dev --> make\*\n'

--- a/testsuite/tests/with/missing-deps/test.py
+++ b/testsuite/tests/with/missing-deps/test.py
@@ -27,7 +27,7 @@ run_alr('with', 'hello^3', force=True)
 p = run_alr('with', '--solve')
 assert_match('.*Dependencies \(solution\):\n'
              '   hello=3\.0\.0.*'  # skip origin
-             'Dependencies \(external\):\n'
+             'Dependencies \(missing\):\n'
              '   libhello\^3.*'    # skip flags
              '   unobtanium\*.*',
              p.out, flags=re.S)

--- a/testsuite/tests/with/pin-dir/test.py
+++ b/testsuite/tests/with/pin-dir/test.py
@@ -28,7 +28,7 @@ run_alr('build')
 p = run_alr('with', '--solve')
 # For this match we don't know where the test is temporarily put, so we skip
 # over some parts of the output
-assert_match('.*Dependencies \(external\):.*'
+assert_match('.*Dependencies \(solution\):.*'
              'libhello\^1\.0\.0 \(direct,linked'
              ',path=.*/my_index/crates/libhello_1.0.0\).*',
              p.out, flags=re.S)


### PR DESCRIPTION
When a complete solution is printed (`alr show|with --solve`), the "external" section is now named "missing" (which is what it actually meant).

When a diff is shown that contains missing dependencies, a new section is appended containing separately all missing dependencies, labeled as such:
```
$ alr -f with hello unobtanium
Requested changes:

   ✓ hello      ^1.0.2 (add)
   ✓ unobtanium *      (add)

Changes to dependency solution:

   New solution is incomplete.
   +        hello      1.0.2 (new)
   Missing:
   +❗      unobtanium *     (new,missing:unknown)
```

This should eliminate any ambiguity about what is actually missing.

Fixes #646 
Fixes #685 