### PR TITLE
Relocate cache with config builtin `cache.dir`

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -6,6 +6,23 @@ stay on top of `alr` new features.
 
 ## Release `2.0-dev`
 
+### Cache and toolchain storage location overridding
+
+PR [#1593](https://github.com/alire-project/alire/pull/1593)
+
+The cache directory can now be set independently of the configuration
+directory, by setting the `cache.dir` config builtin to an absolute path. For
+example:
+```
+alr config --global --set cache.dir /path/to/my/global/cache
+```
+Since the cache by default also contains installed toolchains, which may not be
+needed to be moved elsewhere, the `toolchain.dir` can be used to dissociate
+toolchain location from cache location in a similar way:
+```
+alr config --global --set toolchain.dir /path/to/my/toolchains
+```
+
 ### New switch `alr build --stop-after=<build stage>`
 
 PR [#1573](https://github.com/alire-project/alire/pull/1573)

--- a/src/alire/alire-config-builtins.ads
+++ b/src/alire/alire-config-builtins.ads
@@ -6,6 +6,15 @@ package Alire.Config.Builtins is
    -- Builtins --
    --------------
 
+   --  CACHE
+
+   Cache_Dir : constant Builtin := New_Builtin
+     (Key  => "cache.dir",
+      Kind => Cfg_Absolute_Path,
+      Def  => "",
+      Help =>
+        "Directory where Alire will store its cache.");
+
    --  DEPENDENCIES
 
    Dependencies_Git_Keep_Repository : constant Builtin := New_Builtin
@@ -106,6 +115,13 @@ package Alire.Config.Builtins is
       Help =>
         "If true, and assistant to select the default toolchain will run "
       & "when first needed.");
+
+   Toolchain_Dir : constant Builtin := New_Builtin
+     (Key  => "toolchain.dir",
+      Kind => Cfg_Absolute_Path,
+      Def  => "",
+      Help =>
+        "Directory where Alire will store its toolchains.");
 
    Toolchain_External : constant Builtin := New_Builtin
      (Key    => "toolchain.external",

--- a/src/alire/alire-config-edit.adb
+++ b/src/alire/alire-config-edit.adb
@@ -181,9 +181,12 @@ package body Alire.Config.Edit is
    ----------------
 
    function Cache_Path return Absolute_Path
-   is (if Path = Default_Config_Path
-       then Platforms.Folders.Cache
-       else Path / Paths.Cache_Folder_Inside_Working_Folder);
+   is (if Builtins.Cache_Dir.Get /= "" then
+          Builtins.Cache_Dir.Get
+       elsif Path /= Default_Config_Path then
+          Path / Paths.Cache_Folder_Inside_Working_Folder
+       else
+          Platforms.Folders.Cache);
 
    --------------
    -- Set_Path --

--- a/src/alire/alire-config-edit.ads
+++ b/src/alire/alire-config-edit.ads
@@ -47,10 +47,11 @@ package Alire.Config.Edit is
    --  * Default per-platform path (see alire-platforms-*)
 
    function Cache_Path return Absolute_Path;
-   --  The location for data that will be recreated if missing; defaults to
-   --  Platforms.Folders.Cache; if Path above is overridden, the cache will
-   --  be inside the config folder so as to keep that configuration completely
-   --  isolated.
+   --  The location for data that will be recreated if missing; its value in
+   --  precedence order is:
+   --  1) Config builtin 'cache.dir'
+   --  2) if Path above is overridden, Path/cache
+   --  3) Platforms.Folders.Cache
 
    procedure Set_Path (Path : Absolute_Path);
    --  Override global config folder path

--- a/src/alire/alire-toolchains.adb
+++ b/src/alire/alire-toolchains.adb
@@ -587,7 +587,9 @@ package body Alire.Toolchains is
    ----------
 
    function Path return Absolute_Path
-   is (Config.Edit.Cache_Path / "toolchains");
+   is (if Config.Builtins.Toolchain_Dir.Get /= ""
+       then Config.Builtins.Toolchain_Dir.Get
+       else Config.Edit.Cache_Path / "toolchains");
 
    ------------
    -- Deploy --

--- a/src/alire/alire-toolchains.ads
+++ b/src/alire/alire-toolchains.ads
@@ -130,7 +130,7 @@ package Alire.Toolchains is
 
    function Path return Absolute_Path;
    --  Returns the base folder in which all toolchain releases live, defaults
-   --  to <cache>/toolchains
+   --  to <cache>/toolchains, overridable via config builtin `toolchain.dir`
 
    procedure Deploy (Release  : Releases.Release;
                      Location : Any_Path := Path);

--- a/testsuite/tests/config/cache-relocation/test.py
+++ b/testsuite/tests/config/cache-relocation/test.py
@@ -1,0 +1,36 @@
+"""
+Check cache location overrides in increasing order of precedence.
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+from drivers.helpers import on_windows
+
+if on_windows():
+    drive = "C:"
+else:
+    drive = ""
+
+# Default cache location (inside test config dir)
+assert_match(r".*cache folder:[^\n]*config__cache-relocation/alr-config/cache",
+             run_alr("version").out.replace("\\", "/"))
+
+# Check toolchain location inside cache location
+assert_match(r".*toolchain folder:[^\n]*config__cache-relocation/alr-config/cache/toolchains",
+             run_alr("version").out.replace("\\", "/"))
+
+# Override via config (takes precedence)
+run_alr("config", "--global", "--set", "cache.dir", f"{drive}/relocated-to-root")
+assert_match(r".*cache folder:[^\n]*/relocated-to-root",
+             run_alr("version").out.replace("\\", "/"))
+
+# Check toolchain location inside cache location
+assert_match(r".*toolchain folder:[^\n]*/relocated-to-root/toolchains",
+             run_alr("version").out.replace("\\", "/"))
+
+# Check toolchain override via config (takes precedence over cache override)
+run_alr("config", "--global", "--set", "toolchain.dir", f"{drive}/relocated-toolchains")
+assert_match(r".*toolchain folder:[^\n]*/relocated-toolchains",
+             run_alr("version").out.replace("\\", "/"))
+
+print("SUCCESS")

--- a/testsuite/tests/config/cache-relocation/test.yaml
+++ b/testsuite/tests/config/cache-relocation/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+build_mode: both  # one of shared, sandboxed, both (default)
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
Since toolchains are also stored in the cache, a separate override is also available.