### PR TITLE
Override distro via config key

### DIFF
--- a/src/alire/alire-config-builtins.ads
+++ b/src/alire/alire-config-builtins.ads
@@ -1,3 +1,5 @@
+with Alire.Config.Checks;
+
 package Alire.Config.Builtins is
 
    subtype Builtin is Builtin_Option;
@@ -32,12 +34,24 @@ package Alire.Config.Builtins is
       & "location inside the global cache. When false, "
       & "dependencies are sandboxed in each workspace.");
 
+   --  DISTRIBUTION
+
    Distribution_Disable_Detection : constant Builtin := New_Builtin
      (Key  => "distribution.disable_detection",
       Def  => False,
       Help =>
         "If true, Alire will report an unknown distribution and will not"
-      & " attempt to use the system package manager.");
+      & " attempt to use the system package manager. Takes precedence over "
+      & " distribution.override.");
+
+   Distribution_Override          : constant Builtin := New_Builtin
+     (Key   => "distribution.override",
+      Kind  => Cfg_String,
+      Check => Checks.Valid_Distro'Access,
+      Def   => "",
+      Help  =>
+        "Distribution name to be used instead of autodetection. No effect if "
+      & "distribution.disable_detection is True.");
 
    --  EDITOR
 

--- a/src/alire/alire-config-checks.adb
+++ b/src/alire/alire-config-checks.adb
@@ -1,0 +1,20 @@
+with AAA.Enum_Tools;
+
+with Alire.Platforms;
+
+package body Alire.Config.Checks is
+
+   function Is_Valid is
+     new AAA.Enum_Tools.Is_Valid (Alire.Platforms.Known_Distributions);
+
+   ------------------
+   -- Valid_Distro --
+   ------------------
+
+   function Valid_Distro (Key   : CLIC.Config.Config_Key;
+                          Value : TOML.TOML_Value)
+                          return Boolean
+   is (Value.Kind in TOML.TOML_String
+       and then Is_Valid (Value.As_String));
+
+end Alire.Config.Checks;

--- a/src/alire/alire-config-checks.ads
+++ b/src/alire/alire-config-checks.ads
@@ -1,0 +1,9 @@
+with TOML;
+
+package Alire.Config.Checks is
+
+   function Valid_Distro (Key   : CLIC.Config.Config_Key;
+                          Value : TOML.TOML_Value)
+                          return Boolean;
+
+end Alire.Config.Checks;

--- a/src/alire/alire-warnings.adb
+++ b/src/alire/alire-warnings.adb
@@ -26,4 +26,18 @@ package body Alire.Warnings is
    function Already_Warned (Id : Warning_Id) return Boolean
    is (Already_Emitted.Contains (String (Id)));
 
+   ----------------------
+   -- Warn_With_Result --
+   ----------------------
+
+   function Warn_With_Result (Text   : String;
+                  Result : Returned;
+                  Level  : Trace.Levels := Trace.Warning)
+                  return Returned
+   is
+   begin
+      Trace.Log (Text, Level);
+      return Result;
+   end Warn_With_Result;
+
 end Alire.Warnings;

--- a/src/alire/alire-warnings.ads
+++ b/src/alire/alire-warnings.ads
@@ -14,6 +14,15 @@ package Alire.Warnings with Preelaborate is
    function Already_Warned (Id : Warning_Id) return Boolean;
    --  Says if a warning has been already emitted in the current run
 
+   generic
+      type Returned (<>) is private;
+   function Warn_With_Result (Text   : String;
+                              Result : Returned;
+                              Level  : Trace.Levels := Trace.Warning)
+                              return Returned;
+   --  Return Result after printing Text; for use in expressions. See instances
+   --  in Alire.Warnings.Typed.
+
    ------------------
    --  Defined Ids --
    ------------------

--- a/testsuite/tests/config/distro-override/test.py
+++ b/testsuite/tests/config/distro-override/test.py
@@ -1,0 +1,23 @@
+"""
+Verify that distro overridding works as intended
+"""
+
+from drivers.alr import run_alr, distro_is_known
+from drivers.asserts import assert_match
+
+# Overriding distro detection. We force Debian as our tests run in Ubuntu and
+# many other distros so it is only giving a false positive on Debian.
+run_alr("config", "--global",
+        "--set", "distribution.override", "debian")
+
+assert_match(".*distribution:[^\n]*DEBIAN",
+             run_alr("version").out)
+
+# Disabling distro detection takes precedence
+run_alr("config", "--global",
+        "--set", "distribution.disable_detection", "true")
+
+assert_match(".*distribution:[^\n]*DISTRIBUTION_UNKNOWN",
+             run_alr("version").out)
+
+print('SUCCESS')

--- a/testsuite/tests/config/distro-override/test.yaml
+++ b/testsuite/tests/config/distro-override/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
Rather than adding more environment variables, that has the problems stated in #1368, use a configuration builtin.

Supersedes #1368.