### PR TITLE
fix: incorrect example in `alr help index`

### DIFF
--- a/src/alr/alr-commands-index.adb
+++ b/src/alr/alr-commands-index.adb
@@ -214,7 +214,7 @@ package body Alr.Commands.Index is
                & "git+https://github.com/org/repo[#commit]")
       .Append ("- git over SSH:        "
                & "git+ssh://[user@]host.com/path/to/repo[#commit]")
-      .Append ("- git user over SSH:   git@github.com:/org/repo[#commit]")
+      .Append ("- git user over SSH:   git@github.com:/org/repo")
      );
 
    ---------------------


### PR DESCRIPTION
A `#<commit>` fragment is not supported in SCP-style index origins as of #1736.

(I doubt #1897 would have slipped through review if I had updated this properly at the time; sorry about that)