### PR TITLE
Rename option arguments to indicate expected type

### DIFF
--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -273,13 +273,15 @@ package body Alr.Commands.Build is
         (Config,
          Cmd.Profiles'Access,
          "", Switch_Profiles & "=",
-         "Comma-separated list of <crate>=<profile> values (see description)");
+         "Comma-separated list of <crate>=<profile> values (see description)",
+         Argument => "LIST");
 
       Define_Switch
         (Config,
          Cmd.Stop_After'Access,
          "", Switch_Stop & "=",
-         "Build stage after which to stop (see description)");
+         "Build stage after which to stop (see description)",
+         Argument => "STAGE");
 
    end Setup_Switches;
 

--- a/src/alr/alr-commands-edit.adb
+++ b/src/alr/alr-commands-edit.adb
@@ -276,7 +276,8 @@ package body Alr.Commands.Edit is
                      Cmd.Prj'Access,
                      "", "--project=",
                      "Select the project file to open if the crate " &
-                       "provides multiple project files, ignored otherwise");
+                       "provides multiple project files, ignored otherwise",
+                     Argument => "FILE");
       Define_Switch (Config,
                      Cmd.Set'Access,
                      "", "--select-editor",

--- a/src/alr/alr-commands-exec.adb
+++ b/src/alr/alr-commands-exec.adb
@@ -123,7 +123,8 @@ package body Alr.Commands.Exec is
         (Config,
          Cmd.Prj'Access,
          Switch => "-P?",
-         Help => "Add ""-P <PROJECT_FILE>"" to the command switches");
+         Help => "Add ""-P <PROJECT_FILE>"" to the command switches",
+         Argument => "NUM");
    end Setup_Switches;
 
 end Alr.Commands.Exec;

--- a/src/alr/alr-commands-install.adb
+++ b/src/alr/alr-commands-install.adb
@@ -141,7 +141,8 @@ package body Alr.Commands.Install is
                      Cmd.Prefix'Access,
                      "", "--prefix=",
                      "Override installation prefix (default is "
-                     & TTY.URL (Alire.Install.Default_Prefix) & ")");
+                     & TTY.URL (Alire.Install.Default_Prefix) & ")",
+                     Argument => "DIR");
 
       Define_Switch (Config,
                      Cmd.Info'Access,

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -151,7 +151,8 @@ package body Alr.Commands.Publish is
         (Config,
          Cmd.Manifest'Access,
          "", "--manifest=",
-         "Selects a manifest file other than ./alire.toml");
+         "Selects a manifest file other than ./alire.toml",
+         Argument => "FILE");
 
       Define_Switch
         (Config,

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -364,8 +364,8 @@ package body Alr.Commands.Show is
       Define_Switch (Config,
                      Cmd.Dependents'Access,
                      "", "--dependents?",
-                     "Show dependent crates (ARG=direct|shortest|all)",
-                     Argument => "=ARG");
+                     "Show dependent crates (WHICH=direct|shortest|all)",
+                     Argument => "=WHICH");
 
       Define_Switch (Config,
                      Cmd.Detail'Access,

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -153,12 +153,14 @@ package body Alr.Commands is
       Define_Switch (Config,
                      Command_Line_Config_Path'Access,
                      "-s=", "--settings=",
-                     "Override settings folder location");
+                     "Override settings folder location",
+                     Argument => "DIR");
 
       Define_Switch (Config,
                      Command_Line_Chdir_Target_Path'Access,
                      "-C=", "--chdir=",
-                     "Run `alr` in the given directory");
+                     "Run `alr` in the given directory",
+                     Argument => "DIR");
 
       Define_Switch (Config,
                      Alire.Force'Access,


### PR DESCRIPTION
In commands with options that admit arguments, like `--prefix` in `alr install`, is useful to provide an argument name in the command help that gives a hint of the expected type.

For example, `alr install -h` shows the message:
```
OPTIONS
   --prefix=ARG   Override installation prefix (default is ...)
```

When changed to:
```
OPTIONS
   --prefix=DIR   Override installation prefix (default is ...)
```
the `DIR` name of the argument immediately says what is expected in this option. In cases where this is not so obvious, it helps even more.

For example, in `alr build -h`:
```
OPTIONS
   --profiles=LIST     Comma-separated list of <crate>=<profile> values (see description)
   --stop-after=STAGE  Build stage after which to stop (see description)
```
is a quick remainder of what is expected in that options.
