### PR TITLE
Remove redundant parentheses inside all operators

### DIFF
--- a/src/alire/alire-properties-scenarios.adb
+++ b/src/alire/alire-properties-scenarios.adb
@@ -38,7 +38,7 @@ package body Alire.Properties.Scenarios is
                   if Val.Kind = TOML_String then
                      if Val.As_String = "" then
                         Props := Props and
-                          (New_Property (GPR.Free_Variable (Key)));
+                          New_Property (GPR.Free_Variable (Key));
                      else
                         Table.Checked_Error
                           ("free scenario variable must be given as """"");


### PR DESCRIPTION
GNAT already emits a style warning when redundant parentheses appear inside top-level conditions. This warning will be soon emitted for other operators as well, so remove redundant parentheses to avoid build failures.