### PR TITLE
Remove .md extension from internal documentation links (Fixes #893)

### DIFF
--- a/doc/catalog-format-spec.md
+++ b/doc/catalog-format-spec.md
@@ -1169,7 +1169,7 @@ project My_Crate is
 
 Dependencies in Alire are used also to deal with compiler versions and
 cross-compilers. Also related is the information on toolchains available in the
-[Toolchain management](./toolchains.md) document or via `alr help toolchains`.
+[Toolchain management](toolchains) document or via `alr help toolchains`.
 
 ### Excluding compiler versions
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -293,9 +293,9 @@ not an error) with `-q`, which enables quiet mode. Any subprocess that exist
 abnormally will be reported, including its invocation arguments.
 
 If you suspect your configuration may be the source of some problem, please
-check our section on [Configuration](configuration.md), and in particular how
+check our section on [Configuration](configuration), and in particular how
 to use a [default pristine
-configuration](configuration.md#Relocating-your-configuration)
+configuration](configuration#Relocating-your-configuration)
 
 ## Running tests
 

--- a/doc/policies.md
+++ b/doc/policies.md
@@ -60,7 +60,7 @@ major/minor/patch/build version changes), but not modified.
   - Tests, demos, examples, etc., can be provided in nested crates so they can
     be conveniently used locally when needed without causing extra build load
     on clients. See the documentation on
-    [local pins](catalog-format-spec.md#using-pins-for-crate-testing) for
+    [local pins](catalog-format-spec#using-pins-for-crate-testing) for
     details.
 
   - The manifests of these nested crates need not to be published to the

--- a/doc/publishing.md
+++ b/doc/publishing.md
@@ -57,7 +57,7 @@ crate and version it contains. A file contains the description of a release,
 with other metadata.
 
 The complete specification of such TOML files is available in this
-[document](catalog-format-spec.md).
+[document](catalog-format-spec).
 
 ## New crates and releases
 
@@ -88,7 +88,7 @@ release of `alr`.
 
 Each crate is "owned" by a list of maintainers, provided with the
 `maintainers-logins` property of the crate file. After the initial submission,
-which will be manually approved (see the [policies](policies.md) for details),
+which will be manually approved (see the [policies](policies) for details),
 the maintainers of a crate are the only people allowed to submit new releases
 or metadata modifications to the corresponding crate.
 
@@ -100,7 +100,7 @@ Other checks your submission will go through are:
 
 ## Best practices
 
-See the section on [best practices](policies.md#best-practices) for crates
+See the section on [best practices](policies#best-practices) for crates
 before publishing your first release.
 
 ## Detailed steps

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -153,8 +153,8 @@ be reviewed and merged manually. This can now be done with `alr publish
 
 PR [#1406](https://github.com/alire-project/alire/pull/1406)
 
-A pending submission can be closed with `alr publish --cancel
-<num> --reason <text>`.
+A pending submission can be closed with
+`alr publish --cancel <num> --reason <text>`.
 
 ### Track user's index submissions with `alr publish --status`
 
@@ -697,8 +697,8 @@ crate_1.var2 = true
 crate_2.var1 = "Debug"
 ```
 
-Check more examples and details in the catalog specification section ["Using
-configuration"](https://github.com/mosteo/alire/blob/master/doc/catalog-format-spec.md#using-crate-configuration).
+Check more examples and details in the catalog specification section
+[Using configuration](catalog-format-spec#using-crate-configuration).
 
 ## Release `1.0`
 
@@ -823,7 +823,7 @@ to be submitted to the community index via pull request. An upload link is
 provided for convenience that can be used to create this pull request.
 
 Complete information about this feature is available in the updated
-[Publishing](publishing.md) page.
+[Publishing](publishing) page.
 
 Other features of the assistant are that, in the local mode, a branch or tag
 can be specified to pinpoint a commit, and that the test build of the crate can
@@ -847,8 +847,8 @@ files, executables, maintainers, etc.).
 The manifest internal format has been simplified by eliminating the possibility
 of multiple releases from its contents, which removes some nesting, and
 removing or making optional some fields that only make sense at the time of
-publishing a crate to some index. Check the [catalog-format-spec.md] file for
-details.
+publishing a crate to some index. Check the [catalog-format-spec](catalog-format-spec)
+file for details.
 
 The `alire` directory continues to exist, and it is used to store the source
 code of dependencies, local configuration and backup files. It can be safely


### PR DESCRIPTION
Fixes the broken toolchain.md link by removing the .md extension and ./ prefix.

I also changed all of the other internal documentation links with .md extensions for consistency.

There was a syntax error caused by a line break under PR 1406 in user-changes.md that broke formatting of old changelogs, so I fixed this as well.

Tested with local jekyll build.