### PR TITLE
Classify builds by release milestone

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -12,7 +12,10 @@ on:
   workflow_dispatch:
 
 env:
-  ALIRE_OS: "windows"
+  ALIRE_OS:     windows
+  MINGW64_PATH: C:\Users\runneradmin\AppData\Local\alire\cache\msys64\mingw64\bin
+  MSYS2_PATH:   C:\Users\runneradmin\AppData\Local\alire\cache\msys64\usr\bin
+  PACMAN:       C:\Users\runneradmin\AppData\Local\alire\cache\msys64\usr\bin\pacman --noconfirm
 
 jobs:
 
@@ -35,11 +38,11 @@ jobs:
     - name: Build alr
       run: gprbuild -j0 -p -P alr_env
 
-    - name: alr first run to install msys2
-      run: ./bin/alr --non-interactive help get
+    - name: Display built alr and trigger install of msys2
+      run: ./bin/alr version
 
     - name: install tar from msys2 (Git tar in Actions VM does not seem to work)
-      run: C:\Users\runneradmin\AppData\Local\alire\msys64\usr\bin\pacman --noconfirm -S tar
+      run: ${{env.PACMAN}} -S tar
 
     - name: Install Python 3.x (required for the testsuite)
       uses: actions/setup-python@v2
@@ -57,17 +60,17 @@ jobs:
       run: gprinstall -p -P alr_env --prefix=${{ runner.temp }}/alr_install
 
     - name: Install qt-installer-framework in msys2
-      run: C:\Users\runneradmin\AppData\Local\alire\msys64\usr\bin\pacman --noconfirm -S mingw64/mingw-w64-x86_64-qt-installer-framework
+      run: ${{env.PACMAN}} -S mingw64/mingw-w64-x86_64-qt-installer-framework
 
     - name: Add msys2 /mingw64/bin to the path (for qt-installer-framework)
-      run: echo 'C:\Users\runneradmin\AppData\Local\alire\msys64\mingw64\bin' >> $GITHUB_PATH
+      run: echo '${{env.MINGW64_PATH}}' >> $GITHUB_PATH
       shell: bash
 
     - name: Install zip in msys2
-      run: C:\Users\runneradmin\AppData\Local\alire\msys64\usr\bin\pacman --noconfirm -S zip
+      run: ${{env.PACMAN}} --noconfirm -S zip
 
     - name: Add msys2 /usr/bin to the path (for zip)
-      run: echo 'C:\Users\runneradmin\AppData\Local\alire\msys64\usr\bin' >> $GITHUB_PATH
+      run: echo '${{env.MSYS2_PATH}}' >> $GITHUB_PATH
       shell: bash
 
     - name: Run installer build script

--- a/src/alire/alire-builds.adb
+++ b/src/alire/alire-builds.adb
@@ -97,9 +97,8 @@ package body Alire.Builds is
    is
       Base : constant Absolute_Path :=
                Builds.Path
-                 / (Release.Deployment_Folder
-                    & "_"
-                    & Root.Build_Hash (Release.Name));
+                 / Release.Deployment_Folder
+                 / Root.Build_Hash (Release.Name);
    begin
       if Subdir and then Release.Origin.Is_Monorepo then
          return Base / Release.Origin.Subdir;

--- a/testsuite/drivers/asserts.py
+++ b/testsuite/drivers/asserts.py
@@ -7,6 +7,7 @@ import difflib
 import os
 import re
 import difflib
+import sys
 
 from drivers.alr import run_alr
 from drivers.helpers import contents, lines_of

--- a/testsuite/drivers/builds.py
+++ b/testsuite/drivers/builds.py
@@ -34,27 +34,21 @@ def are_shared() -> bool:
         return False
 
 
-def clear_builds_dir() -> None:
-    """
-    Clear the shared build directory
-    """
-    rmtree(path())
-
-
 def find_dir(crate_name: str) -> str:
     """
-    Find the build dir of a crate in the shared build directory
+    Find the build dir of a crate in the shared build directory. It always uses
+    forward slashes in the returned folder path.
     """
-    if len(found := glob(f"{path()}/{crate_name}_*")) != 1:
+    if len(found := glob(f"{path()}/{crate_name}*/*")) != 1:
         raise AssertionError(f"Unexpected number of dirs for crate {crate_name}: {found}")
-    return glob(f"{path()}/{crate_name}_*")[0]
+    return glob(f"{path()}/{crate_name}*/*")[0].replace(os.sep, "/")
 
 
 def find_hash(crate_name: str) -> str:
     """
     Find the hash of a crate in the shared build directory
     """
-    return find_dir(crate_name).split("_")[-1]
+    return find_dir(crate_name).split("/")[-1]
 
 
 def hash_input(crate_name: str, as_lines: bool=False) -> str:

--- a/testsuite/tests/dockerized/misc/default-cache/test.py
+++ b/testsuite/tests/dockerized/misc/default-cache/test.py
@@ -49,7 +49,7 @@ run_alr("build", complain_on_error=False)
 # procedures)
 hash = "0774083df8ff003084c32cabdec6090a58b41c6be317cec0475df5eacbca0d23"
 assert \
-    os.path.isdir(f"{base}/builds/crate_real_1.0.0_filesystem_{hash}"), \
+    os.path.isdir(f"{base}/builds/crate_real_1.0.0_filesystem/{hash}"), \
     f"Shared build not found at the expected location: f{contents(base)}"
 
 print('SUCCESS')

--- a/testsuite/tests/pin/downgrade/test.py
+++ b/testsuite/tests/pin/downgrade/test.py
@@ -27,7 +27,7 @@ def check_child(version, output, pinned):
     # Verify dependency folders
     if builds.are_shared():
         run_alr('update')  # force hash computation
-        assert builds.find_dir('libchild_' + version + '_filesystem')
+        assert builds.find_dir('libchild_' + version)
     else:
         assert os.path.exists('alire/cache/dependencies/libchild_' + version +
                             '_filesystem')

--- a/testsuite/tests/settings/shared-deps/test.py
+++ b/testsuite/tests/settings/shared-deps/test.py
@@ -41,12 +41,12 @@ assert_contents(base := os.path.join(vault_dir, "hello_1.0.1_filesystem"),
 # because no build has been attempted yet, hence a sync has not been performed.
 # And, since there's no sync yet, neither the build dir exists:
 
-assert len(glob.glob(os.path.join(build_dir, "hello_1.0.1_filesystem_*"))) == 0, \
+assert len(glob.glob(os.path.join(build_dir, "hello_1.0.1_filesystem/*"))) == 0, \
     "Build dir should not exist yet"
 
 # Do a build, and now the sync should have happened and the build dir be filled
 run_alr("build")
-base = builds.find_dir("hello_1.0.1_filesystem")
+base = builds.find_dir("hello")
 
 # There's too much object files and the like, check a few critical files:
 files = contents(base)  # This returns "normalized" paths (with '/' separators)


### PR DESCRIPTION
This is a minor change in foreseeing that the builds folder could grow to be unmanageable pretty quickly. 

Previously, all builds of all crates were at the same level, now they're classified by release:

Before:
```
cache/
   releases/
      crate_0.1.0_feadfead/
      hello_1.0.0_abcdabcd/
   builds/
      crate_0.1.0_feadfead_abdcabdcabdcabdcabdcabdcabdcabdc/
      hello_1.0.0_abcdabcd_abcdabcdabcdabcdabcdabcdabcdabcd/
      hello_1.0.0_abcdabcd_bcdabcdabcdabcdabcdabcdabcdabcda/
```
After:
```
cache/
   releases/
      crate_0.1.0_feadfead/
      hello_1.0.0_abcdabcd/
   builds/
      crate_0.1.0_feadfead/
         abdcabdcabdcabdcabdcabdcabdcabdc/
      hello_1.0.0_abcdabcd/
         abcdabcdabcdabcdabcdabcdabcdabcd/
         bcdabcdabcdabcdabcdabcdabcdabcda/
```