### PR TITLE
Made error message more specific.

### DIFF
--- a/src/alire/alire-properties-labeled.adb
+++ b/src/alire/alire-properties-labeled.adb
@@ -144,8 +144,9 @@ package body Alire.Properties.Labeled is
 
             if L.Value'Length > Max_Tag_Length then
                From.Checked_Error
-                 ("Tag string is too long (must be no more than"
-                  & Max_Tag_Length'Img  & ")");
+                 ("Tag string '" & L.Value
+                 & "' is too long (must be no more than"
+                 & Max_Tag_Length'Img  & " characters)");
             end if;
 
             if not Utils.Is_Valid_Tag (L.Value) then


### PR DESCRIPTION
Changed the error message which complains about a tag being too long, to actually tell which tag it is.