### PR TITLE
Don't try to obtain the parent dir of '/' in tmp cleanup

### DIFF
--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -1,5 +1,6 @@
 with AAA.Directories;
 
+with Ada.Directories.Hierarchical_File_Names;
 with Ada.Numerics.Discrete_Random;
 with Ada.Real_Time;
 with Ada.Unchecked_Conversion;
@@ -749,11 +750,21 @@ package body Alire.Directories is
       --  Remove temp dir if empty to keep things tidy, and avoid modifying
       --  lots of tests, but only when within <>/alire/tmp
 
-      if Ada.Directories.Simple_Name (Parent (Parent (This.Filename))) =
-        Paths.Working_Folder_Inside_Root
-      then
-         AAA.Directories.Remove_Folder_If_Empty (Parent (This.Filename));
-      end if;
+      begin
+         if not Adirs.Hierarchical_File_Names.Is_Root_Directory_Name
+            (Parent (This.Filename))
+           and then
+             Adirs.Simple_Name (Parent (Parent (This.Filename))) =
+               Paths.Working_Folder_Inside_Root
+         then
+            AAA.Directories.Remove_Folder_If_Empty (Parent (This.Filename));
+         end if;
+      exception
+         when Use_Error =>
+            --  May be raised by Adirs.Containing_Directory
+            Trace.Debug ("Failed to identify location of temp file: "
+                         & This.Filename);
+      end;
 
    exception
       when E : others =>


### PR DESCRIPTION
Fixes #1608.

Note that to reach that point you must have permissions to create a temp file at a filesystem root and having an environment without `TMP` or equivalent, so this won't affect regular users, but might arise in bare-bones testing environments running as root.