### PR TITLE
Fix GCC 15 warnings

### DIFF
--- a/src/alire/alire-conditional_trees.ads
+++ b/src/alire/alire-conditional_trees.ads
@@ -447,7 +447,7 @@ private
    procedure To_TOML (This : Vector_Node; Parent : TOML.TOML_Value);
 
    overriding
-   function TO_YAML (V : Vector_Node) return String;
+   function To_YAML (V : Vector_Node) return String;
 
    function Is_Vector (This : Tree) return Boolean is
      (not This.Is_Empty and then This.Root in Vector_Node);


### PR DESCRIPTION
> alire-conditional_trees.adb:30:14: (style) bad casing of "TO_YAML" declared at alire-conditional_trees.ads:450 [-gnatyr]

<!-- Description of the changes -->

##### PR creation checklist
- [ ] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
