### PR TITLE
feat: add test runner selection via `--id`

### DIFF
--- a/doc/catalog-format-spec.md
+++ b/doc/catalog-format-spec.md
@@ -449,6 +449,8 @@ static, i.e. they cannot depend on the context.
     # OR
     command = ["<command>", "<argument>", ...]
 
+    # optional keys
+    id = <string>
     directory = <relative path>
     jobs = <number>
     ```
@@ -465,7 +467,10 @@ static, i.e. they cannot depend on the context.
 
     The `[test]` section also accepts an array of test runners (with
     `[[test]]`), although you lose the ability to pass extra arguments to the
-    test command with `alr test`.
+    test command with `alr test`. You can assign a unique `id` to a test runner
+    and then select it with `alr test --id=<id>`, which allows you to pass
+    command line arguments to this runner only. The `<id>` must be a unique,
+    non-empty string.
 
  - `auto-gpr-with`: optional Boolean value that specifies if the project (gpr) files
    of a crate can be automatically depended upon ('withed') directly by the root

--- a/src/alire/alire-properties-tests.ads
+++ b/src/alire/alire-properties-tests.ads
@@ -39,9 +39,11 @@ is
 
    function Runner (S : Settings) return Runner_Type;
 
-   function Directory (S : Settings) return Unbounded_Relative_Path;
+   function Directory (S : Settings) return Relative_Path;
 
    function Jobs (S : Settings) return Natural;
+
+   function Id (S : Settings) return String;
 
    function Default return Settings;
 
@@ -51,16 +53,19 @@ private
       Runner    : Runner_Type;
       Directory : Unbounded_Relative_Path;
       Jobs      : Natural;
+      Id        : UString;
    end record;
 
    overriding
    function Image (S : Settings) return String
-   is (" test runner: "
+   is (" test runner"
+       & (if Id (S) = "" then "" else ("'" & Id (S) & "'"))
+       & ": "
        & (case S.Runner.Kind is
             when Alire_Runner => "alire",
-            when External => S.Runner.Command.Flatten)
+            when External => "`" & S.Runner.Command.Flatten & "`")
        & ", directory: "
-       & UStrings.To_String (S.Directory)
+       & Directory (S)
        & (if S.Runner.Kind = Alire_Runner then (", jobs:" & S.Jobs'Image)
           else ""));
 
@@ -73,22 +78,28 @@ private
               when External => S.Runner.Command.Flatten)
        & New_Line
        & "directory: "
-       & Alire.Utils.YAML.YAML_Stringify (UStrings.To_String (S.Directory))
+       & Alire.Utils.YAML.YAML_Stringify (Directory (S))
        & New_Line
        & "jobs:"
-       & S.Jobs'Image);
+       & S.Jobs'Image
+       & New_Line
+       & "id: "
+       & Alire.Utils.YAML.YAML_Stringify (Id (S)));
 
    function Runner (S : Settings) return Runner_Type
    is (S.Runner);
 
-   function Directory (S : Settings) return Unbounded_Relative_Path
-   is (S.Directory);
+   function Directory (S : Settings) return Relative_Path
+   is (+S.Directory);
 
    function Jobs (S : Settings) return Natural
    is (S.Jobs);
 
+   function Id (S : Settings) return String
+   is (+S.Id);
+
    function Default return Settings
    is (Properties.Property
-       with (Kind => Alire_Runner), +Alire.Paths.Default_Tests_Folder, 0);
+       with (Kind => Alire_Runner), +Alire.Paths.Default_Tests_Folder, 0, +"");
 
 end Alire.Properties.Tests;

--- a/src/alire/alire-toml_keys.ads
+++ b/src/alire/alire-toml_keys.ads
@@ -49,6 +49,7 @@ package Alire.TOML_Keys with Preelaborate is
    Test_Command   : constant String := "command";
    Test_Folder    : constant String := "directory";
    Test_Jobs      : constant String := "jobs";
+   Test_Id        : constant String := "id";
    Toolchain      : constant String := "toolchain";
    Version        : constant String := "version";
    Version_Cmd    : constant String := "version-command";

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -1,5 +1,4 @@
 with Ada.Containers;
-with Ada.Strings.Unbounded;
 
 with Alire.Directories;
 with Alire.OS_Lib;
@@ -55,6 +54,7 @@ package body Alr.Commands.Test is
 
    overriding
    procedure Execute (Cmd : in out Command; Args : AAA.Strings.Vector) is
+      use type GNAT.Strings.String_Access;
       use type Ada.Containers.Count_Type;
       use Alire.Properties.Tests;
 
@@ -70,6 +70,30 @@ package body Alr.Commands.Test is
       if All_Settings.Is_Empty then
          Trace.Warning ("no test runner defined, running legacy actions");
          Execute_Legacy (Cmd.Root);
+      end if;
+
+      --  id selection logic
+      if Cmd.By_Id /= null and then Cmd.By_Id.all /= "" then
+         declare
+            Found : Natural := 0;
+         begin
+            for I in All_Settings.First_Index .. All_Settings.Last_Index loop
+               if Settings (All_Settings.Element (I)).Id = Cmd.By_Id.all then
+                  Found := I;
+               end if;
+            end loop;
+
+            if Found = 0 then
+               Reportaise_Command_Failed
+                 ("Could not find test runner with id '"
+                  & Cmd.By_Id.all
+                  & "'");
+            else
+               --  swap to first position and remove the rest
+               All_Settings.Swap (All_Settings.First_Index, Found);
+               All_Settings.Set_Length (1);
+            end if;
+         end;
       end if;
 
       if not Args.Is_Empty
@@ -91,11 +115,10 @@ package body Alr.Commands.Test is
       end if;
 
       for Test_Setting of All_Settings loop
-         if Alire.Directories.Is_Directory (+Settings (Test_Setting).Directory)
+         if Alire.Directories.Is_Directory (Settings (Test_Setting).Directory)
          then
             declare
                use Alire.Directories;
-               use all type Ada.Strings.Unbounded.Unbounded_String;
 
                function Get_Args return AAA.Strings.Vector
                is (if All_Settings.Length = 1 then Args
@@ -104,8 +127,7 @@ package body Alr.Commands.Test is
 
                S : constant Settings := Settings (Test_Setting);
 
-               Dir      : constant Alire.Relative_Path :=
-                 To_String (S.Directory);
+               Dir      : constant Alire.Relative_Path := S.Directory;
                Failures : Integer;
 
                Guard : Alire.Directories.Guard (Enter (Dir))
@@ -146,7 +168,7 @@ package body Alr.Commands.Test is
             Trace.Error ("while running" & (Settings (Test_Setting).Image));
             Reportaise_Command_Failed
               ("directory '"
-               & (+Settings (Test_Setting).Directory)
+               & (Settings (Test_Setting).Directory)
                & "' does not exist.");
          end if;
       end loop;
@@ -194,6 +216,14 @@ package body Alr.Commands.Test is
          & " if 0",
          Default  => -1,
          Argument => "N");
+
+      Define_Switch
+        (Config,
+         Cmd.By_Id'Access,
+         "",
+         "--id=",
+         "Select a specific test runner by id",
+         Argument => "<id>");
    end Setup_Switches;
 
 end Alr.Commands.Test;

--- a/src/alr/alr-commands-test.ads
+++ b/src/alr/alr-commands-test.ads
@@ -36,6 +36,7 @@ private
 
    type Command is new Commands.Command with record
       Jobs : aliased Integer := 0;
+      By_Id : aliased GNAT.Strings.String_Access;
    end record;
 
 end Alr.Commands.Test;

--- a/testsuite/tests/test/select_id/test.py
+++ b/testsuite/tests/test/select_id/test.py
@@ -1,0 +1,51 @@
+"""
+Select a specific test runner by its id
+"""
+
+import os.path
+
+from drivers.alr import init_local_crate, run_alr
+from drivers.asserts import assert_not_substring, assert_substring
+
+init_local_crate("xxx")
+
+with open("alire.toml", "+a") as f:
+   f.writelines([
+      "\n",
+      "[[test]]\n",
+      "id = 'a'\n",
+      "command = ['echo', 'MAGIC_TEST_A']\n",
+      "directory = '.'\n",
+      "\n",
+      "[[test]]\n",
+      "id = 'b'\n",
+      "command = ['echo', 'MAGIC_TEST_B']\n",
+      "directory = '.'\n",
+   ])
+
+# check that both test runners run without argyments
+p = run_alr("test")
+assert_substring("MAGIC_TEST_A", p.out)
+assert_substring("MAGIC_TEST_B", p.out)
+
+# check that arguments are not forwarded
+p = run_alr("test", "EXTRA_MAGIC")
+assert_substring("MAGIC_TEST_A", p.out)
+assert_substring("MAGIC_TEST_B", p.out)
+assert_not_substring("EXTRA_MAGIC", p.out)
+
+# check that only one test runner is selected with "--id"
+p = run_alr("test", "--id", "a")
+assert_substring ("MAGIC_TEST_A", p.out)
+assert_not_substring("MAGIC_TEST_B", p.out)
+
+# check that arguments are forwarded with "--id"
+p = run_alr("test", "--id", "b", "EXTRA_MAGIC")
+assert_substring ("MAGIC_TEST_B", p.out)
+assert_not_substring("MAGIC_TEST_A", p.out)
+assert_substring ("EXTRA_MAGIC", p.out)
+
+# check for failure when using an invalid id
+p = run_alr("test", "--id", "c", complain_on_error = False)
+
+print('SUCCESS')

--- a/testsuite/tests/test/select_id/test.yaml
+++ b/testsuite/tests/test/select_id/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
Closes #1899

I picked the name `id` as it made more sense to me personally, but it's still possible to change it.

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [x] `doc/catalog-format-spec.md` has been updated, if applicable.
