### PR TITLE
New dev/clean.sh

### DIFF
--- a/dev/clean.sh
+++ b/dev/clean.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Import reusable bits
 pushd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd ) > /dev/null || exit 1
     . functions.sh
@@ -5,4 +7,4 @@ popd > /dev/null || exit 1
 
 export ALIRE_OS=$(get_OS)
 
-gnatstudio -P alr_env & >/dev/null 2>&1
+gprclean -f -r -Palr_env.gpr


### PR DESCRIPTION
Also set `ALIRE_OS` before opening GNAT Studio, which seems to fail otherwise in the 2024 release.