### PR TITLE
fix: static linking to libgcc in nightlies

### DIFF
--- a/.github/workflows/ci-toolchain.yml
+++ b/.github/workflows/ci-toolchain.yml
@@ -43,6 +43,7 @@ jobs:
       uses: alire-project/alr-install@v1
       with:
         crates: gnat_native^${{matrix.gcc_version}} gprbuild
+        cache: false
 
     - name: Build alr with toolchain from `alr install`
       shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,14 +21,14 @@ jobs:
       fail-fast: false # Attempt to generate as many of them as possible
       matrix:
         os:
-          - macos-14
           - macos-12
+          - macos-14
           - ubuntu-20.04
           - windows-latest
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -36,25 +36,36 @@ jobs:
       uses: alire-project/alr-install@v1
       with:
         crates: gnat_native gprbuild
+        prefix: alire_prefix
 
-    - name: Replace toolchain with aarch64
-      if: ${{ runner.arch == 'ARM64' }}
+    - name: Display toolchain configuration and verify matching arch
+      shell: bash
       run: |
-          curl -L https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-14.1.0-3/gnat-aarch64-darwin-14.1.0-3.tar.gz \
-           | tar xzf - --strip-components=1 -C /Users/runner/work/alire/alire/alire_prefix
-          curl -L https://github.com/alire-project/GNAT-FSF-builds/releases/download/gprbuild-24.0.0-1/gprbuild-aarch64-darwin-24.0.0-1.tar.gz \
-           | tar xzf - --strip-components=1 -C /Users/runner/work/alire/alire/alire_prefix
-          which gcc
-          gcc -v
+        case ${{runner.arch}} in
+          X64)   target_arch=x86_64;;
+          ARM64) target_arch=aarch64;;
+          *)     echo "Unknown arch" && exit 1;;
+        esac
+        which gcc
+        gcc -v
+        gcc -dumpmachine   && gcc -dumpmachine   | grep -q $target_arch || exit 1
+        gprbuild --version && gprbuild --version | grep -q $target_arch || exit 1
 
     - name: Install Python 3.x (required for the testsuite)
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 
     - name: Run test script
       run: scripts/ci-github.sh
       shell: bash
+
+    # Ascertain whether alr can run without the toolchain that built it
+    - name: Remove toolchain used for building & testing
+      shell: bash
+      run: |
+        rm -rf alire_prefix
+        which gnat || { echo "Toolchain purged"; ./bin/alr version; }
 
     - name: Upload logs (if failed)
       if: failure()

--- a/scripts/ci-github.sh
+++ b/scripts/ci-github.sh
@@ -29,24 +29,12 @@ fi
 # Patch version
 scripts/version-patcher.sh
 
-# use -static-libgcc only in recent-enough GCC versions (>=12). The version is
-# the last space-separated field of the first line in gcc --version output.
-# Also, this is only needed on macOS for now.
-ALR_LINKER_ARGS=
-if [ "$(get_OS)" == "macos" ]; then
-    gcc_version=$(gcc --version | head -n 1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -n1 | cut -f1 -d.)
-    if [ "$(echo "$gcc_version >= 12" | bc)" -eq 1 ]; then
-        ALR_LINKER_ARGS="-static-libgcc"
-    fi
-fi
-
 # Build alr if no argument is "build=false"
 if [[ " $* " == *" build=false "* ]]; then
     echo "Skipping alr build, explicitly disabled via arguments"
 else
     export ALIRE_OS=$(get_OS)
-    echo "Using ALR_LINKER_ARGS=$ALR_LINKER_ARGS"
-    gprbuild -j0 -p -P alr_env -largs $ALR_LINKER_ARGS
+    gprbuild -j0 -p -P alr_env
 fi
 
 # Disable distro detection if supported
@@ -81,12 +69,6 @@ echo ALR SEARCH:
 # List releases for the record
 alr -q -d search --list --external
 echo ............................
-
-# Exit without testing if some argument is "test=false"
-if [[ " $* " == *" test=false "* ]]; then
-    echo "SKIPPING testsuite, explicitly disabled via arguments"
-    exit 0
-fi
 
 echo TESTSUITE:
 # Run e3.testsuite


### PR DESCRIPTION
There is some inconsistency at least on macOS compilers that was introducing a dependency on the compiler in some cases.