### PR TITLE
Improve error when evaluating unknown predefined variables in env

### DIFF
--- a/src/alire/alire-environment-loading.adb
+++ b/src/alire/alire-environment-loading.adb
@@ -1,3 +1,5 @@
+with Ada.Exceptions;
+
 with Alire_Early_Elaboration;
 with Alire.Formatting;
 with Alire.GPR;
@@ -144,10 +146,11 @@ package body Alire.Environment.Loading is
                end case;
             end;
          exception
-            when Formatting.Unknown_Formatting_Key =>
+            when E : Formatting.Unknown_Formatting_Key =>
                Raise_Checked_Error
-                 ("Unknown environment variable formatting key in var '" &
-                    Act.Name & " of '" & Origin & "'");
+                 ("Unknown predefined variable in environment variable '" &
+                    Act.Name & "' of '" & Origin & "': " &
+                    Ada.Exceptions.Exception_Message (E));
          end;
       end loop;
 


### PR DESCRIPTION
Now, the full message mentions the fact that this evaluation is expected for predefined variables only, and the offending key is printed.

Example:
```
error: Unknown predefined variable in environment variable 'PATH' of 'alr': Unknown formatting key: HOME
```

##### PR creation checklist
- [ ] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
