### PR TITLE
feat: search without solving and with --solve

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -6,6 +6,17 @@ stay on top of `alr` new features.
 
 ## Release `2.1`
 
+PR [1799](https://github.com/alire-project/alire/pull/1799)
+
+`alr search` no longer solves dependencies of releases by default, in order to
+speed up the command. The `--solve` switch can be used to achieve the old
+behavior.
+
+In the new default situation, releases that have dependencies are marked with a
+'?' symbol in the STATUS column. The `--solve` switch will solve the
+dependencies and replace the '?' with either nothing for a solvable release or
+the usual 'X' if dependencies are unsatisfiable.
+
 ## Release `2.0`
 
 ### `ALIRE_SETTINGS_DIR` replaces `ALR_CONFIG`

--- a/src/alr/alr-commands-search.adb
+++ b/src/alr/alr-commands-search.adb
@@ -51,7 +51,12 @@ package body Alr.Commands.Search is
             (if R.Is_Available (Platform.Properties)
                then " " else Flag_Unav) &
             (if R.Origin.Is_System then " " else
-                   (if Solver.Is_Resolvable
+                   (if not Cmd.Solve
+                    then
+                      (if R.Dependencies (Platform.Properties).Is_Empty
+                       then " "
+                       else TTY.Dim ("?"))
+                    elsif Solver.Is_Resolvable
                       (R.Dependencies (Platform.Properties),
                        Platform.Properties,
                        Alire.Solutions.Empty_Valid_Solution,
@@ -334,6 +339,8 @@ package body Alr.Commands.Search is
       .Append ("E: the release is externally provided.")
       .Append ("S: the release is available through a system package.")
       .Append ("U: the release is not available in the current platform.")
+      .Append ("?: the release has dependencies but solving was skipped "
+               & "(see --solve).")
       .Append ("X: the release has dependencies that cannot be resolved.")
       .New_Line
       .Append ("The reasons for unavailability (U) can be ascertained with"
@@ -383,6 +390,11 @@ package body Alr.Commands.Search is
                      Cmd.External'Access,
                      "", "--external",
                      "Include externally-provided releases in search");
+
+      Define_Switch (Config,
+                     Cmd.Solve'Access,
+                     "", "--solve",
+                     "Solve dependencies of releases");
    end Setup_Switches;
 
 end Alr.Commands.Search;

--- a/src/alr/alr-commands-search.ads
+++ b/src/alr/alr-commands-search.ads
@@ -36,6 +36,7 @@ private
       Full     : aliased Boolean := False;
       List     : aliased Boolean := False;
       External : aliased Boolean := False;
+      Solve    : aliased Boolean := False;
    end record;
 
 end Alr.Commands.Search;

--- a/testsuite/tests/search/basic/test.py
+++ b/testsuite/tests/search/basic/test.py
@@ -17,9 +17,16 @@ def format_table(*args):
         lines.append(format_line(*arg))
     return ''.join(lines)
 
-
-# List latest releases crates
+# List latest releases crates, without solving dependencies
 p = run_alr('search', '--list')
+assert_eq(format_table(
+    ('hello', '  ?', '1.0.1', '"Hello, world!" demonstration project', '', ''),
+    ('libhello', '', '1.0.0',
+     '"Hello, world!" demonstration project support library', '', ''),
+), p.out)
+
+# List latest releases crates, solving dependencies
+p = run_alr('search', '--list', '--solve')
 assert_eq(format_table(
     ('hello', '', '1.0.1', '"Hello, world!" demonstration project', '', ''),
     ('libhello', '', '1.0.0',
@@ -28,7 +35,7 @@ assert_eq(format_table(
 
 
 # List all releases crates
-p = run_alr('search', '--list', '--full')
+p = run_alr('search', '--list', '--full', '--solve')
 assert_eq(format_table(
     ('hello', '', '1.0.1', '"Hello, world!" demonstration project', '', ''),
     ('hello', '', '1.0.0', '"Hello, world!" demonstration project', '', ''),


### PR DESCRIPTION
We were solving all releases found during `alr search` which could slow notably the search in exchange for knowing upfront whether all dependencies are solvable.

This is now skipped, dependencies (if existing) are marked with a dimmed '?':
```
$ alr search unicode
NAME                 STATUS  VERSION               DESCRIPTION                                                           NOTES  MATCHES
emojis                       1.0.1                 A library to replace names between colons with emojis                        Tag
gwindows              U      1.4.3                 GWindows - Ada Framework for Windows Development                             Long_Description
mandelbrot_ascii             1.0.0                 Mandelbrot renderer using Unicode glyphs                                     Description
matreshka_league       ?     21.0.0                League - universal string library. Part of Matreshka framework               Tag
umwi                         0.1.0                 Unicode Monospace Width Information                                          Description, Tag
universal_text_file    ?     20220720.0.0          Proposed universal format for Unicode text files                             Description, Long_Description, Tag
utf8test                     0.1.0                 Test the terminal behavior when outputting Latin-1 and UTF-8 strings         Tag
uxstrings              ?     0.7.1+alpha-20240525  Unicode Extended Strings utilities                                           Description, Tag
vss                    ?     24.0.0                Advanced string and text manipulation with Unicode support                   Description, Tag
xmlada                 ?     24.0.0                The XML/Ada toolkit                                                          Project_File
```
The old behavior can be enabled with `--solve`:
```
$ alr search unicode --solve
NAME                 STATUS  VERSION               DESCRIPTION                                                           NOTES  MATCHES
emojis                       1.0.1                 A library to replace names between colons with emojis                        Tag
gwindows              U      1.4.3                 GWindows - Ada Framework for Windows Development                             Long_Description
mandelbrot_ascii             1.0.0                 Mandelbrot renderer using Unicode glyphs                                     Description
matreshka_league             21.0.0                League - universal string library. Part of Matreshka framework               Tag
umwi                         0.1.0                 Unicode Monospace Width Information                                          Description, Tag
universal_text_file          20220720.0.0          Proposed universal format for Unicode text files                             Description, Long_Description, Tag
utf8test                     0.1.0                 Test the terminal behavior when outputting Latin-1 and UTF-8 strings         Tag
uxstrings                    0.7.1+alpha-20240525  Unicode Extended Strings utilities                                           Description, Tag
vss                          24.0.0                Advanced string and text manipulation with Unicode support                   Description, Tag
xmlada                       24.0.0                The XML/Ada toolkit
```