### PR TITLE
Fix CI using deprecated version of actions/upload-artifact

### DIFF
--- a/.github/workflows/ci-appimage.yml
+++ b/.github/workflows/ci-appimage.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: e3-log-linux.zip
         path: testsuite/out
@@ -114,7 +114,7 @@ jobs:
     # regular PRs for easy testing.
     - name: Upload as artifact (when not a release)
       if: (github.event_name != 'release')
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: alr-${{ steps.get_ref.outputs.short_sha }}-x86_64.AppImage.zip
         path: alr.AppImage

--- a/.github/workflows/ci-appimage.yml
+++ b/.github/workflows/ci-appimage.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: e3-log-linux.zip
         path: testsuite/out
@@ -114,7 +114,7 @@ jobs:
     # regular PRs for easy testing.
     - name: Upload as artifact (when not a release)
       if: (github.event_name != 'release')
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@main
       with:
         name: alr-${{ steps.get_ref.outputs.short_sha }}-x86_64.AppImage.zip
         path: alr.AppImage

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: e3-log-docker-${{ matrix.tag }}.zip
         path: testsuite/out

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: e3-log-docker-${{ matrix.tag }}.zip
         path: testsuite/out

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -48,7 +48,7 @@ jobs:
         INDEX: ""
 
     - name: Upload binaries
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@main
       with:
         name: alr-bin-linux.zip
         path: |

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -48,7 +48,7 @@ jobs:
         INDEX: ""
 
     - name: Upload binaries
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: alr-bin-linux.zip
         path: |
@@ -57,7 +57,7 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: e3-log-linux.zip
         path: testsuite/out

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: e3-log-linux.zip
         path: testsuite/out

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -62,7 +62,7 @@ jobs:
         INDEX: ""
 
     - name: Upload binaries
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@main
       with:
         name: alr-bin-${{ env.ARCH }}-macos.zip
         path: |
@@ -71,7 +71,7 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: testsuite-log-macos.zip
         path: testsuite/out

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -62,7 +62,7 @@ jobs:
         INDEX: ""
 
     - name: Upload binaries
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: alr-bin-${{ env.ARCH }}-macos.zip
         path: |
@@ -71,7 +71,7 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: testsuite-log-macos.zip
         path: testsuite/out

--- a/.github/workflows/ci-unsupported.yml
+++ b/.github/workflows/ci-unsupported.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: e3-log-unsupported.zip
         path: testsuite/out

--- a/.github/workflows/ci-unsupported.yml
+++ b/.github/workflows/ci-unsupported.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: e3-log-unsupported.zip
         path: testsuite/out

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -108,7 +108,7 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: testsuite-log-windows.zip
         path: testsuite/out

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -89,26 +89,26 @@ jobs:
         ALR_INSTALL_OS: ${{ runner.os }}
 
     - name: Upload installer
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: installer-release-package
         path: scripts/installer/alire-*.exe
 
     - name: Upload zip archive
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: zip-release-package
         path: scripts/installer/alire-*.zip
 
     - name: Upload tar archive
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: tar-release-package
         path: scripts/installer/alire-*.tar.xz
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: testsuite-log-windows.zip
         path: testsuite/out

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,13 +58,13 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: e3-log-linux.zip
         path: testsuite/out
 
     - name: Upload artifact
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v4
       with:
         name: alr-bin-${{ matrix.os }}.zip
         path: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,13 +58,13 @@ jobs:
 
     - name: Upload logs (if failed)
       if: failure()
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: e3-log-linux.zip
         path: testsuite/out
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@main
       with:
         name: alr-bin-${{ matrix.os }}.zip
         path: |


### PR DESCRIPTION
Fixes errors like [this one](https://github.com/alire-project/alire/actions/runs/10769331395/job/29860309465?pr=1745) due to `actions/upload-artifact@v1` and `actions/upload-artifact@v2` [being deprecated](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).

All references have been changed to `actions/upload-artifact@v4`.