### PR TITLE
Fix changing branch of pins with 'git+ssh://' and 'xyz+https://' urls

### DIFF
--- a/testsuite/tests/pin/branch-remote-protocols/test.py
+++ b/testsuite/tests/pin/branch-remote-protocols/test.py
@@ -1,0 +1,98 @@
+"""
+Check pinning to branches with "git+ssh://" and "xyz+https://" urls
+"""
+
+import os
+import subprocess
+
+from drivers.alr import alr_pin, alr_unpin, init_local_crate
+from drivers.helpers import init_git_repo, git_branch
+from drivers.asserts import assert_eq
+
+
+# Create a crate with differing branches.
+init_local_crate(name="remote", enter=False)
+LOCAL_REPO_PATH = os.path.join(os.getcwd(), "remote")
+# On the default branch, test_file contains "This is the main branch.\n".
+test_file_path = os.path.join(LOCAL_REPO_PATH, "test_file")
+with open(test_file_path, "w") as f:
+    f.write("This is the main branch.\n")
+init_git_repo("remote")
+os.chdir("remote")
+default_branch = git_branch()
+# On the "other" branch, test_file contains "This is the other branch.\n".
+subprocess.run(["git", "checkout", "-b", "other"]).check_returncode()
+with open(test_file_path, "w") as f:
+    f.write("This is the other branch.\n")
+subprocess.run(["git", "add", "test_file"]).check_returncode()
+subprocess.run(["git", "commit", "-m", "Change test_file"]).check_returncode()
+# Return to the default branch
+subprocess.run(["git", "checkout", default_branch]).check_returncode()
+os.chdir("..")
+
+
+# Prepare a directory on PATH at which to mock git.
+ACTUAL_GIT_PATH = (
+    subprocess.run(["bash", "-c", "type -p git"], capture_output=True)
+    .stdout.decode()
+    .strip()
+)
+MOCK_PATH = os.path.join(os.getcwd(), "mock_path")
+os.mkdir(MOCK_PATH)
+os.environ["PATH"] = f'{MOCK_PATH}:{os.environ["PATH"]}'
+
+
+# Perform the actual tests
+URLs = [
+    "git+ssh://ssh.gitlab.company-name.com/path/to/repo.git",
+    "xyz+https://github.com/path/to/repo.git",
+]
+SANITISED_URLS = [
+    "ssh://ssh.gitlab.company-name.com/path/to/repo.git",
+    "https://github.com/path/to/repo.git",
+]
+CACHE_TEST_FILE_PATH = "alire/cache/pins/remote/test_file"
+for URL, S_URL in zip(URLs, SANITISED_URLS):
+    # Mock git with a wrapper that naively converts the url into the local path
+    # to the "remote" crate.
+    wrapper_script = "\n".join(
+        [
+            "#! /usr/bin/env python",
+            "import subprocess, sys",
+            'if sys.argv[1:] == ["config", "--list"]:',
+            f'    print("remote.origin.url={S_URL}\\n")',
+            "else:",
+            "    args = [",
+            f'        ("{LOCAL_REPO_PATH}" if a == "{S_URL}" else a)',
+            "        for a in sys.argv[1:]",
+            "    ]",
+            f'    subprocess.run(["{ACTUAL_GIT_PATH}"] + args).check_returncode()',
+        ]
+    )
+    wrapper_descriptor = os.open(
+        os.path.join(MOCK_PATH, "git"),
+        flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC),
+        mode=0o764,
+    )
+    with open(wrapper_descriptor, "w") as f:
+        f.write(wrapper_script)
+
+    # Create an empty crate, and pin the default branch of the test repo
+    init_local_crate()
+    alr_pin("remote", url=URL, branch=default_branch)
+    with open(CACHE_TEST_FILE_PATH) as f:
+        assert_eq("This is the main branch.\n", f.read())
+
+    # Edit pin to point to the other branch, and verify the cached copy changes
+    # as it should
+    alr_unpin("remote", update=False)
+    alr_pin("remote", url=URL, branch="other")
+    with open(CACHE_TEST_FILE_PATH) as f:
+        assert_eq("This is the other branch.\n", f.read())
+
+
+# Restore PATH
+os.environ["PATH"] = os.environ["PATH"][len(MOCK_PATH) + 1 :]
+
+
+print("SUCCESS")

--- a/testsuite/tests/pin/branch-remote-protocols/test.yaml
+++ b/testsuite/tests/pin/branch-remote-protocols/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+control:
+    - [SKIP, "skip_linux",   "Test is Linux-only"]
+indexes: {}


### PR DESCRIPTION
Currently, specifying the branch of pinned remote repositories fails for `git+ssh://` urls. The requested branch is fetched correctly when alr build is first run (or after manually clearing the cache), but subsequent changes to the `branch =` component of the pin in `alire.toml` always results in the default branch being checked out. The same bug is also observed with `[^+]*\+https:` urls.

`git+ssh://` urls actually [appear to be deprecated](https://github.com/git/git/blob/ad850ef1cf1b4af1c1fa3ed8f79e48b8273aa557/connect.c#L725), but we should probably support them anyway.

The issue manifests in [the `Update` procedure](https://github.com/alire-project/alire/blob/master/src/alire/alire-user_pins.adb#L196). This detects if the url has changed and, if so, it clears the cached copy and does a fresh `git clone` (presumably on the basis that a different url probably points to a different version of the repository, which may have diverged sufficiently that an update will fail).

For some reason, this fresh `git clone` always checks out the default branch ([calls `Checkout`](https://github.com/alire-project/alire/blob/master/src/alire/alire-user_pins.adb#L210), rather than `Checkout (Branch => Branch)`). I'm not sure whether this is intended behaviour, but it is not ordinarily a problem as [`Deploy`](https://github.com/alire-project/alire/blob/master/src/alire/alire-user_pins.adb#L128) always seems to be called several times. As such:
- The first call identifies that the url has changed, and consequently does a fresh `clone` of the default branch
- The second (and subsequent) call(s) considers the url to be unchanged (since it is the same as the first call), and therefore triggers the normal update procedure (which does checkout the correct branch)

This fails for `git+ssh://` and `[^+]*\+https:` urls because the [`Repo`](https://github.com/alire-project/alire/blob/master/src/alire/alire-vcss-git.adb#L164) function (which constructs the url when performing the `clone`) [removes the prefix](https://github.com/alire-project/alire/blob/master/src/alire/alire-vcss.adb#L55). A change to the url is detected by comparing the appropriate line in `git config --list` ([here](https://github.com/alire-project/alire/blob/master/src/alire/alire-vcss-git.adb#L328)) with the string defined in `alire.toml` ([here](https://github.com/alire-project/alire/blob/master/src/alire/alire-user_pins.adb#L470)). `git config` returns the form passed to the `clone` command (without the prefix), while the string in `alire.toml` retains the full `git+ssh://` form. The net effect is that a pin with a `git+ssh://` url will **always** be treated as having changed (from `ssh://` to `git+ssh://`), and the default branch will always be used (for **every** call to `Deploy`).

This pull request resolves the issue by substituting `git+ssh://` &rarr; `ssh://` and `xyz+https://` &rarr; `https://` when reading `alire.toml`.