### PR TITLE
feat: propagate verbosity in `alr test`

### DIFF
--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -157,6 +157,12 @@ package body Alr.Commands.Test is
                                  Empty_Vector
                                      & "-d"
                                      & "-n"
+                                     & (if Alire.Log_Level >= Detail
+                                        then To_Vector ("-v")
+                                        else Empty_Vector)
+                                     & (if Alire.Log_Level >= Debug
+                                        then To_Vector ("-v")
+                                        else Empty_Vector)
                                      & (if Alire.Force
                                         then To_Vector ("--force")
                                         else Empty_Vector);

--- a/testsuite/tests/test/verbose-propagation/test.py
+++ b/testsuite/tests/test/verbose-propagation/test.py
@@ -1,0 +1,33 @@
+"""
+Check that when running `alr test` with the verbose flag, the spawned command
+of the default test action inherits the verbosity flag.
+"""
+
+import os
+from drivers.alr import init_local_crate, run_alr
+from drivers.asserts import assert_not_substring, assert_substring
+from drivers.helpers import content_of
+
+# Run `alr test` in a local crate for this test with increasing verbosity
+# levels; we check the existence of expected output in the test log. The
+# selected messages are representative of the log level at play.
+
+LOGFILE = os.path.join("alire", "alr_test_local.log")
+
+init_local_crate()
+
+# Default log level
+run_alr("test", quiet=False)
+assert_not_substring("alr build done", content_of(LOGFILE))
+
+# Verbose
+run_alr("-v", "test", quiet=False)
+assert_substring("alr build done", content_of(LOGFILE))
+assert_not_substring("Setenv ALIRE=True", content_of(LOGFILE))
+
+# More verbose
+run_alr("-vv", "test", quiet=False)
+assert_substring("alr build done", content_of(LOGFILE))
+assert_substring("Setenv ALIRE=True", content_of(LOGFILE))
+
+print("SUCCESS")

--- a/testsuite/tests/test/verbose-propagation/test.yaml
+++ b/testsuite/tests/test/verbose-propagation/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+build_mode: both
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
When `alr test` spawns `alr build`, it now propagates any `-v`, so it can help in debugging a complex build with hooks.

Ideally we shouldn't spawn any `alr` at all to avoid these interactions. I think the only place remaining now is precisely `alr test`. It could be done but it would be more involved than this PR which is intended as a minimal intervention. I will track that in a separate issue.

##### PR creation checklist
- [x] A test is included, if required by the changes.
