### PR TITLE
dev: control build jobs with $ALIRE_BUILD_JOBS

### DIFF
--- a/dev/build.sh
+++ b/dev/build.sh
@@ -5,7 +5,8 @@ pushd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) > /de
     . functions.sh
 popd > /dev/null
 
+ALIRE_BUILD_JOBS="${ALIRE_BUILD_JOBS:-0}"
 export ALIRE_OS=$(get_OS)
 
-echo Building with ALIRE_OS=$ALIRE_OS...
-gprbuild -j0 -r -p -P `dirname $0`/../alr_env.gpr "$@"
+echo "Building with ALIRE_OS=$ALIRE_OS..."
+gprbuild "-j$ALIRE_BUILD_JOBS" -r -p -P `dirname $0`/../alr_env.gpr "$@"


### PR DESCRIPTION
This is just a minor quality-of-life improvement for packaging. Note that this also quotes the argument to echo so that if (somehow) $ALIRE_OS were set to a malicious value, no harm could be done.

By the way, congratulations on 2.0.0! Thanks so much :)