### PR TITLE
Don't say unknown crate for abstract crates in `alr get`

### DIFF
--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -12,6 +12,8 @@ with Alire.Solutions.Diffs;
 with Alire.Solver;
 with Alire.Utils.Switches;
 
+with Alr.Common;
+
 with CLIC.User_Input;
 
 with Semantic_Versioning.Extended;
@@ -341,8 +343,16 @@ package body Alr.Commands.Get is
          Cmd.Auto_Update_Index;
 
          if not Alire.Index.Exists (Allowed.Crate) then
-            Reportaise_Command_Failed
-              ("Crate [" & Args (1) & "] does not exist in the index.");
+            --  Even if the crate does not exist, it may be an abstract crate
+            --  provided by some others (e.g. gnat -> gnat_native), so inform
+            --  about it rather than saying it doesn't exist.
+            if Common.Show_Providers (Allowed) then
+               return;
+            else
+               Reportaise_Command_Failed
+                 ("Crate [" & Allowed.Crate.As_String
+                  & "] does not exist in the index.");
+            end if;
          end if;
 
          Check_Unavailable_External (Allowed.Crate);

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -11,7 +11,8 @@ with Alire.Roots.Optional;
 with Alire.Solutions;
 with Alire.Solver;
 with Alire.Utils.Tables;
-with Alire.Utils.TTY;
+
+with Alr.Common;
 
 with Semantic_Versioning.Extended;
 
@@ -248,27 +249,6 @@ package body Alr.Commands.Show is
                        (Name, Versions).TTY_Image);
    end Report_Jekyll;
 
-   --------------------
-   -- Show_Providers --
-   --------------------
-
-   function Show_Providers (Dep : Alire.Dependencies.Dependency) return Boolean
-   is
-      use Alire;
-   begin
-      if Index.All_Crate_Aliases.Contains (Dep.Crate) then
-         Trace.Info ("Crate " & Utils.TTY.Name (Dep.Crate) & " is abstract and"
-                     & " provided by:");
-         for Provider of Index.All_Crate_Aliases.all (Dep.Crate) loop
-            Trace.Info ("   " & Utils.TTY.Name (Provider));
-         end loop;
-
-         return True;
-      else
-         return False;
-      end if;
-   end Show_Providers;
-
    -------------
    -- Execute --
    -------------
@@ -310,7 +290,7 @@ package body Alr.Commands.Show is
             --  Even if the crate does not exist, it may be an abstract crate
             --  provided by some others (e.g. gnat_native -> gnat).
 
-            if Show_Providers (Allowed) then
+            if Common.Show_Providers (Allowed) then
                return;
             else
                raise Alire.Query_Unsuccessful;

--- a/src/alr/alr-common.adb
+++ b/src/alr/alr-common.adb
@@ -1,0 +1,27 @@
+with Alire.Index;
+with Alire.Utils.TTY;
+
+package body Alr.Common is
+
+   --------------------
+   -- Show_Providers --
+   --------------------
+
+   function Show_Providers (Dep : Alire.Dependencies.Dependency) return Boolean
+   is
+      use Alire;
+   begin
+      if Index.All_Crate_Aliases.Contains (Dep.Crate) then
+         Trace.Always ("Crate " & Utils.TTY.Name (Dep.Crate)
+                       & " is abstract and provided by:");
+         for Provider of Index.All_Crate_Aliases.all (Dep.Crate) loop
+            Trace.Always ("   " & Utils.TTY.Name (Provider));
+         end loop;
+
+         return True;
+      else
+         return False;
+      end if;
+   end Show_Providers;
+
+end Alr.Common;

--- a/src/alr/alr-common.ads
+++ b/src/alr/alr-common.ads
@@ -1,0 +1,10 @@
+with Alire.Dependencies;
+
+package Alr.Common is
+
+   --  Some reusable bits across commands
+
+   function Show_Providers (Dep : Alire.Dependencies.Dependency)
+                            return Boolean;
+
+end Alr.Common;

--- a/testsuite/tests/get/provides/test.py
+++ b/testsuite/tests/get/provides/test.py
@@ -1,0 +1,26 @@
+"""
+Test the output of `alr get` for an abstract crate
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq
+
+# gnat does not contain releases but several other crates provide it, so rather
+# than saying that the crate doesn't exist, show its providers:
+
+assert_eq("""Crate gnat is abstract and provided by:
+   gnat_cross_1
+   gnat_cross_2
+   gnat_external
+   gnat_native
+""",
+          run_alr("get", "gnat", "--dirname").out)
+
+# Check the error for a truly unknown crate:
+
+assert_eq("""\
+ERROR: Crate [unobtanium] does not exist in the index.
+""",
+          run_alr("get", "unobtanium", "--dirname", complain_on_error=False).out)
+
+print('SUCCESS')

--- a/testsuite/tests/get/provides/test.yaml
+++ b/testsuite/tests/get/provides/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+indexes:
+    toolchain_index:
+        in_fixtures: true


### PR DESCRIPTION
Instead, show it's concrete providers, just like we do in `alr show`.