### PR TITLE
fix: remove `libgcc_s_seh-1.dll` dependency

### DIFF
--- a/alire_common.gpr
+++ b/alire_common.gpr
@@ -132,6 +132,14 @@ abstract project Alire_Common is
         );
    end Binder;
 
+   package Linker is
+      case Host_OS is
+         -- Link statically on Windows to avoid DLL dependencies
+         when "windows" => for Switches ("Ada") use ("-static");
+         when others    => null;
+      end case;
+   end Linker;
+
    package Ide is
       for Vcs_Kind use "Git";
    end Ide;

--- a/alr.gpr
+++ b/alr.gpr
@@ -36,6 +36,7 @@ project Alr is
    end Builder;
 
    package Binder renames Alire_Common.Binder;
+   package Linker renames Alire_Common.Linker;
    package Ide renames Alire_Common.Ide;
 
 end Alr;

--- a/testsuite/tests/misc/empty-path/test.py
+++ b/testsuite/tests/misc/empty-path/test.py
@@ -1,0 +1,26 @@
+"""
+Verify that `alr` doesn't depend on anything being on `PATH` for basic commands
+(e.g. `.dll` files on Windows).
+"""
+
+
+import os
+from drivers.alr import run_alr
+
+
+# Check `alr --version` succeeds and prints something.
+p = run_alr("--version")
+assert len(p.out) > 0
+
+# Completely clear `PATH`.
+#
+# Setting it to an empty string causes a buffer overflow on some platforms
+# so we set it to a nonexistent directory.
+os.environ["PATH"] = os.path.join(os.getcwd(), "nonexistent")
+
+# Check `alr --version` still succeeds and prints something.
+p = run_alr("--version")
+assert len(p.out) > 0
+
+
+print("SUCCESS")

--- a/testsuite/tests/misc/empty-path/test.yaml
+++ b/testsuite/tests/misc/empty-path/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
It seems 134d1157 added a dependency on `libgcc_s_seh-1.dll` (via the new `den` crate) on Windows, without which all commands instantly (and silently) fail. This DLL is packaged along with GNAT but, since `alr` should be able to auto-install the toolchain on a fresh system, this behaviour seems like a bug.

This PR adds the `-static` linker switch, removing the external dependency on `libgcc_s_seh-1.dll`.

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
