### PR TITLE
fix: Did_You_Mean crashing with invalid data

### DIFF
--- a/src/alire/alire-utils-did_you_mean.adb
+++ b/src/alire/alire-utils-did_you_mean.adb
@@ -7,14 +7,14 @@ package body Alire.Utils.Did_You_Mean with Preelaborate is
    -------------------------------
 
    function Levenshtein_Edit_Distance (S, T : String) return Natural is
-      D : array (0 .. S'Last, 0 .. T'Last) of Natural;
+      D : array (S'First - 1 .. S'Last, T'First - 1 .. T'Last) of Natural;
    begin
       for I in D'Range (1) loop
-         D (I, 0) := I;
+         D (I, T'First - 1) := I;
       end loop;
 
       for J in D'Range (2) loop
-         D (0, J) := J;
+         D (S'First - 1, J) := J;
       end loop;
 
       for I in S'Range loop

--- a/testsuite/tests/issues/did-you-mean/test.py
+++ b/testsuite/tests/issues/did-you-mean/test.py
@@ -1,0 +1,16 @@
+"""
+Verify that `alr --format=yam` does not crash
+"""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_substring
+
+
+p = run_alr("--format=yam", complain_on_error=False)  # Note, not yaml
+
+# The invalid format should be properly reported instead of a exception being raised
+
+assert_substring("Unknown argument in --format=yam", p.out)
+
+
+print("SUCCESS")

--- a/testsuite/tests/issues/did-you-mean/test.yaml
+++ b/testsuite/tests/issues/did-you-mean/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
I was getting intermittent errors (so I guess this is related to uninitialized memory, as per the fix):
```
$ alr --format=yam
error: alire-utils-did_you_mean.adb:28 invalid data
error: alr encountered an unexpected error, re-run with -d for details.
error: error location: 0xe0d03e Alire.Utils.Did_You_Mean.Levenshtein_Edit_Distance at alire-utils-did_you_mean.adb:28
$ alr --format=yam
error: Unknown argument in --format=yam. Can be: JSON, TOML.
```

##### PR creation checklist
- [x] A test is included, if required by the changes.
