### PR TITLE
Add check that commit ID is valid hexadecimal

### DIFF
--- a/src/alire/alire-origins.adb
+++ b/src/alire/alire-origins.adb
@@ -427,14 +427,14 @@ package body Alire.Origins is
    begin
       case Scheme is
          when Pure_Git | Git | HTTP =>
-            if Commit'Length /= Git_Commit'Length then
+            if not Is_Valid_Commit (Commit) then
                Raise_Checked_Error
                  ("invalid git commit id, " &
                     "40 digits hexadecimal expected");
             end if;
             return New_Git (VCS_URL, Commit, Subdir);
          when Hg =>
-            if Commit'Length /= Hg_Commit'Length then
+            if not Is_Valid_Mercurial_Commit (Commit) then
                Raise_Checked_Error
                  ("invalid mercurial commit id, " &
                     "40 digits hexadecimal expected");

--- a/src/alire/alire-origins.ads
+++ b/src/alire/alire-origins.ads
@@ -130,6 +130,10 @@ package Alire.Origins is
    is (S'Length = Git_Commit'Length and then
        (for all Char of S => Char in Alire.Utils.Hexadecimal_Character));
 
+   function Is_Valid_Mercurial_Commit (S : String) return Boolean
+   is (S'Length = Hg_Commit'Length and then
+       (for all Char of S => Char in Alire.Utils.Hexadecimal_Character));
+
    function Short_Commit (Commit : String) return String;
    --  First characters in the commit
 

--- a/testsuite/tests/publish/bad-arguments/test.py
+++ b/testsuite/tests/publish/bad-arguments/test.py
@@ -34,6 +34,16 @@ p = run_alr("publish", "git+http://github.com/repo", "deadbeef",
 assert_match(".*invalid git commit id, 40 digits hexadecimal expected.*",
              p.out)
 
+# Bad commit characters
+p = run_alr("publish", "git+http://github.com/repo", "_"*40,
+            complain_on_error=False)
+assert_match(".*invalid git commit id, 40 digits hexadecimal expected.*",
+             p.out)
+p = run_alr("publish", "hg+http://host.name/repo", "_"*40,
+            complain_on_error=False)
+assert_match(".*invalid mercurial commit id, 40 digits hexadecimal expected.*",
+             p.out)
+
 # VCS without transport or extension
 p = run_alr("publish", "http://somehost.com/badrepo", "deadbeef",
             complain_on_error=False)


### PR DESCRIPTION
At present,

```
alr publish https://host.invalid/path/to/repo.git 0000000000000000000000000000000000000000
```

merely complains about the untrusted host (as it should), but

```
alr publish https://host.invalid/path/to/repo.git zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
```

yields a rather unhelpful

```
error: Dynamic_Predicate failed at alire-origins.adb:435
error: alr encountered an unexpected error, re-run with -d for details.
```

The same issue arises with commits specified in the `[origin]` section of index manifests.

This PR adds an explicit check for non-hexadecimal characters alongside the existing check for an incorrect number of characters, so the new error message is

```
error: Could not complete the publishing assistant:
error:    invalid git commit id, 40 digits hexadecimal expected
```