### PR TITLE
fix: upgrade deprecated Ubuntu runners

### DIFF
--- a/.github/workflows/ci-appimage.yml
+++ b/.github/workflows/ci-appimage.yml
@@ -18,7 +18,7 @@ jobs:
 
     # Oldest supported by Alire+GitHub to increase AppImage back-compatibility
     # Unfortunately we depend on the static elaboration model of recent GNATs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Check out repository

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -46,7 +46,7 @@ jobs:
           - os: macos-latest        # arm64
             id: aarch64-macos
 
-          - os: ubuntu-20.04        # x64, oldest supported so releases can run on older distros
+          - os: ubuntu-22.04        # x64, oldest supported so releases can run on older distros
             id: x86_64-linux
 
           - os: ubuntu-24.04-arm    # new ARM runners
@@ -188,7 +188,7 @@ jobs:
           - os: macos-latest
             id: universal-macos
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             id: x86_64-linux
 
           - os: ubuntu-24.04-arm

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
         os:
           - macos-13         # x64
           - macos-14         # arm64
-          - ubuntu-20.04     # oldest supported to be able to run on those
+          - ubuntu-22.04     # oldest supported to be able to run on those
           - ubuntu-24.04-arm # oldest with ARM arch
           - windows-latest
 


### PR DESCRIPTION
20.04 is being deprecated: https://github.com/actions/runner-images/issues/11101