### PR TITLE
Handle config switch errors on missing parameter

### DIFF
--- a/testsuite/tests/config/missing-config-path/test.py
+++ b/testsuite/tests/config/missing-config-path/test.py
@@ -1,0 +1,18 @@
+"""
+Verify that errors are properly handled when no config path is given
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_match
+
+import re
+
+p = run_alr("--config", complain_on_error=False)
+assert p.status != 0, "command should fail"
+assert_match("ERROR: Switch --config requires argument.*", p.out, flags=re.S)
+
+p = run_alr("-c", complain_on_error=False)
+assert p.status != 0, "command should fail"
+assert_match("ERROR: Switch -c requires argument.*", p.out, flags=re.S)
+
+print('SUCCESS')

--- a/testsuite/tests/config/missing-config-path/test.yaml
+++ b/testsuite/tests/config/missing-config-path/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    basic_index: {}


### PR DESCRIPTION
Both `alr -c` and `alr --config` throw exceptions because a required parameter is missing.

This fix handle missing parameter of config switch in the same way as, for example, `alr -C` and `alr --chdir`: an error message informs the user that a required parameter is missing.
