### PR TITLE
Missing dependencies in testsuite documentation.

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -2,9 +2,9 @@ Alire/ALR's testsuite
 =====================
 
 This directory intends to host a comprehensive testsuite for Alire/ALR as a
-library/tool. The testsuite framework currently requires a Python 3
-interpreter with the [e3-testsuite](https://e3-testsuite.readthedocs.io) and
-[pexpect](https://pexpect.readthedocs.io) packages (from PyPI) installed.
+library/tool. The testsuite framework currently requires a Python 3 interpreter
+with the [e3-testsuite](https://e3-testsuite.readthedocs.io) package (from PyPI)
+installed.
 
 You also must have [GNAT](https://www.gnu.org/software/gnat) and
 [GPRBuild](https://github.com/AdaCore/gprbuild) in your `PATH`. You can install
@@ -28,7 +28,7 @@ $ virtualenv my-virtual-env
 $ source my-virtual-env/bin/activate
 
 # Install e3-testsuite and all its dependencies
-$ pip install e3-testsuite pexpect
+$ pip install -r requirements.txt
 
 # You should now be able to run the testsuite (make sure you built alr and
 # made it available with your PATH):

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -2,9 +2,9 @@ Alire/ALR's testsuite
 =====================
 
 This directory intends to host a comprehensive testsuite for Alire/ALR as a
-library/tool. The testsuite framework currently requires a Python 3 interpreter
-with the [e3-testsuite](https://e3-testsuite.readthedocs.io) package (from PyPI)
-installed.
+library/tool. The testsuite framework currently requires a Python 3
+interpreter with the [e3-testsuite](https://e3-testsuite.readthedocs.io) and
+[pexpect](https://pexpect.readthedocs.io) packages (from PyPI) installed.
 
 You also must have [GNAT](https://www.gnu.org/software/gnat) and
 [GPRBuild](https://github.com/AdaCore/gprbuild) in your `PATH`. You can install
@@ -28,7 +28,7 @@ $ virtualenv my-virtual-env
 $ source my-virtual-env/bin/activate
 
 # Install e3-testsuite and all its dependencies
-$ pip install e3-testsuite
+$ pip install e3-testsuite pexpect
 
 # You should now be able to run the testsuite (make sure you built alr and
 # made it available with your PATH):


### PR DESCRIPTION
Required package `pexpect` is not installed as a dependency of `e3-testsuite`, so is has to be explicitly installed.

Neither `e3-testsuite` nor `e3-core` depend on it:

```
$ pip show e3-testsuite e3-core
Name: e3-testsuite
Version: 26.0
Summary: E3 testsuite
Home-page:
Author: AdaCore
Author-email: info@adacore.com
License: GPLv3
Location: /home/ada/opt/alire/venv/lib/python3.10/site-packages Requires: e3-core
Required-by:
---
Name: e3-core
Version: 22.4.0
Summary: E3 core. Tools and library for building and testing software Home-page: https://github.com/AdaCore/e3-core
Author: AdaCore
Author-email: info@adacore.com
License: GPLv3
Location: /home/ada/opt/alire/venv/lib/python3.10/site-packages Requires: colorama, ld, packaging, psutil, python-dateutil, pyyaml, requests, requests-cache, requests-toolbelt, setuptools, stevedore, tqdm
Required-by: e3-testsuite
```