### PR TITLE
fix: make explicit Git URLs backward compatible

### DIFF
--- a/src/alire/alire-selftest.adb
+++ b/src/alire/alire-selftest.adb
@@ -140,7 +140,7 @@ package body Alire.Selftest is
 
       --  Proper transform starting with .git
       pragma Assert (Transform_To_Public ("git@github.com:user/project.git") =
-                       "https://github.com/user/project.git");
+                       "git+https://github.com/user/project.git");
 
       --  GitLab
       pragma Assert (Transform_To_Public ("git@gitlab.com:user/project") =

--- a/src/alire/alire-uri.adb
+++ b/src/alire/alire-uri.adb
@@ -199,11 +199,14 @@ package body Alire.URI is
             elsif Current_Kind = SCP_Style_Git then
                --  git@host:/path is already explicit
                return This;
-            elsif Current_Kind in Probably_Git then
-               --  Prepend prefix to make it *_Definitely_Git
+            elsif not Has_Prefix (This, VCS_Prefix) then
+               --  Ensure a 'vcs+' prefix is present
+               --
+               --  We do this even for URLs with a '.git' suffix, as they are
+               --  not otherwise recognized by pre-2.1 versions of alr.
                return VCS_Prefix & This;
             else
-               --  This is already recognized as the correct VCS, so do nothing
+               --  This already has a 'vcs+' prefix, so do nothing
                return This;
             end if;
          when others =>

--- a/src/alire/alire-uri.ads
+++ b/src/alire/alire-uri.ads
@@ -231,14 +231,11 @@ package Alire.URI with Preelaborate is
 
    function Make_VCS_Explicit (This : String; Kind : VCS_Kinds) return String
      with Post => URI_Kind (Make_VCS_Explicit'Result) in VCS_URIs;
-   --  Return the URL minimally modified to make the VCS recognizable.
+   --  Return the URL modified to ensure the VCS is recognizable.
    --
    --  For example, This => "https://host/path" with Kind => Git returns
    --  "git+https://host/path", and This => "/some/path" with Kind => Hg
    --  returns "hg+file:/some/path".
-   --
-   --  Changes are only made if necessary, so This => "https://host/path.git"
-   --  and Kind => Git returns the URL unmodified.
    --
    --  Raises Program_Error if the URL already looks like a different VCS
    --  or has a URI_Kind of External or System.

--- a/testsuite/tests/publish/private-indexes/test.py
+++ b/testsuite/tests/publish/private-indexes/test.py
@@ -254,6 +254,7 @@ for force_arg in ([], ["--force"]):
             expect_success=False
         )
         # "alr publish --for-private-index" will succeed.
+        explicit_url = url if url.startswith("git@") else f"git+{url}"
         test(
             args=force_arg + ["publish", "--for-private-index"],
             url=url,
@@ -264,7 +265,7 @@ for force_arg in ([], ["--force"]):
                 r".*Please upload this file to the index in the xx/xxx/ subdirectory",
             ],
             gen_manifest=[
-                f'.*url = "{re.escape(url)}".*',
+                f'.*url = "{re.escape(explicit_url)}".*',
             ],
             expect_success=True
         )


### PR DESCRIPTION
As of #1736, `https://host/path.git` URLs are recognised as Git URLs due to the `.git` suffix. Prior to this, however, recognition was inconsistent, so a URL produced by `Alire.URI.Make_VCS_Explicit` is not necessarily backward compatible. In particular, `alr publish` with `alr 2.1` [can produce a manifest which `alr 2.0` considers invalid](https://github.com/alire-project/alire-index/pull/1359#discussion_r1914526256).

As mentioned [here](https://github.com/alire-project/alire/commit/685f1f39fd02807cd56ab2c16b427e5529d87aaa#commitcomment-151631822), this PR changes `Alire.URI.Make_VCS_Explicit` to always add a `git+`, even if there is a `.git` suffix, so that `alr publish` produces backward-compatible manifests.

##### PR creation checklist
- [x] A test is included, if required by the changes.
