### PR TITLE
fix: updating pins with `subdir` which track Alire-generated files

### DIFF
--- a/src/alire/alire-user_pins.adb
+++ b/src/alire/alire-user_pins.adb
@@ -250,7 +250,9 @@ package body Alire.User_Pins is
                --  checkout in the 'alire/cache/pins' directory themselves, so
                --  we require user confirmation before discarding anything.
                declare
-                  Paths : constant AAA.Strings.Set :=
+                  use AAA.Strings;
+
+                  Paths : constant Set :=
                     VCSs.Git.Handler.Dirty_Files
                       (Destination, Include_Untracked => True);
 
@@ -258,10 +260,16 @@ package body Alire.User_Pins is
                   Paths_List : constant String :=
                     List_Sep & Paths.To_Vector.Flatten (List_Sep);
 
+                  Subdir_Prefix : constant String :=
+                    (if This.Subdir /= ""
+                     then (String (Alire.VFS.To_Portable (+This.Subdir)) & "/")
+                     else "");
+                  Alire_Generated_Dirs : constant Vector :=
+                    Empty_Vector & "alire/" & "config/";
                   Alire_Generated_Dirs_Only : constant Boolean :=
                     (for all Path of Paths =>
-                       AAA.Strings.Has_Prefix (Path, "alire/")
-                       or else AAA.Strings.Has_Prefix (Path, "config/"));
+                       (for some Generated_Dir of Alire_Generated_Dirs =>
+                          Has_Prefix (Path, Subdir_Prefix & Generated_Dir)));
                   --  'git status' yields '/' separated paths, even on Windows
 
                   Question : constant String :=

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -412,7 +412,7 @@ def alr_unpin(crate, manual=True, fail_if_missing=True, update=True):
         run_alr("pin", "--unpin", crate)
 
 
-def alr_pin(crate, version="", path="", url="", commit="", branch="",
+def alr_pin(crate, version="", path="", url="", commit="", branch="", subdir="",
             manual=True, update=True, force=False):
     """
     Pin a crate, either manually or using the command-line interface. Use only
@@ -430,12 +430,15 @@ def alr_pin(crate, version="", path="", url="", commit="", branch="",
             pin_line = f'{crate} = {{ version = "{version}" }}'
         elif path != "":
             pin_line = f"{crate} = {{ path = '{path}' }}"  # literal so \ works
-        elif url != "" and commit != "":
-            pin_line = f"{crate} = {{ url = '{url}', commit = '{commit}' }}"
-        elif url != "" and branch != "":
-            pin_line = f"{crate} = {{ url = '{url}', branch = '{branch}' }}"
         elif url != "":
-            pin_line = f"{crate} = {{ url = '{url}' }}"
+            if branch != "":
+                rev_part = f", branch = '{branch}'"
+            elif commit != "":
+                rev_part = f", commit = '{commit}'"
+            else:
+                rev_part = ""
+            subdir_part = f", subdir = '{subdir}'" if subdir != "" else ""
+            pin_line = f"{crate} = {{ url = '{url}'{rev_part}{subdir_part} }}"
         else:
             raise ValueError("Specify either version, path or url")
 
@@ -468,6 +471,9 @@ def alr_pin(crate, version="", path="", url="", commit="", branch="",
                 args += ["--commit", f"{commit}"]
             elif branch != "":
                 args += ["--branch", f"{branch}"]
+
+            if subdir != "":
+                args += ["--subdir", f"{subdir}"]
 
         return run_alr("pin", *args, force=force)
 


### PR DESCRIPTION
Updates #1788 in line with #1857.

##### PR creation checklist
- [x] A test is included, if required by the changes.
