### PR TITLE
Ensure index repos can be deleted on Windows

### DIFF
--- a/src/alire/alire-index_on_disk.adb
+++ b/src/alire/alire-index_on_disk.adb
@@ -77,11 +77,11 @@ package body Alire.Index_On_Disk is
    ------------
 
    function Delete (This : Index'Class) return Outcome is
-      use Ada.Directories;
+      package Adirs renames Ada.Directories;
    begin
-      if Exists (This.Metadata_Directory) then
-         if Kind (This.Metadata_Directory) = Ada.Directories.Directory then
-            Delete_Tree (This.Metadata_Directory);
+      if Adirs.Exists (This.Metadata_Directory) then
+         if Adirs.Kind (This.Metadata_Directory) in Adirs.Directory then
+            Directories.Delete_Tree (This.Metadata_Directory);
             Trace.Debug ("Metadata dir deleted: " & This.Metadata_Directory);
          else
             return Outcome_Failure

--- a/src/alire/alire-version.ads
+++ b/src/alire/alire-version.ads
@@ -16,7 +16,7 @@ private
    --  be replaced by `alr build` with the current commit, and appended with
    --  "_or_later" after build.
 
-   Current_Str : constant String := "2.1-dev";
+   Current_Str : constant String := "2.1-dev+bd25511f_or_later";
    --  2.0.0:     alr settings refactor and minor fixes
    --  2.0.0-rc1: release candidate for 2.0
    --  2.0.0-b1:  first public release on the 2.0 branch

--- a/src/alire/alire-version.ads
+++ b/src/alire/alire-version.ads
@@ -16,7 +16,7 @@ private
    --  be replaced by `alr build` with the current commit, and appended with
    --  "_or_later" after build.
 
-   Current_Str : constant String := "2.1-dev+bd25511f_or_later";
+   Current_Str : constant String := "2.1-dev";
    --  2.0.0:     alr settings refactor and minor fixes
    --  2.0.0-rc1: release candidate for 2.0
    --  2.0.0-b1:  first public release on the 2.0 branch


### PR DESCRIPTION
As indexes are git repos, they suffer from the old deletion problem when some internal files are marked read-only by git