### PR TITLE
Fix early error on Windows with msys2 disabled

### DIFF
--- a/src/alire/alire-platforms-common.ads
+++ b/src/alire/alire-platforms-common.ads
@@ -20,7 +20,14 @@ private package Alire.Platforms.Common is
    ---------------------
 
    function Unix_Home_Folder return String
-   is (OS_Lib.Getenv ("HOME", Default => "/tmp"));
+   is (if OS_Lib.Getenv ("HOME", "unset") = "unset" and then
+       GNAT.OS_Lib.Directory_Separator = '\'
+       then
+          raise Checked_Error with
+            "$HOME is not set, you might be running an"
+       & " `alr` built for a non-Windows OS"
+       else
+          OS_Lib.Getenv ("HOME", Default => "/tmp"));
 
    ----------------------
    -- Unix_Temp_Folder --

--- a/src/alire/os_windows/alire-platforms-current__windows.adb
+++ b/src/alire/os_windows/alire-platforms-current__windows.adb
@@ -88,7 +88,20 @@ package body Alire.Platforms.Current is
             return Detect_Msys2_Root;
 
          when others =>
-            return OS_Lib.Getenv ("HOMEDRIVE");
+            declare
+               Root : constant String := OS_Lib.Getenv ("HOMEDRIVE", "C:\");
+            begin
+               if Root'Length not in 2 | 3 then
+                  Raise_Checked_Error
+                    ("$HOMEDRIVE is not a proper drive: " & Root);
+               end if;
+
+               if Root (Root'Last) not in '/' | '\' then
+                  return Root & '\';
+               else
+                  return Root;
+               end if;
+            end;
 
       end case;
    end Distribution_Root;

--- a/src/alire/os_windows/alire-platforms-folders__windows.adb
+++ b/src/alire/os_windows/alire-platforms-folders__windows.adb
@@ -2,6 +2,8 @@ with Ada.Directories;
 
 with Alire.OS_Lib;
 
+with GNAT.OS_Lib;
+
 package body Alire.Platforms.Folders is
 
    use OS_Lib.Operators;
@@ -11,7 +13,18 @@ package body Alire.Platforms.Folders is
    ----------
 
    function Home return Absolute_Path
-   is (OS_Lib.Getenv ("USERPROFILE"));
+   is
+   begin
+      if OS_Lib.Getenv ("USERPROFILE", "unset") = "unset" and then
+        GNAT.OS_Lib.Directory_Separator = '/'
+      then
+         Raise_Checked_Error
+           ("$USERPROFILE not set "
+            & "(might you be running an `alr` built for Windows?)");
+      else
+         return OS_Lib.Getenv ("USERPROFILE");
+      end if;
+   end Home;
 
    -----------
    -- Cache --

--- a/testsuite/tests/settings/distro-disable/test.py
+++ b/testsuite/tests/settings/distro-disable/test.py
@@ -2,11 +2,24 @@
 Verify that disabling distro detection works as intended
 """
 
-from drivers.alr import run_alr, distro_is_known
+from drivers.alr import run_alr, distro_is_known, init_local_crate, alr_with, alr_manifest
 
 run_alr("settings", "--global",
         "--set", "distribution.disable_detection", "true")
 
+# Inspect output of `alr version`
 assert not distro_is_known(), "Unexpected distro detection"
+
+# Ensure that basic environment can be printed for crates that use
+# $DISTRIB_ROOT
+
+init_local_crate()
+# Append usage of DISTRIB_ROOT to the manifest
+with open(alr_manifest(), "a") as f:
+    f.write("""
+    [environment]
+    PATH.append = "${DISTRIB_ROOT}"
+    """)
+run_alr("printenv")
 
 print('SUCCESS')

--- a/testsuite/tests/settings/distro-disable/test.yaml
+++ b/testsuite/tests/settings/distro-disable/test.yaml
@@ -1,3 +1,3 @@
 driver: python-script
 indexes:
-    basic_index: {}
+    compiler_only_index: {}


### PR DESCRIPTION
This triggered only when ${DISTRIB_ROOT} was needed in some crate manifest.

Fixes https://github.com/alire-project/alire/issues/1743