### PR TITLE
Don't run OS initialization during elaboration

### DIFF
--- a/src/alire/alire-platforms-current.ads
+++ b/src/alire/alire-platforms-current.ads
@@ -31,6 +31,15 @@ package Alire.Platforms.Current is
 
    function Operating_System return Platforms.Operating_Systems;
 
+   ----------------------
+   --  Self configuration
+
+   procedure Initialize;
+   --  Do any initialization that is necessary for this platform. This is
+   --  called as soon as we know the user is not running `alr config`, as we
+   --  want to allow the opportunity to configure things without triggering
+   --  this initialization.
+
    --------------------------------
    -- Portable derived utilities --
    --------------------------------

--- a/src/alire/os_freebsd/alire-platforms-current__freebsd.adb
+++ b/src/alire/os_freebsd/alire-platforms-current__freebsd.adb
@@ -31,4 +31,10 @@ package body Alire.Platforms.Current is
    function Operating_System return Alire.Platforms.Operating_Systems
    is (Alire.Platforms.FreeBSD);
 
+   ----------------
+   -- Initialize --
+   ----------------
+
+   procedure Initialize is null;
+
 end Alire.Platforms.Current;

--- a/src/alire/os_linux/alire-platforms-current__linux.adb
+++ b/src/alire/os_linux/alire-platforms-current__linux.adb
@@ -133,4 +133,10 @@ package body Alire.Platforms.Current is
    function Operating_System return Alire.Platforms.Operating_Systems
    is (Alire.Platforms.Linux);
 
+   ----------------
+   -- Initialize --
+   ----------------
+
+   procedure Initialize is null;
+
 end Alire.Platforms.Current;

--- a/src/alire/os_macos/alire-platforms-current__macos.adb
+++ b/src/alire/os_macos/alire-platforms-current__macos.adb
@@ -74,4 +74,10 @@ package body Alire.Platforms.Current is
 
    function Operating_System return Platforms.Operating_Systems is (MacOS);
 
+   ----------------
+   -- Initialize --
+   ----------------
+
+   procedure Initialize is null;
+
 end Alire.Platforms.Current;

--- a/src/alire/os_windows/alire-platforms-current__windows.adb
+++ b/src/alire/os_windows/alire-platforms-current__windows.adb
@@ -27,21 +27,9 @@ package body Alire.Platforms.Current is
    ------------------
 
    function Detect_Msys2 return Boolean is
-      use AAA.Strings;
    begin
       --  Try to detect if Msys2's pacman tool is already in path
-      declare
-         Unused : Vector;
-      begin
-         Unused := OS_Lib.Subprocess.Checked_Spawn_And_Capture
-           ("pacman", Empty_Vector & ("-V"),
-            Err_To_Out => True);
-         return True;
-      exception when others =>
-            null;
-      end;
-
-      return False;
+      return OS_Lib.Locate_Exec_On_Path ("pacman") /= "";
    end Detect_Msys2;
 
    -----------------------
@@ -268,6 +256,12 @@ package body Alire.Platforms.Current is
          return Alire.Outcome_Success;
       end if;
 
+      --  Prevent unwilling installation of msys2 during testsuite runs
+      if OS_Lib.Getenv (Environment.Testsuite, "unset") /= "unset" then
+         raise Program_Error
+           with "Attempting to install msys2 during testsuite run";
+      end if;
+
       Result := Download_File (Msys2_Installer_URL,
                                Msys2_Installer,
                                Install_Dir);
@@ -421,6 +415,13 @@ package body Alire.Platforms.Current is
 
    end Setup_Msys2;
 
-begin
-   Setup_Msys2;
+   ----------------
+   -- Initialize --
+   ----------------
+
+   procedure Initialize is
+   begin
+      Setup_Msys2;
+   end Initialize;
+
 end Alire.Platforms.Current;

--- a/src/alr/alr-commands-config.ads
+++ b/src/alr/alr-commands-config.ads
@@ -4,9 +4,11 @@ package Alr.Commands.Config is
 
    type Command is new Commands.Command with private;
 
+   Command_Name : constant String := "config";
+
    overriding
    function Name (Cmd : Command) return CLIC.Subcommand.Identifier
-   is ("config");
+   is (Command_Name);
 
    overriding
    procedure Execute (Cmd  : in out Command;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -518,6 +518,26 @@ package body Alr.Commands is
 
       begin
 
+         --  Once we know the user is not trying to configure, run the
+         --  platform-specific initialization (which may rely on such config).
+
+         begin
+            if Sub_Cmd.What_Command /= Config.Command_Name
+            then
+               Alire.Platforms.Current.Initialize;
+               Trace.Debug ("Platform-specific initialization done.");
+            else
+               Trace.Debug
+                 ("Platform-specific initialization skipped (alr config).");
+            end if;
+         exception
+            when Sub_Cmd.Error_No_Command =>
+               Trace.Debug
+                 ("Platform-specific initialization skipped (no command).");
+               --  If the user is running plain `alr` or `alr --version`, it's
+               --  likely not the time to interrup with an msys2 installation.
+         end;
+
          Set_Builtin_Aliases;
 
          Sub_Cmd.Load_Aliases (Alire.Config.DB.all);

--- a/testsuite/tests/index/local-index-not-found/test.py
+++ b/testsuite/tests/index/local-index-not-found/test.py
@@ -13,7 +13,12 @@ from drivers.asserts import assert_match
 
 for d in ('no-such-directory',
           'file://no-such-directory', ):
+
+    # Delete old configuration and indexes, but disable msys2 installation or
+    # installation will be reattempted.
     rm('alr-config', recursive=True)
+    run_alr("config", "--global", "--set", "msys2.do_not_install", "true")
+
     prepare_indexes('alr-config', '.',
                     {'bad_index': {'dir': d, 'in_fixtures': False}})
     p = run_alr("search", "--crates", complain_on_error=False, debug=False)


### PR DESCRIPTION
As this makes impossible to tweak such initialization with `alr config`.

More precisely, it was now impossible to disable installation of msys2 via `alr config --set msys2.do_not_install`.

With this PR, msys2 installation is not run unconditionally during elaboration, but later on when we are sure the user is not running `alr config` (or `alr --version`)

For good measure, also check that unexpected msys2 installation is not attempted during test runs.