### PR TITLE
feat: abbreviated dependency tree printing

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -24,10 +24,12 @@ Dependencies (tree):
        └── xmlada=25.0.0 (~25.0.0)
            └── gnat=14.1.3 (gnat_native) (>=11)
    gnatcoll_gmp=25.0.0 (~25.0.0)
-   ├── gnatcoll=25.0.0 (~25.0.0) ···
+   ├── gnatcoll=25.0.0 (~25.0.0)
+   │   └── ...
    └── libgmp=6.3.0 (*)
    gnatcoll_iconv=25.0.0 (~25.0.0)
-   └── gnatcoll=25.0.0 (~25.0.0) ···
+   └── gnatcoll=25.0.0 (~25.0.0)
+       └── ...
 ```
 
 Whenever '...' appears, it means that the preceding release has its

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -6,6 +6,10 @@ stay on top of `alr` new features.
 
 ## Release `2.1`
 
+### Abbreviated `--tree` output for repeating dependencies
+
+### Faster `alr search` without resolving dependencies
+
 PR [1799](https://github.com/alire-project/alire/pull/1799)
 
 `alr search` no longer solves dependencies of releases by default, in order to

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -8,6 +8,34 @@ stay on top of `alr` new features.
 
 ### Abbreviated `--tree` output for repeating dependencies
 
+PR [1814](https://github.com/alire-project/alire/pull/1814)
+
+By default, repeated dependencies are now omitted by `--tree` output, e.g.:
+
+```
+$ alr show --tree libgpr2
+...
+Dependencies (tree):
+   gnat=14.1.3 (gnat_native) (>=14)
+   gnatcoll=25.0.0 (~25.0.0)
+   ├── gnat=14.1.3 (gnat_native) (>=13)
+   └── libgpr=25.0.0 (~25.0.0)
+       ├── gnat=14.1.3 (gnat_native) (/=2020)
+       └── xmlada=25.0.0 (~25.0.0)
+           └── gnat=14.1.3 (gnat_native) (>=11)
+   gnatcoll_gmp=25.0.0 (~25.0.0)
+   ├── gnatcoll=25.0.0 (~25.0.0) ···
+   └── libgmp=6.3.0 (*)
+   gnatcoll_iconv=25.0.0 (~25.0.0)
+   └── gnatcoll=25.0.0 (~25.0.0) ···
+```
+
+Whenever '...' appears, it means that the preceding release has its
+dependencies already printed somewhere in the preceding tree lines.
+
+The old behavior can be obtained by increasing verbosity with the global `-v`
+switch.
+
 ### Faster `alr search` without resolving dependencies
 
 PR [1799](https://github.com/alire-project/alire/pull/1799)

--- a/src/alire/alire-solutions.adb
+++ b/src/alire/alire-solutions.adb
@@ -926,9 +926,8 @@ package body Alire.Solutions is
                     (if TTY.Color_Enabled then U ("└── ") else "+-- ");
       Branch    : constant String :=
                     (if TTY.Color_Enabled then U ("│   ") else "|   ");
-      More_Deps : constant String :=
-                    (if TTY.Color_Enabled then U (" ···") else " ...");
       No_Branch : constant String := "    ";
+      More_Deps : constant String := (Last_Node & "...");
 
       Printed   : AAA.Strings.Sets.Set;
       --  Dependencies already printed, to avoid reprinting in Concise mode
@@ -942,6 +941,13 @@ package body Alire.Solutions is
           then This.State (Dep.Crate).Milestone_Image
           else This.State (Dep.Crate).TTY_Image);
 
+      ---------------------
+      -- Already_Printed --
+      ---------------------
+
+      function Already_Printed (Dep : Dependencies.Dependency) return Boolean
+      is (Printed.Contains (Label (Dep)));
+
       -----------
       -- Print --
       -----------
@@ -953,28 +959,30 @@ package body Alire.Solutions is
         --  is printed without the root release.
       is
 
-         -------------------------------------
-         -- Inline_Concise_Marker_If_Needed --
-         -------------------------------------
+         ----------------------
+         -- Has_Dependencies --
+         ----------------------
 
-         function Inline_Concise_Marker_If_Needed
-           (Dep : Dependencies.Dependency) return String is
-         begin
-            if Concise
-              and then Printed.Contains (Label (Dep))
-              and then This.State (Dep.Crate).Has_Release
-              and then not Conditional.Enumerate
-                (This.State (Dep.Crate).Release.Dependencies).Is_Empty
-            then
-               return More_Deps;
-            else
-               return "";
-            end if;
-         end Inline_Concise_Marker_If_Needed;
+         function Has_Dependencies (Dep : Dependencies.Dependency)
+                                     return Boolean
+         is (This.State (Dep.Crate).Has_Release
+             and then not Conditional.Enumerate
+               (This.State (Dep.Crate).Release.Dependencies).Is_Empty);
 
          Last : UString;
          --  Used to store the last dependency name in a subtree, to be able to
          --  use the proper ASCII connector. See just below.
+
+         ----------------------
+         -- Parent_Connector --
+         ----------------------
+
+         function Parent_Connector (Dep : Dependencies.Dependency)
+                                    return String
+         is (if +Dep.Crate = +Last
+             then No_Branch  -- End of this connector
+             else Branch);   -- Continuation
+
       begin
 
          --  Find last printable dependency. This is related to OR trees, that
@@ -1008,18 +1016,21 @@ package body Alire.Solutions is
                   & Label (Dep)
 
                   --  And dependency that introduces the crate in the solution
-                  & " (" & TTY.Emph (Dep.Versions.Image) & ")"
+                  & " (" & TTY.Emph (Dep.Versions.Image) & ")");
 
-                  --  If concise and this has dependencies, print the marker
-                  & Inline_Concise_Marker_If_Needed (Dep)
-                 );
+               --  Recurse for further releases, or print the concise marker
 
-               --  Recurse for further releases if not conise and printed
-
-               if (not Concise or else not Printed.Contains (Label (Dep)))
-                 and then This.State (Dep.Crate).Has_Release
-                 and then not Conditional.Enumerate
-                   (This.State (Dep.Crate).Release.Dependencies).Is_Empty
+               if
+                 Concise
+                 and then Already_Printed (Dep)
+                 and then Has_Dependencies (Dep)
+               then
+                  Trace.Always (Prefix
+                                & Parent_Connector (Dep)
+                                & More_Deps);
+               elsif
+                 (not Concise or else not Printed.Contains (Label (Dep)))
+                 and then Has_Dependencies (Dep)
                then
                   Print
                     (Conditional.Enumerate
@@ -1027,11 +1038,9 @@ package body Alire.Solutions is
                      Prefix =>
                        Prefix
                        --  Indent adding the proper running connector
-                     & (if Omit
-                       then ""
-                       else (if +Dep.Crate = +Last
-                         then No_Branch  -- End of this connector
-                         else Branch))); -- "│" over the subtree
+                       & (if Omit
+                          then ""
+                          else Parent_Connector (Dep)));
                end if;
 
                Printed.Include (Label (Dep));

--- a/src/alire/alire-solutions.ads
+++ b/src/alire/alire-solutions.ads
@@ -412,9 +412,11 @@ package Alire.Solutions is
    procedure Print_Tree (This       : Solution;
                          Root       : Alire.Releases.Release;
                          Prefix     : String := "";
-                         Print_Root : Boolean := True);
+                         Print_Root : Boolean := True;
+                         Concise    : Boolean := not Detailed);
    --  Print the solution in tree form. If Print_Root, Root is printed too;
    --  otherwise the tree is a forest starting at Root direct dependencies.
+   --  If Concise, print each unique dependency only once.
 
    procedure Print_Versions (This : Solution;
                              Root : Roots.Root);

--- a/testsuite/tests/with/tree-concise/test.py
+++ b/testsuite/tests/with/tree-concise/test.py
@@ -1,0 +1,43 @@
+"""
+Test the concise mode of the --tree switch. Repeating dependencies are
+substituted by a "..." ellipsis.
+"""
+
+import os
+import re
+from drivers.alr import run_alr, alr_with, init_local_crate
+from drivers.asserts import assert_eq, assert_match
+
+# Prepare a crate in which dependencies appear twice, so their dependencies in
+# turn can be elided.
+
+init_local_crate("yyy")
+alr_with("hello")
+os.chdir("..")
+init_local_crate("xxx")
+alr_with("hello")
+alr_with("yyy", path="../yyy")
+
+# Check the concise tree
+assert_eq("""\
+xxx=0.1.0-dev
++-- hello=1.0.1 (*)
+|   +-- libhello=1.0.0 (^1.0)
++-- yyy=0.1.0-dev (*)
+    +-- hello=1.0.1 (*)
+        +-- ...\
+""",
+           run_alr("with", "--tree").out.strip())
+
+# Check the regular tree
+assert_match(".*" + re.escape("""\
+xxx=0.1.0-dev
++-- hello=1.0.1 (*)
+|   +-- libhello=1.0.0 (^1.0)
++-- yyy=0.1.0-dev (*)
+    +-- hello=1.0.1 (*)
+        +-- libhello=1.0.0 (^1.0)\
+"""),
+           run_alr("-v", "with", "--tree", quiet=False).out.strip())
+
+print("SUCCESS")

--- a/testsuite/tests/with/tree-concise/test.py
+++ b/testsuite/tests/with/tree-concise/test.py
@@ -24,7 +24,8 @@ xxx=0.1.0-dev
 +-- hello=1.0.1 (*)
 |   +-- libhello=1.0.0 (^1.0)
 +-- yyy=0.1.0-dev (*)
-    +-- hello=1.0.1 (*) ...\
+    +-- hello=1.0.1 (*)
+        +-- ...\
 """,
            run_alr("with", "--tree").out.strip())
 

--- a/testsuite/tests/with/tree-concise/test.py
+++ b/testsuite/tests/with/tree-concise/test.py
@@ -24,8 +24,7 @@ xxx=0.1.0-dev
 +-- hello=1.0.1 (*)
 |   +-- libhello=1.0.0 (^1.0)
 +-- yyy=0.1.0-dev (*)
-    +-- hello=1.0.1 (*)
-        +-- ...\
+    +-- hello=1.0.1 (*) ...\
 """,
            run_alr("with", "--tree").out.strip())
 

--- a/testsuite/tests/with/tree-concise/test.yaml
+++ b/testsuite/tests/with/tree-concise/test.yaml
@@ -1,0 +1,5 @@
+driver: python-script
+build_mode: both
+indexes:
+    basic_index:
+        in_fixtures: true


### PR DESCRIPTION
This declutters the output of `--tree` when dependencies start to repeat by replacing repeats with `...`, e.g.:
```
$ alr show --tree libgpr2
Dependencies (tree):
   gnat=14.1.3 (gnat_native) (>=14)
   gnatcoll=25.0.0 (~25.0.0)
   ├── gnat=14.1.3 (gnat_native) (>=13)
   └── libgpr=25.0.0 (~25.0.0)
       ├── gnat=14.1.3 (gnat_native) (/=2020)
       └── xmlada=25.0.0 (~25.0.0)
           └── gnat=14.1.3 (gnat_native) (>=11)
   gnatcoll_gmp=25.0.0 (~25.0.0)
   ├── gnatcoll=25.0.0 (~25.0.0) ···
   └── libgmp=6.3.0 (*)
   gnatcoll_iconv=25.0.0 (~25.0.0)
   └── gnatcoll=25.0.0 (~25.0.0) ···
```
vs (previous default)
```
$ alr -v show --tree libgpr2
Dependencies (tree):                                                       
   gnat=14.1.3 (gnat_native) (>=14)
   gnatcoll=25.0.0 (~25.0.0)
   ├── gnat=14.1.3 (gnat_native) (>=13)
   └── libgpr=25.0.0 (~25.0.0)
       ├── gnat=14.1.3 (gnat_native) (/=2020)
       └── xmlada=25.0.0 (~25.0.0)
           └── gnat=14.1.3 (gnat_native) (>=11)
   gnatcoll_gmp=25.0.0 (~25.0.0)
   ├── gnatcoll=25.0.0 (~25.0.0)
   │   ├── gnat=14.1.3 (gnat_native) (>=13)
   │   └── libgpr=25.0.0 (~25.0.0)
   │       ├── gnat=14.1.3 (gnat_native) (/=2020)
   │       └── xmlada=25.0.0 (~25.0.0)
   │           └── gnat=14.1.3 (gnat_native) (>=11)
   └── libgmp=6.3.0 (*)
   gnatcoll_iconv=25.0.0 (~25.0.0)
   └── gnatcoll=25.0.0 (~25.0.0)
       ├── gnat=14.1.3 (gnat_native) (>=13)
       └── libgpr=25.0.0 (~25.0.0)
           ├── gnat=14.1.3 (gnat_native) (/=2020)
           └── xmlada=25.0.0 (~25.0.0)
               └── gnat=14.1.3 (gnat_native) (>=11)
```

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [x] `doc/user-changes.md` has been updated, if applicable.
