### PR TITLE
Fix nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,9 @@ jobs:
         submodules: true
 
     - name: Install FSF toolchain
-      uses: alire-project/setup-alire@v3
+      uses: alire-project/alr-install@v1
+      with:
+        crates: gnat_native gprbuild
 
     - name: Install Python 3.x (required for the testsuite)
       uses: actions/setup-python@v2


### PR DESCRIPTION
That were relying on a compiler not explicitly installed; now we use latest FSF GNAT explicitly.

Tested [here](https://github.com/mosteo/alire/actions/runs/8372310503).