### PR TITLE
More conventional location for settings on Windows

### DIFF
--- a/src/alire/os_windows/alire-platforms-folders__windows.adb
+++ b/src/alire/os_windows/alire-platforms-folders__windows.adb
@@ -18,14 +18,16 @@ package body Alire.Platforms.Folders is
    -----------
 
    function Cache return Absolute_Path
-   is (OS_Lib.Getenv ("LocalAppData", Home / ".local" / "share")
-       / "alire");
+   is (OS_Lib.Getenv ("LocalAppData", Home / "AppData" / "Local")
+       / "alire" / "cache");
 
    ------------
    -- Config --
    ------------
 
-   function Config return Absolute_Path is (Home / ".config" / "alire");
+   function Config return Absolute_Path
+   is (OS_Lib.Getenv ("LocalAppData", Home / "AppData" / "Local")
+       / "alire" / "settings");
 
    ----------
    -- Temp --

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -56,7 +56,8 @@ def prepare_env(config_dir, env):
         # tests that need it.
         run_alr("-c", config_dir, "settings", "--global",
                 "--set", "msys2.install_dir",
-                os.path.join(os.environ.get("LocalAppData"), "alire", "msys64"))
+                os.path.join(
+                    os.environ.get("LocalAppData"), "alire", "cache", "msys64"))
 
     # Disable autoconfig of the community index, to prevent unintended use of
     # it in tests, besides the overload of fetching it


### PR DESCRIPTION
I couldn't find a more usual location than this one (excluding the registry ofc). See e.g. [here](https://learn.microsoft.com/en-us/windows/apps/design/app-settings/store-and-retrieve-app-data).

To avoid mixing top levels, also nest the cache to its own subdir.