### PR TITLE
feat: improved error message when error in pin

### DIFF
--- a/src/alire/alire-errors.adb
+++ b/src/alire/alire-errors.adb
@@ -126,7 +126,9 @@ package body Alire.Errors is
    -- Pretty_Print --
    ------------------
 
-   procedure Pretty_Print (Error : String) is
+   procedure Pretty_Print (Error : String;
+                           Level : Trace.Levels := Trace.Error)
+   is
       Lines : constant AAA.Strings.Vector := Split (Error, ASCII.LF);
    begin
       for I in Lines.First_Index .. Lines.Last_Index loop
@@ -134,7 +136,7 @@ package body Alire.Errors is
             Line : constant String := Trim (Lines (I));
          begin
             if Line /= "" then
-               Trace.Error
+               Trace.Log
                  ((if I > Lines.First_Index then "   " else "")
                   --  Indentation
 
@@ -146,11 +148,11 @@ package body Alire.Errors is
                   & (if I < Lines.Last_Index
                     and then Line (Line'Last) /= ':'
                     then ":"
-                    else "")
+                    else ""),
                   --  Trailing ':' except for last line
-                 );
+                 Level);
             else
-               Trace.Error (Line);
+               Trace.Log (Line, Level);
             end if;
          end;
       end loop;

--- a/src/alire/alire-errors.ads
+++ b/src/alire/alire-errors.ads
@@ -52,7 +52,8 @@ package Alire.Errors with Preelaborate is
    --  Returns the error for Ex if it exists, or defaults to Exception_Message.
    --  The stored error is cleared.
 
-   procedure Pretty_Print (Error : String);
+   procedure Pretty_Print (Error : String;
+                           Level : Trace.Levels := Trace.Error);
    --  Split Error at LFs to prefix each sub-error in a new line with the
    --  appropriate tracing prefix. Also, from the second line on, messages are
    --  indented. This way, several top-level errors are easier to distinguish.

--- a/src/alire/alire-user_pins.adb
+++ b/src/alire/alire-user_pins.adb
@@ -1,6 +1,7 @@
 with Ada.Directories;
 
 with Alire.Directories;
+with Alire.Errors;
 with Alire.Origins;
 with Alire.Roots.Optional;
 with Alire.Utils.User_Input;
@@ -363,9 +364,12 @@ package body Alire.User_Pins is
 
          if not Root.Is_Valid then
             Put_Warning
-              ("Pin for " & Utils.TTY.Name (Crate) &
-                 " does not contain an Alire " &
-                 "manifest. It will be used as a raw GNAT project.");
+              ("Pin for " & Utils.TTY.Name (Crate) & " at "
+               & Utils.TTY.URL (Destination)
+               & " does not contain a valid Alire manifest. "
+               & "It will be used as a raw GNAT project.");
+            Errors.Pretty_Print
+              ("Pin diagnostic is:" & New_Line & Root.Message, Trace.Warning);
          end if;
 
       end;

--- a/testsuite/Dockerfile
+++ b/testsuite/Dockerfile
@@ -1,6 +1,7 @@
 # This docker image is used in tests with the `docker_wrapper` driver.
 
-FROM alire/gnat:ubuntu-lts
+# Latest tested is 24.04
+FROM alire/gnat:ubuntu-lts 
 
 RUN useradd -m -s /bin/bash user && \
     chown user:user /home/user && \


### PR DESCRIPTION
Print a more informative error if we fail to load a manifest in a linked dependency because it contains an error.

This also helps errors where the linked manifest itself is valid, but it contains some non-obvious problem (e.g., another linked crate that does not exist in the current environment). 
