### PR TITLE
feat: structured output with `alr --format show`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,3 +66,6 @@
 [submodule "deps/lml"]
 	path = deps/lml
 	url = https://github.com/mosteo/lml_ada
+[submodule "deps/yeison"]
+	path = deps/yeison
+	url = https://github.com/mosteo/yeison

--- a/TODO
+++ b/TODO
@@ -1,2 +1,0 @@
-- Test for `alr --format show`
-- Check all commands to either reject --format or work properly

--- a/TODO
+++ b/TODO
@@ -1,0 +1,2 @@
+- Test for `alr --format show`
+- Check all commands to either reject --format or work properly

--- a/alire.toml
+++ b/alire.toml
@@ -53,7 +53,7 @@ windows = { ALIRE_OS = "windows" }
 [[pins]]
 [pins.aaa]
 url    = "https://github.com/mosteo/aaa"
-commit = "ddfeffe2d6c8f9d19161df7b31d16d37bef4ba71"
+commit = "04450085232edda086d7376a6dcaf17ab6b45aa9"
 
 [pins.ada_toml]
 url    = "https://github.com/pmderodat/ada-toml"
@@ -72,7 +72,7 @@ url    = "https://github.com/alire-project/clic"
 commit = "56bbdc008e16996b6f76e443fd0165a240de1b13"
 [pins.den]
 url    = "https://github.com/mosteo/den"
-commit = "653a4c9ba4469d7e1a8896088789b6514ecdf834"
+commit = "377d1d906f83262b81b45c7989de8cd5b4aba67f"
 
 [pins.dirty_booleans]
 url    = "https://github.com/mosteo/dirty_booleans"
@@ -87,7 +87,7 @@ url    = "https://github.com/alire-project/gnatcoll-core.git"
 commit = "4e663b87a028252e7e074f054f8f453661397166"
 [pins.lml]
 url    = "https://github.com/mosteo/lml_ada.git"
-commit = "ae156ef82a2fedb7e28bb4dcaeb3d5c0a2e046ec"
+commit = "8a9e8158f4ffda54af7f321607a94d689bf0cbb2"
 
 [pins.minirest]
 url    = "https://github.com/mosteo/minirest.git"
@@ -112,6 +112,11 @@ commit = "f607a63b714f09bbf6126de9851cbc21cf8666c9"
 [pins.toml_slicer]
 url    = "https://github.com/mosteo/toml_slicer"
 commit = "3e5cbdb5673b85a1da6344a41764ef1cbafe3289"
+
+[pins.yeison_12]
+url    = "https://github.com/mosteo/yeison"
+subdir = "yeison_12"
+commit = "d443204288fe67145f8a352073253db227065a69"
 
 # To disable version updating, export ALR_VERSION_DONT_PATCH with any value
 

--- a/alire.toml
+++ b/alire.toml
@@ -27,7 +27,7 @@ diskflags = "~0.1"
 gnatcoll = "^21"
 lml = "~0.1"
 minirest = "~0.3"
-optional = "~0.1"
+optional = "~0.1.1"
 semantic_versioning = "^3.0"
 simple_logging = "^2.0"
 si_units = "~0.2.2"
@@ -92,6 +92,10 @@ commit = "8a9e8158f4ffda54af7f321607a94d689bf0cbb2"
 [pins.minirest]
 url    = "https://github.com/mosteo/minirest.git"
 commit = "9a9c660f9c6f27f5ef75417e7fac7061dff14d78"
+
+[pins.optional]
+url    = "https://github.com/mosteo/optional.git"
+commit = "7b8132a09a6c3c467409ab15d34fac605b1e5711"
 
 [pins.semantic_versioning]
 url    = "https://github.com/alire-project/semantic_versioning"

--- a/alire.toml
+++ b/alire.toml
@@ -87,7 +87,7 @@ url    = "https://github.com/alire-project/gnatcoll-core.git"
 commit = "4e663b87a028252e7e074f054f8f453661397166"
 [pins.lml]
 url    = "https://github.com/mosteo/lml_ada.git"
-commit = "8a9e8158f4ffda54af7f321607a94d689bf0cbb2"
+commit = "3d79edaff98bc4985014c641327ceb22d655df6b"
 
 [pins.minirest]
 url    = "https://github.com/mosteo/minirest.git"
@@ -120,7 +120,7 @@ commit = "3e5cbdb5673b85a1da6344a41764ef1cbafe3289"
 [pins.yeison_12]
 url    = "https://github.com/mosteo/yeison"
 subdir = "yeison_12"
-commit = "d443204288fe67145f8a352073253db227065a69"
+commit = "88b66242f8826fd4847e0ea06c7901b753e03c74"
 
 # To disable version updating, export ALR_VERSION_DONT_PATCH with any value
 

--- a/alr_env.gpr
+++ b/alr_env.gpr
@@ -31,7 +31,8 @@ aggregate project Alr_Env is
                          "deps/toml_slicer",
                          "deps/umwi",
                          "deps/uri-ada",
-                         "deps/xmlezout"
+                         "deps/xmlezout",
+                         "deps/yeison/yeison_12"
                         );
 
    for Project_Files use ("alr.gpr");

--- a/dev/reset-version.sh
+++ b/dev/reset-version.sh
@@ -1,0 +1,2 @@
+# Restore version in metadata to unknown
+git checkout -- src/alire/alire-meta.ads

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -6,6 +6,26 @@ stay on top of `alr` new features.
 
 ## Release `2.1`
 
+### New `--format` global switch to produce structured output
+
+PR [#1819](https://github.com/alire-project/alire/pull/1819)
+
+The global switch `--format` can be used to produce JSON format with some
+commands, e.g., `index`, `search`, `show`.
+
+This new switch accepts an optional parameter that can be JSON or TOML, to
+select the desired output language:
+
+```
+$ alr --format=TOML search --crates hello
+[[data]]                                        
+description = "'Hello, world!' demonstration project"
+name = "hello"
+[[data]]
+description = "Basic library demonstration project"
+name = "libhello"
+```
+
 ### Allow pinning a crate in a subdirectory of a git repository
 
 PR [#1857](https://github.com/alire-project/alire/pull/1857)

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -8,7 +8,7 @@ stay on top of `alr` new features.
 
 ### New `--format` global switch to produce structured output
 
-PR [#1819](https://github.com/alire-project/alire/pull/1819)
+PR [#1851](https://github.com/alire-project/alire/pull/1851)
 
 The global switch `--format` can be used to produce JSON format with some
 commands, e.g., `index`, `search`, `show`.

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -13,7 +13,7 @@ PR [#1851](https://github.com/alire-project/alire/pull/1851)
 The global switch `--format` can be used to produce JSON format with some
 commands, e.g., `index`, `search`, `show`.
 
-This new switch accepts an optional parameter that can be JSON or TOML, to
+This new switch accepts an optional parameter that can be JSON, TOML or YAML, to
 select the desired output language:
 
 ```

--- a/src/alire/alire-dependencies-graphs.adb
+++ b/src/alire/alire-dependencies-graphs.adb
@@ -183,13 +183,22 @@ package body Alire.Dependencies.Graphs is
 
       Filtered : constant Graph := This.Filtering_Unused (Solution.Crates);
    begin
+      if Utils.Tables.Structured_Output then
+         Table.Header ("Dependent").Header ("Dependency").New_Row;
+      end if;
+
       for Dep of Filtered loop
          Table.Append
            (Prefix & Label_Dependent (+Dep.Dependent, Solution, TTY => True));
-         Table.Append ("-->");
+
+         if not Utils.Tables.Structured_Output then
+            Table.Append ("-->");
+         end if;
+
          Table.Append
            (Label_Dependee
               (+Dep.Dependent, +Dep.Dependee, Solution, For_Plot => False));
+
          Table.New_Row;
       end loop;
 

--- a/src/alire/alire-formatting.adb
+++ b/src/alire/alire-formatting.adb
@@ -7,6 +7,9 @@ with Alire.OS_Lib;
 with Alire.Platforms.Current;
 with Alire.Version;
 
+with LML.Input.TOML;
+with LML.Output.Factory;
+
 package body Alire.Formatting is
 
    --------------
@@ -215,5 +218,18 @@ package body Alire.Formatting is
          return +Result;
       end if;
    end Format;
+
+   -----------
+   -- Print --
+   -----------
+
+   procedure Print (This   : TOML.TOML_Value;
+                    Format : Formats := Utils.Tables.Structured_Output_Format)
+   is
+      Builder : LML.Output.Builder'Class := LML.Output.Factory.Get (Format);
+   begin
+      LML.Input.TOML.From_TOML (This, Builder);
+      Trace.Always (LML.Encode (Builder.To_Text));
+   end Print;
 
 end Alire.Formatting;

--- a/src/alire/alire-formatting.ads
+++ b/src/alire/alire-formatting.ads
@@ -1,4 +1,7 @@
 with Alire.Roots;
+with Alire.Utils.Tables;
+
+with TOML;
 
 private with Ada.Containers.Indefinite_Ordered_Maps;
 
@@ -48,6 +51,21 @@ package Alire.Formatting is
    --  with native slashes on Windows, unless they are an escape sequence.
 
    Unknown_Formatting_Key : exception;
+
+   ------------------------------
+   --  Structured Data Output  --
+   ------------------------------
+
+   --  Features to dump lightweight markup when --format is in effect
+
+   subtype Formats is Utils.Tables.Formats;
+
+   Structured_Output : Boolean renames Utils.Tables.Structured_Output;
+
+   procedure Print (This   : TOML.TOML_Value;
+                    Format : Formats := Utils.Tables.Structured_Output_Format);
+   --  We require TOML input because that is what's currently being generated
+   --  everywhere. The actual output is according to Utils.Tables.Format
 
 private
 

--- a/src/alire/alire-meta.ads
+++ b/src/alire/alire-meta.ads
@@ -6,8 +6,8 @@ package Alire.Meta with Preelaborate is
 
    package Working_Tree is
 
-      Commit  : constant String := "0ec4e6ae2d231695a0cb57c7074afbfed1d6674c";
-      Changes : constant String := "dirty";
+      Commit  : constant String := "unknown";
+      Changes : constant String := "unknown";
 
       Main_Branch : constant String := "master";
       --  In case some day we rename the master branch in the repo

--- a/src/alire/alire-meta.ads
+++ b/src/alire/alire-meta.ads
@@ -6,8 +6,8 @@ package Alire.Meta with Preelaborate is
 
    package Working_Tree is
 
-      Commit  : constant String := "unknown";
-      Changes : constant String := "unknown";
+      Commit  : constant String := "0ec4e6ae2d231695a0cb57c7074afbfed1d6674c";
+      Changes : constant String := "dirty";
 
       Main_Branch : constant String := "master";
       --  In case some day we rename the master branch in the repo

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -40,17 +40,6 @@ package body Alire.Releases is
        then Sort_Compilers (L, R)
        else Standard_Sorting (L, R));
 
-   ------------
-   -- Adjust --
-   ------------
-
-   overriding procedure Adjust (This : in out Release) is
-   begin
-      if This.Imported.Is_Present then
-         This.Imported := This.Imported.Clone;
-      end if;
-   end Adjust;
-
    --------------------
    -- All_Properties --
    --------------------
@@ -485,8 +474,7 @@ package body Alire.Releases is
 
       return Replacement : constant Release
         (Base.Name.Length, New_Notes'Length) :=
-        (Parent with
-         Prj_Len   => Base.Name.Length,
+        (Prj_Len   => Base.Name.Length,
          Notes_Len => New_Notes'Length,
          Name      => Base.Name,
          Notes     => New_Notes,
@@ -543,8 +531,7 @@ package body Alire.Releases is
                          Properties   : Conditional.Properties;
                          Available    : Conditional.Availability)
                          return Release
-   is (Parent with
-       Prj_Len      => Name.Length,
+   is (Prj_Len      => Name.Length,
        Notes_Len    => Notes'Length,
        Name         => Name,
        Version      => Version,
@@ -556,7 +543,7 @@ package body Alire.Releases is
        Forbidden    => Conditional.For_Dependencies.Empty,
        Properties   => Properties,
        Available    => Available,
-       Imported     => TOML.No_TOML_Value);
+       Imported     => No_TOML_Value);
 
    -----------------------
    -- New_Empty_Release --
@@ -578,8 +565,7 @@ package body Alire.Releases is
       Properties   : Conditional.Properties   :=
         Default_Properties)
       return         Release is
-     (Parent with
-      Prj_Len      => Name.Length,
+     (Prj_Len      => Name.Length,
       Notes_Len    => 0,
       Name         => Name,
       Version      => +"0.0.0",
@@ -591,7 +577,7 @@ package body Alire.Releases is
       Forbidden    => Conditional.For_Dependencies.Empty,
       Properties   => Properties,
       Available    => Conditional.Empty,
-      Imported     => TOML.No_TOML_Value
+      Imported     => No_TOML_Value
      );
 
    -------------------------
@@ -872,7 +858,7 @@ package body Alire.Releases is
             --  missing for releases being created from scratch during `alr
             --  init`, but there's no way for a user to get us here until
             --  after the release has been reloaded from its manifest.
-            Formatting.Print (R.Imported);
+            Formatting.Print (R.Imported.all);
          else
             if R.Properties.Is_Unconditional then
                Formatting.Print
@@ -1067,7 +1053,7 @@ package body Alire.Releases is
          --  expressions unresolved. Keep a copy since TOML is using reference
          --  semantics.
 
-         This.Imported := From.Unwrap.Clone;
+         This.Imported.all := From.Unwrap.Clone;
 
          --  Extract the version ASAP to show it properly during logging
 
@@ -1312,8 +1298,7 @@ package body Alire.Releases is
    function Whenever (R : Release;
                       P : Alire.Properties.Vector)
                       return Release
-   is (Parent with
-       Prj_Len      => R.Prj_Len,
+   is (Prj_Len      => R.Prj_Len,
        Notes_Len    => R.Notes_Len,
        Name         => R.Name,
        Version      => R.Version,
@@ -1326,7 +1311,7 @@ package body Alire.Releases is
        Properties   => R.Properties.Evaluate (P),
        Available    => R.Available.Evaluate (P),
 
-       Imported     => TOML.No_TOML_Value
+       Imported     => No_TOML_Value
        --  We are discarding information above, so the imported information
        --  would no longer match.
       );

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -40,6 +40,17 @@ package body Alire.Releases is
        then Sort_Compilers (L, R)
        else Standard_Sorting (L, R));
 
+   ------------
+   -- Adjust --
+   ------------
+
+   overriding procedure Adjust (This : in out Release) is
+   begin
+      if This.Imported.Is_Present then
+         This.Imported := This.Imported.Clone;
+      end if;
+   end Adjust;
+
    --------------------
    -- All_Properties --
    --------------------
@@ -474,7 +485,8 @@ package body Alire.Releases is
 
       return Replacement : constant Release
         (Base.Name.Length, New_Notes'Length) :=
-        (Prj_Len   => Base.Name.Length,
+        (Parent with
+         Prj_Len   => Base.Name.Length,
          Notes_Len => New_Notes'Length,
          Name      => Base.Name,
          Notes     => New_Notes,
@@ -531,7 +543,8 @@ package body Alire.Releases is
                          Properties   : Conditional.Properties;
                          Available    : Conditional.Availability)
                          return Release
-   is (Prj_Len      => Name.Length,
+   is (Parent with
+       Prj_Len      => Name.Length,
        Notes_Len    => Notes'Length,
        Name         => Name,
        Version      => Version,
@@ -565,7 +578,8 @@ package body Alire.Releases is
       Properties   : Conditional.Properties   :=
         Default_Properties)
       return         Release is
-     (Prj_Len      => Name.Length,
+     (Parent with
+      Prj_Len      => Name.Length,
       Notes_Len    => 0,
       Name         => Name,
       Version      => +"0.0.0",
@@ -1298,7 +1312,8 @@ package body Alire.Releases is
    function Whenever (R : Release;
                       P : Alire.Properties.Vector)
                       return Release
-   is (Prj_Len      => R.Prj_Len,
+   is (Parent with
+       Prj_Len      => R.Prj_Len,
        Notes_Len    => R.Notes_Len,
        Name         => R.Name,
        Version      => R.Version,

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -854,7 +854,7 @@ package body Alire.Releases is
          if R.Imported.Is_Present then
             --  This field may be missing if R.Whenever has been used, in which
             --  case we properly want to print the re-exported information
-            --  without dynamic expressions (else branch). It may be also
+            --  without dynamic expressions (else branch below). It may be also
             --  missing for releases being created from scratch during `alr
             --  init`, but there's no way for a user to get us here until
             --  after the release has been reloaded from its manifest.

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -7,11 +7,13 @@ with Alire.Directories;
 with Alire.Defaults;
 with Alire.Errors;
 with Alire.Flags;
+with Alire.Formatting;
 with Alire.Origins.Deployers.System;
 with Alire.Paths;
 with Alire.Properties.Bool;
 with Alire.Properties.Scenarios;
 with Alire.TOML_Load;
+with Alire.Utils.Tables;
 with Alire.Utils.YAML;
 with Alire.Warnings;
 
@@ -845,6 +847,15 @@ package body Alire.Releases is
    procedure Print (R : Release) is
       use GNAT.IO;
    begin
+      if Alire.Utils.Tables.Structured_Output then
+         Formatting.Print
+           (R.To_TOML
+              (if R.Origin.Kind in Origins.Filesystem
+               then Manifest.Local
+               else Manifest.Index));
+         return;
+      end if;
+
       --  MILESTONE
       Put_Line (R.Milestone.TTY_Image & ": " & R.TTY_Description);
 

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -487,8 +487,7 @@ package body Alire.Releases is
          Forbidden    => Base.Forbidden,
          Properties   => Base.Properties,
          Available    => Base.Available,
-
-         Imported     => TOML.No_TOML_Value)
+         Imported     => Base.Imported)
       do
          null;
       end return;
@@ -578,7 +577,6 @@ package body Alire.Releases is
       Forbidden    => Conditional.For_Dependencies.Empty,
       Properties   => Properties,
       Available    => Conditional.Empty,
-
       Imported     => TOML.No_TOML_Value
      );
 

--- a/src/alire/alire-releases.ads
+++ b/src/alire/alire-releases.ads
@@ -412,6 +412,10 @@ private
       Forbidden    : Conditional.Dependencies;
       Properties   : Conditional.Properties;
       Available    : Conditional.Availability;
+
+      Imported     : TOML.TOML_Value;
+      --  For releases loaded from a manifest, this is the original structured
+      --  data that generated it, in which case Imported.Is_Present.
    end record;
 
    function From_TOML (This   : in out Release;

--- a/src/alire/alire-releases.ads
+++ b/src/alire/alire-releases.ads
@@ -422,13 +422,13 @@ private
       --  For releases loaded from a manifest, this is the original structured
       --  data that generated it, in which case Imported.Is_Present.
       --
-      --  Not deep-copying this value on copy of Release triggers a hard to
-      --  diagnose bug somewhere for GNAT<14, in which finalization of the
-      --  main Ada library raises for some reason. This is likely caused
-      --  by TOML_Value being internally a by-reference type. I found two
-      --  workarounds: using explicit pointers to hold a TOML_Value, which
-      --  allows keeping Release non-controlled (but leaky), or cloning the
-      --  value on Adjust.
+      --  GNATs<14 have trouble with this value, raising during main Ada lib
+      --  finalization. Given that GNAT 14 is happy, and that TOML_Value is
+      --  a by-reference type internally, it seems pretty likely this is some
+      --  obscure bug in older GNATs. The only workaround I've found at this
+      --  time is to avoid finalization by explicitly allocating the value.
+      --  This is leaky, so we may want to revisit this issue in the future.
+      --  TODO: find better workaround.
    end record;
 
    function From_TOML (This   : in out Release;

--- a/src/alire/alire-releases.ads
+++ b/src/alire/alire-releases.ads
@@ -26,7 +26,6 @@ with Semantic_Versioning;
 
 with TOML;
 
-private with Ada.Finalization;
 private with Alire.OS_Lib;
 private with Alire.Utils.TTY;
 private with CLIC.TTY;
@@ -399,13 +398,14 @@ private
                             return Alire.Properties.Vector;
    --  Properties that R has under platform properties P
 
-   subtype Parent is Ada.Finalization.Controlled;
-   --  We need to make Release Controlled to work around a bug in GNAT<14. See
-   --  field Imported for more.
+   type TOML_Value_Ptr is access TOML.TOML_Value;
+
+   function No_TOML_Value return TOML_Value_Ptr
+   is (new TOML.TOML_Value'(TOML.No_TOML_Value));
 
    type Release (Prj_Len,
                  Notes_Len : Natural)
-   is new Parent and Interfaces.Yamlable
+   is new Interfaces.Yamlable
    with record
       Name         : Crate_Name (Prj_Len);
       Version      : Semantic_Versioning.Version;
@@ -418,7 +418,7 @@ private
       Properties   : Conditional.Properties;
       Available    : Conditional.Availability;
 
-      Imported     : TOML.TOML_Value;
+      Imported     : TOML_Value_Ptr := No_TOML_Value;
       --  For releases loaded from a manifest, this is the original structured
       --  data that generated it, in which case Imported.Is_Present.
       --
@@ -430,8 +430,6 @@ private
       --  allows keeping Release non-controlled (but leaky), or cloning the
       --  value on Adjust.
    end record;
-
-   overriding procedure Adjust (This : in out Release);
 
    function From_TOML (This   : in out Release;
                        From   :        TOML_Adapters.Key_Queue;

--- a/src/alr/alr-commands-action.adb
+++ b/src/alr/alr-commands-action.adb
@@ -182,6 +182,8 @@ package body Alr.Commands.Action is
    procedure Execute (Cmd  : in out Command;
                       Args :        AAA.Strings.Vector) is
    begin
+      Cmd.Forbids_Structured_Output;
+
       if Args.Is_Empty then
          Cmd.List;
       else

--- a/src/alr/alr-commands-build.adb
+++ b/src/alr/alr-commands-build.adb
@@ -127,6 +127,8 @@ package body Alr.Commands.Build is
    is
       use type Alire.Builds.Stop_Points;
    begin
+      Cmd.Forbids_Structured_Output;
+
       --  Prevent premature update of dependencies, as the exact folders
       --  will depend on the build hashes, which are yet unknown until
       --  build profiles are applied.

--- a/src/alr/alr-commands-cache.adb
+++ b/src/alr/alr-commands-cache.adb
@@ -1,5 +1,6 @@
 with Alire.Cache;
 with Alire.Directories;
+with Alire.Formatting;
 with Alire.Utils.Tables;
 
 package body Alr.Commands.Cache is
@@ -12,17 +13,26 @@ package body Alr.Commands.Cache is
       use Alire.Directories;
       Table : Alire.Utils.Tables.Table;
       Usage : constant Alire.Cache.Usages := Alire.Cache.Usage;
+      Size  : constant String :=
+                TTY_Image (if Usage.Is_Empty
+                           then 0
+                           else Alire.Cache.Usage.First_Element.Size);
    begin
-      Table
-        .Append ("Path:")
-        .Append (Alire.Cache.Path)
-        .New_Row;
+      if Alire.Formatting.Structured_Output then
+         Table.Header ("Path").Header ("Size").New_Row;
+         Table.Append (Alire.Cache.Path).Append (Size);
+      else
+         Table
+           .Append ("Path:")
+           .Append (Alire.Cache.Path)
+           .New_Row;
 
-      Table
-        .Append ("Size:")
-        .Append (TTY_Image (if Usage.Is_Empty
-                            then 0
-                            else Alire.Cache.Usage.First_Element.Size));
+         Table
+           .Append ("Size:")
+           .Append (TTY_Image (if Usage.Is_Empty
+                    then 0
+                    else Alire.Cache.Usage.First_Element.Size));
+      end if;
 
       Table.Print (Trace.Always);
    end Summary;

--- a/src/alr/alr-commands-clean.adb
+++ b/src/alr/alr-commands-clean.adb
@@ -119,6 +119,7 @@ package body Alr.Commands.Clean is
    is
       use AAA.Strings;
    begin
+      Cmd.Forbids_Structured_Output;
 
       if not (Cmd.Cache or else Cmd.Temp) then
          Cmd.Requires_Workspace;

--- a/src/alr/alr-commands-edit.adb
+++ b/src/alr/alr-commands-edit.adb
@@ -150,6 +150,8 @@ package body Alr.Commands.Edit is
 
       package Builtins renames Alire.Settings.Builtins;
    begin
+      Cmd.Forbids_Structured_Output;
+
       if Args.Count /= 0 then
          Reportaise_Wrong_Arguments (Cmd.Name & " doesn't take arguments");
       end if;

--- a/src/alr/alr-commands-exec.adb
+++ b/src/alr/alr-commands-exec.adb
@@ -20,6 +20,8 @@ package body Alr.Commands.Exec is
       use AAA.Strings;
 
    begin
+      Cmd.Forbids_Structured_Output;
+
       if Args.Is_Empty then
          Reportaise_Wrong_Arguments
            (Cmd.Name & " takes at least one argument");

--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -606,6 +606,7 @@ package body Alr.Commands.Init is
          or else Builtins.User_Name.Is_Empty
          or else Builtins.User_Github_Login.Is_Empty;
    begin
+      Cmd.Forbids_Structured_Output;
 
       if Cmd.Bin and then Cmd.Lib then
          Reportaise_Wrong_Arguments ("Please provide either --bin or --lib");

--- a/src/alr/alr-commands-install.adb
+++ b/src/alr/alr-commands-install.adb
@@ -15,6 +15,8 @@ package body Alr.Commands.Install is
 
    procedure Validate (Cmd : in out Command; Args : AAA.Strings.Vector) is
    begin
+      Cmd.Forbids_Structured_Output;
+
       --  If nothing given, we must be in workspace
       if not Cmd.Info and then Args.Is_Empty then
          Cmd.Requires_Workspace

--- a/src/alr/alr-commands-printenv.adb
+++ b/src/alr/alr-commands-printenv.adb
@@ -16,6 +16,8 @@ package body Alr.Commands.Printenv is
    is
       Enabled : Natural := 0;
    begin
+      Cmd.Forbids_Structured_Output;
+
       if Args.Count /= 0 then
          Reportaise_Wrong_Arguments (Cmd.Name & " doesn't take arguments");
       end if;

--- a/src/alr/alr-commands-publish.adb
+++ b/src/alr/alr-commands-publish.adb
@@ -46,6 +46,8 @@ package body Alr.Commands.Publish is
                      For_Private_Index => Cmd.For_Private_Index);
 
    begin
+      Cmd.Forbids_Structured_Output;
+
       if Alire.Utils.Count_True
         ((Cmd.Tar, Cmd.Print_Trusted, Cmd.Status,
           Cmd.Cancel.all /= Unset, Cmd.Review.all /= Unset)) > 1

--- a/src/alr/alr-commands-run.adb
+++ b/src/alr/alr-commands-run.adb
@@ -102,6 +102,7 @@ package body Alr.Commands.Run is
       end List;
 
    begin
+      Cmd.Forbids_Structured_Output;
       Cmd.Requires_Workspace;
 
       --  Validation

--- a/src/alr/alr-commands-settings.adb
+++ b/src/alr/alr-commands-settings.adb
@@ -21,6 +21,7 @@ package body Alr.Commands.Settings is
                                             then Alire.Settings.Global
                                             else Alire.Settings.Local);
    begin
+      Cmd.Forbids_Structured_Output;
 
       --  Check no multi-action
       Enabled := Enabled + (if Cmd.List then 1 else 0);

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -2,6 +2,7 @@ with Ada.Containers;
 
 with Alire.Conditional;
 with Alire.Dependencies;
+with Alire.Formatting;
 with Alire.Index.Search;
 with Alire.Milestones;
 with Alire.Platforms.Current;
@@ -79,8 +80,22 @@ package body Alr.Commands.Show is
          Rel : constant Alire.Releases.Release :=
                  Cmd.Find_Target_Release (Name, Versions, Current);
       begin
+         if Alire.Formatting.Structured_Output and then
+           (Cmd.Graph or else Cmd.Solve or else Cmd.Tree)
+         then
+            Reportaise_Wrong_Arguments
+              ("--format global switch is incompatible with "
+               & (if Cmd.Graph then "--graph"
+                  elsif Cmd.Solve then "--solve"
+                  else "--tree"));
+         end if;
+
          if Cmd.System then
             Rel.Whenever (Platform.Properties).Print;
+         elsif Alire.Formatting.Structured_Output then
+            Reportaise_Wrong_Arguments
+              ("--format global switch requires command switch --system, e.g.:"
+               & " " & TTY.Terminal ("alr --format show --system"));
          else
             Rel.Print;
          end if;

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -92,10 +92,6 @@ package body Alr.Commands.Show is
 
          if Cmd.System then
             Rel.Whenever (Platform.Properties).Print;
-         elsif Alire.Formatting.Structured_Output then
-            Reportaise_Wrong_Arguments
-              ("--format global switch requires command switch --system, e.g.:"
-               & " " & TTY.Terminal ("alr --format show --system"));
          else
             Rel.Print;
          end if;

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -617,6 +617,9 @@ package body Alr.Commands.Test is
 
    begin
       --  Validate command line
+
+      Cmd.Forbids_Structured_Output;
+
       if not Cmd.Search then
          for I in Integer range Args.First_Index .. Args.Last_Index loop
             declare

--- a/src/alr/alr-commands-update.adb
+++ b/src/alr/alr-commands-update.adb
@@ -35,6 +35,7 @@ package body Alr.Commands.Update is
       end Parse_Allowed;
 
    begin
+      Cmd.Forbids_Structured_Output;
       Cmd.Requires_Workspace (Sync => False);
       --  The user has explicitly requested an update, so it makes no sense to
       --  sync previously, or the update would never find changes.

--- a/src/alr/alr-commands-withing.adb
+++ b/src/alr/alr-commands-withing.adb
@@ -271,6 +271,7 @@ package body Alr.Commands.Withing is
 
    begin
       Cmd.Requires_Workspace;
+      Cmd.Forbids_Structured_Output;
 
       if Cmd.URL.all /= "" then
          Flags := Flags + 1;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -312,7 +312,7 @@ package body Alr.Commands is
    begin
       if Alire.Formatting.Structured_Output then
          Reportaise_Wrong_Arguments
-           ("Command " & TTY.Terminal (Cmd.Name) & " does not yet support the "
+           ("Command " & TTY.Terminal (Cmd.Name) & " does not support the "
             & TTY.Terminal ("--format") & " switch");
       end if;
    end Forbids_Structured_Output;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -12,6 +12,7 @@ with Alire.Settings.Builtins;
 with Alire.Settings.Edit;
 with Alire.Errors;
 with Alire.Features;
+with Alire.Formatting;
 with Alire.Index_On_Disk.Loading;
 with Alire.Index_On_Disk.Updates;
 with Alire.Lockfiles;
@@ -302,6 +303,19 @@ package body Alr.Commands is
          Detect_Externals => Externals,
          Strict           => Strict);
    end Load;
+
+   -------------------------------
+   -- Forbids_Structured_Output --
+   -------------------------------
+
+   procedure Forbids_Structured_Output (Cmd : in out Command'Class) is
+   begin
+      if Alire.Formatting.Structured_Output then
+         Reportaise_Wrong_Arguments
+           ("Command " & TTY.Terminal (Cmd.Name) & " does not yet support the "
+            & TTY.Terminal ("--format") & " switch");
+      end if;
+   end Forbids_Structured_Output;
 
    -------------------------
    -- Requires_Full_Index --

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -70,6 +70,10 @@ package Alr.Commands is
    --  performing a silent update. If not Sync, only a minimal empty lockfile
    --  is created. If Error, replace the first generic error message with it.
 
+   procedure Forbids_Structured_Output (Cmd : in out Command'Class);
+   --  Use this to mark that the output of a command is not (yet) compatible
+   --  with global flag --format.
+
    function Has_Root (Cmd : in out Command'Class) return Boolean;
    --  True when Requires_Workspace would succeed, false otherwise
 

--- a/testsuite/run.sh
+++ b/testsuite/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 clear
-python3 run.py --show-time-info -M1 "$@"
+python3 run.py -j$(nproc) --show-time-info -M1 "$@"

--- a/testsuite/run.sh
+++ b/testsuite/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 clear
-python3 run.py -j$(nproc) --show-time-info -M1 "$@"
+python3 run.py --show-time-info -M1 "$@"

--- a/testsuite/tests/misc/structured-tables/test.py
+++ b/testsuite/tests/misc/structured-tables/test.py
@@ -2,7 +2,7 @@
 Verify structured output of tables
 """
 
-import json
+import json, yaml
 
 import toml
 from drivers.alr import run_alr, init_local_crate
@@ -36,6 +36,14 @@ name = "gprbuild"
 """,
           run_alr("--format=TOML", "search", "--crates").out)
 
+assert_eq("""\
+- "name": "gnat_external"
+  "description": "GNAT is a compiler for the Ada programming language"
+- "name": "gprbuild"
+  "description": "Fake gprbuild external"
+""",
+          run_alr("--format=YAML", "search", "--crates").out)
+
 # Empty pin list
 
 init_local_crate()
@@ -51,13 +59,15 @@ assert_eq("""\
 
 # Check that objects can be reconstructed and queried from the output
 
-for fmt in ["JSON", "TOML"]:
+for fmt in ["JSON", "TOML", "YAML"]:
     # List of releases
     out = run_alr(f"--format={fmt}", "-q", "search", "--list", "--external").out
     # Load and adjust according to format
     if fmt == "TOML":
         releases = toml.loads(out)["data"]
         # In the TOML case, top-level is always a table with a single key "data"
+    elif fmt == "YAML":
+        releases = yaml.safe_load(out)
     else:
         releases = json.loads(out)
 

--- a/testsuite/tests/misc/structured-tables/test.py
+++ b/testsuite/tests/misc/structured-tables/test.py
@@ -40,8 +40,7 @@ name = "gprbuild"
 
 init_local_crate()
 assert_eq("""\
-[
-]
+[]
 """,
           run_alr("--format=JSON", "pin").out)
 

--- a/testsuite/tests/show/structured-output/test.py
+++ b/testsuite/tests/show/structured-output/test.py
@@ -49,13 +49,13 @@ assert_eq(r"""{
         "type": "Integer"
       },
       "Var6": {
-        "default": 0.00000000000000000E+00,
-        "first": -1.00000000000000000E+00,
-        "last": 1.00000000000000000E+00,
+        "default": 0.0,
+        "first": -1.0,
+        "last": 1.0,
         "type": "Real"
       },
       "Var7": {
-        "default": 0.00000000000000000E+00,
+        "default": 0.0,
         "type": "Real"
       }
     }
@@ -150,5 +150,64 @@ type = "Real"
 url = "file:../../../crates/hello_1.0.1"
 [[depends-on]]
 libhello = "^1.0"'''), run_alr("--format=TOML", "show", "hello").out)
+
+# YAML
+
+assert_eq(r'''"authors":
+  - "Bob"
+  - "Alice"
+"configuration":
+  "values":
+    "hello":
+      "Var1": true
+    "libhello":
+      "Var1": false
+  "variables":
+    "Var1":
+      "type": "Boolean"
+    "Var2":
+      "default": "str"
+      "type": "String"
+    "Var3":
+      "default": "A"
+      "type": "Enum"
+      "values":
+        - "A"
+        - "B"
+    "Var4":
+      "default": 0
+      "type": "Integer"
+    "Var5":
+      "default": 0
+      "first": -1
+      "last": 1
+      "type": "Integer"
+    "Var6":
+      "default": 0.0
+      "first": -1.0
+      "last": 1.0
+      "type": "Real"
+    "Var7":
+      "default": 0.0
+      "type": "Real"
+"depends-on":
+  - "libhello": "^1.0"
+"description": "\"Hello, world!\" demonstration project"
+"licenses": "GPL-3.0-only OR MIT"
+"long-description": "This is an example of long description in a multi-line string.\n\nMarkdown formating `can` be used to have \"nice\" display on the website.\n"
+"maintainers":
+  - "alejandro@mosteo.com"
+  - "bob@example.com"
+"maintainers-logins":
+  - "mylogin"
+"name": "hello"
+"origin":
+  "url": "file:../../../crates/hello_1.0.1"
+"tags":
+  - "tag1"
+  - "other-tag"
+"version": "1.0.1"
+"website": "example.com"
+''', run_alr("--format=YAML", "show", "hello").out)
 
 print("SUCCESS")

--- a/testsuite/tests/show/structured-output/test.py
+++ b/testsuite/tests/show/structured-output/test.py
@@ -1,0 +1,154 @@
+"""
+Check the structured output of `alr show` for a complex crate
+"""
+
+import re
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq, assert_match
+
+# JSON
+
+assert_eq(r"""{
+  "authors": [
+    "Bob",
+    "Alice"
+  ],
+  "configuration": {
+    "values": {
+      "hello": {
+        "Var1": true
+      },
+      "libhello": {
+        "Var1": false
+      }
+    },
+    "variables": {
+      "Var1": {
+        "type": "Boolean"
+      },
+      "Var2": {
+        "default": "str",
+        "type": "String"
+      },
+      "Var3": {
+        "default": "A",
+        "type": "Enum",
+        "values": [
+          "A",
+          "B"
+        ]
+      },
+      "Var4": {
+        "default": 0,
+        "type": "Integer"
+      },
+      "Var5": {
+        "default": 0,
+        "first": -1,
+        "last": 1,
+        "type": "Integer"
+      },
+      "Var6": {
+        "default": 0.00000000000000000E+00,
+        "first": -1.00000000000000000E+00,
+        "last": 1.00000000000000000E+00,
+        "type": "Real"
+      },
+      "Var7": {
+        "default": 0.00000000000000000E+00,
+        "type": "Real"
+      }
+    }
+  },
+  "depends-on": [
+    {
+      "libhello": "^1.0"
+    }
+  ],
+  "description": "\"Hello, world!\" demonstration project",
+  "licenses": "GPL-3.0-only OR MIT",
+  "long-description": "This is an example of long description in a multi-line string.\n\nMarkdown formating `can` be used to have \"nice\" display on the website.\n",
+  "maintainers": [
+    "alejandro@mosteo.com",
+    "bob@example.com"
+  ],
+  "maintainers-logins": [
+    "mylogin"
+  ],
+  "name": "hello",
+  "origin": {
+    "url": "file:../../../crates/hello_1.0.1"
+  },
+  "tags": [
+    "tag1",
+    "other-tag"
+  ],
+  "version": "1.0.1",
+  "website": "example.com"
+}
+""", run_alr("--format", "show", "hello").out)
+
+# TOML
+
+assert_match(re.escape(r'''authors = [
+"Bob",
+"Alice",
+]
+description = "\"Hello, world!\" demonstration project"
+licenses = "GPL-3.0-only OR MIT"
+long-description = "This is an example of long description in a multi-line string.\n\nMarkdown formating `can` be used to have \"nice\" display on the website.\n"
+maintainers = [
+"alejandro@mosteo.com",
+"bob@example.com",
+]
+maintainers-logins = [
+"mylogin",
+]
+name = "hello"
+tags = [
+"tag1",
+"other-tag",
+]
+version = "1.0.1"
+website = "example.com"
+[configuration]
+[configuration.values]
+[configuration.values.hello]
+Var1 = true
+[configuration.values.libhello]
+Var1 = false
+[configuration.variables]
+[configuration.variables.Var1]
+type = "Boolean"
+[configuration.variables.Var2]
+default = "str"
+type = "String"
+[configuration.variables.Var3]
+default = "A"
+type = "Enum"
+values = [
+"A",
+"B",
+]
+[configuration.variables.Var4]
+default = 0
+type = "Integer"
+[configuration.variables.Var5]
+default = 0
+first = -1
+last = 1
+type = "Integer"
+[configuration.variables.Var6]
+default = 0.00000000000000E+00
+first = -1.00000000000000E+00
+last = 1.00000000000000E+00
+type = "Real"
+[configuration.variables.Var7]
+default = 0.00000000000000E+00
+type = "Real"
+[origin]
+url = "file:../../../crates/hello_1.0.1"
+[[depends-on]]
+libhello = "^1.0"'''), run_alr("--format=TOML", "show", "hello").out)
+
+print("SUCCESS")

--- a/testsuite/tests/show/structured-output/test.yaml
+++ b/testsuite/tests/show/structured-output/test.yaml
@@ -1,0 +1,5 @@
+driver: python-script
+build_mode: both
+indexes:
+    basic_index:
+        in_fixtures: true


### PR DESCRIPTION
Show accepts now `--format`:
```
$ alr --format show hello
{
  "authors": [
    "Alejandro R. Mosteo"
  ],
  "depends-on": [
    {
      "libhello": "^1.0"
    }
  ],
  "description": "'Hello, world!' demonstration project",
  "executables": [
    "hello"
  ],
  "licenses": "MIT",
  "maintainers": [
    "Alejandro R. Mosteo <alejandro@mosteo.com>"
  ],
  "maintainers-logins": [
    "mosteo"
  ],
  "name": "hello",
  "origin": {
    "commit": "5715870bf1637ac06c87a3db580d4efdfd5daeed",
    "url": "git+https://github.com/alire-project/hello.git"
  },
  "tags": [
    "hello",
    "demo"
  ],
  "version": "1.0.2",
  "website": "https://github.com/alire-project/hello"
}
```
Also did a general review of all the commands to forbid `--format` when not applicable.

User changes didn't mention `--format` when it was introduced, so added that too.

Fixes https://github.com/alire-project/alire/issues/1151
Fixes https://github.com/alire-project/alire/issues/1600

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [x] `doc/user-changes.md` has been updated, if there are user-visible changes.
