### PR TITLE
Fix non-ASCII char used when --no-color in effect

### DIFF
--- a/src/alire/alire-solutions-diffs.adb
+++ b/src/alire/alire-solutions-diffs.adb
@@ -45,18 +45,18 @@ package body Alire.Solutions.Diffs is
              when Missing    => TTY.Error (U ("❗")), -- alts: ⚠️❗‼️
              when Binary     => TTY.Warn  (U ("📦")),
              when Info       => TTY.Emph  (U ("🛈")))
-       else
+       else "" &
          (case Change is
-             when Added      => U ("+"),
-             when Removed    => U ("-"),
-             when Upgraded   => U ("^"),
-             when Downgraded => U ("v"),
-             when Pinned     => U ("·"),
-             when Unpinned   => U ("o"),
-             when Unchanged  => U ("="),
-             when Missing    => U ("!"),
-             when Binary     => U ("b"),
-             when Info       => U ("i")
+             when Added      => '+',
+             when Removed    => '-',
+             when Upgraded   => '^',
+             when Downgraded => 'v',
+             when Pinned     => '.',
+             when Unpinned   => 'o',
+             when Unchanged  => '=',
+             when Missing    => '!',
+             when Binary     => 'b',
+             when Info       => 'i'
          ));
 
    --  This type is used to summarize every detected change

--- a/testsuite/tests/pin/change-path/test.py
+++ b/testsuite/tests/pin/change-path/test.py
@@ -38,7 +38,7 @@ p = run_alr("pin", quiet=False)
 assert_eq("""Note: Synchronizing workspace...
 Dependencies automatically updated as follows:
 
-   · yyy 0.1.0-dev (path=../nest2/yyy)
+   . yyy 0.1.0-dev (path=../nest2/yyy)
 
 yyy file:../nest2/yyy\n""",
           p.out)

--- a/testsuite/tests/with/changes-info/test.py
+++ b/testsuite/tests/with/changes-info/test.py
@@ -61,7 +61,7 @@ assert_match(".*" +
 
 Changes to dependency solution:
 
-   +· local_crate unknown (new,path=local_crate)""") + ".*",
+   +. local_crate unknown (new,path=local_crate)""") + ".*",
              p.out, flags=re.S)
 
 ###############################################################################
@@ -70,7 +70,7 @@ p = run_alr('pin', 'libhello', quiet=False)
 assert_match(".*" +
              re.escape("""Changes to dependency solution:
 
-   · libhello 2.0.0 (pin=2.0.0)""") + ".*",
+   . libhello 2.0.0 (pin=2.0.0)""") + ".*",
              p.out, flags=re.S)
 
 ###############################################################################


### PR DESCRIPTION
This was causing improper output on Windows even with `--no-color` and `--no-tty` because '·' (middle dot) isn't in ASCII.