### PR TITLE
Clarify remark about `--force` in `alr install --help`

### DIFF
--- a/src/alr/alr-commands-install.adb
+++ b/src/alr/alr-commands-install.adb
@@ -122,8 +122,8 @@ package body Alr.Commands.Install is
          & "templates, should be able to coexist in a same installation prefix"
          & " without issue.")
        .New_Line
-       .Append ("You can use the --force to reinstall already installed "
-         & "releases.")
+       .Append ("You can use the --force global option to reinstall "
+         & "already installed releases.")
       );
 
    --------------------


### PR DESCRIPTION
Since it affects the place where the argument can be used, the user has to be aware of that.