### PR TITLE
fix: enable assertions in test crate

### DIFF
--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -370,6 +370,7 @@ package body Alr.Commands.Init is
          Put_New_Line;
          Put_Line ("[build-profiles]");
          Put_Line (Lower_Name & " = 'validation'");
+         Put_Line (Test_Lower & " = 'validation'");
          TIO.Close (File);
 
          if not Create (+Full_Name (Test_Directory / (+Test_Lower & ".gpr"))) then

--- a/testsuite/tests/test/default-failure/test.py
+++ b/testsuite/tests/test/default-failure/test.py
@@ -9,10 +9,24 @@ from drivers.asserts import assert_match
 
 init_local_crate("xxx", with_test=True)
 
+# Check with explicit exception
+
 with open("./tests/src/xxx_tests-example_test.adb", "w") as f:
    f.write("""procedure Xxx_Tests.Example_Test is
 begin
    raise Program_Error;
+end Xxx_Tests.Example_Test;
+""")
+
+p = run_alr("test", complain_on_error=False)
+assert_match(".*\[ FAIL \] example_test.*", p.out)
+
+# Check with plain assertion (verify that assertions are evaluated)
+
+with open("./tests/src/xxx_tests-example_test.adb", "w") as f:
+   f.write("""procedure Xxx_Tests.Example_Test is
+begin
+   pragma Assert (False);
 end Xxx_Tests.Example_Test;
 """)
 


### PR DESCRIPTION
Plain `pragma Assert` weren't enabled by default.

##### PR creation checklist
- [x] A test is included, if required by the changes.
