### PR TITLE
fix: test from subdir

### DIFF
--- a/src/alire/alire-meta.ads
+++ b/src/alire/alire-meta.ads
@@ -6,8 +6,8 @@ package Alire.Meta with Preelaborate is
 
    package Working_Tree is
 
-      Commit  : constant String := "unknown";
-      Changes : constant String := "unknown";
+      Commit  : constant String := "32d5831a4dc3add6a24be82cfa6889bc1cf67501";
+      Changes : constant String := "dirty";
 
       Main_Branch : constant String := "master";
       --  In case some day we rename the master branch in the repo

--- a/src/alire/alire-meta.ads
+++ b/src/alire/alire-meta.ads
@@ -6,8 +6,8 @@ package Alire.Meta with Preelaborate is
 
    package Working_Tree is
 
-      Commit  : constant String := "32d5831a4dc3add6a24be82cfa6889bc1cf67501";
-      Changes : constant String := "dirty";
+      Commit  : constant String := "unknown";
+      Changes : constant String := "unknown";
 
       Main_Branch : constant String := "master";
       --  In case some day we rename the master branch in the repo

--- a/testsuite/drivers/helpers.py
+++ b/testsuite/drivers/helpers.py
@@ -8,10 +8,17 @@ import platform
 import re
 import shutil
 import stat
-import sys
 from subprocess import run
 from typing import Union
 from zipfile import ZipFile
+
+
+def mkcd(dir: str, exist_ok: bool = True):
+    """
+    Create a directory and cd into it
+    """
+    os.makedirs(dir, exist_ok=exist_ok)
+    os.chdir(dir)
 
 
 # Return the entries (sorted) under a given folder, both folders and files
@@ -140,7 +147,7 @@ def offset_timestamp(file, seconds):
     """
     Add offset to the modification time of a file
     """
-    os.utime(file, (os.path.getatime(file), 
+    os.utime(file, (os.path.getatime(file),
                     os.path.getmtime(file) + seconds))
 
 

--- a/testsuite/tests/test/from-subdir/test.py
+++ b/testsuite/tests/test/from-subdir/test.py
@@ -1,0 +1,33 @@
+"""
+Test that running `alr test` from a subdirectory other than the root and the
+`tests` directory works as expected.
+"""
+
+import os
+from drivers.alr import init_local_crate, run_alr
+from drivers.asserts import assert_match
+
+# Initialize a local crate with a test
+init_local_crate("xxx", with_test=True)
+
+# Run the test from the root directory to verify it works
+p = run_alr("test")
+assert_match(".*\\[ PASS \\] example_test.*", p.out)
+
+# Create a subdirectory and run the test from there
+os.makedirs("subdir", exist_ok=True)
+os.chdir("subdir")
+
+# Run the test from the subdirectory
+p = run_alr("test")
+assert_match(".*\\[ PASS \\] example_test.*", p.out)
+
+# Create another level of subdirectory
+os.makedirs("deeper", exist_ok=True)
+os.chdir("deeper")
+
+# Run the test from the deeper subdirectory
+p = run_alr("test")
+assert_match(".*\\[ PASS \\] example_test.*", p.out)
+
+print("SUCCESS")

--- a/testsuite/tests/test/from-subdir/test.py
+++ b/testsuite/tests/test/from-subdir/test.py
@@ -5,14 +5,14 @@ Test that running `alr test` from a subdirectory other than the root and the
 
 import os
 from drivers.alr import init_local_crate, run_alr
-from drivers.asserts import assert_match
+from drivers.asserts import assert_substring
 
 # Initialize a local crate with a test
 init_local_crate("xxx", with_test=True)
 
 # Run the test from the root directory to verify it works
 p = run_alr("test")
-assert_match(".*\\[ PASS \\] example_test.*", p.out)
+assert_substring("[ PASS ]", p.out)
 
 # Create a subdirectory and run the test from there
 os.makedirs("subdir", exist_ok=True)
@@ -20,7 +20,7 @@ os.chdir("subdir")
 
 # Run the test from the subdirectory
 p = run_alr("test")
-assert_match(".*\\[ PASS \\] example_test.*", p.out)
+assert_substring("[ PASS ]", p.out)
 
 # Create another level of subdirectory
 os.makedirs("deeper", exist_ok=True)
@@ -28,6 +28,6 @@ os.chdir("deeper")
 
 # Run the test from the deeper subdirectory
 p = run_alr("test")
-assert_match(".*\\[ PASS \\] example_test.*", p.out)
+assert_substring("[ PASS ]", p.out)
 
 print("SUCCESS")

--- a/testsuite/tests/test/from-subdir/test.py
+++ b/testsuite/tests/test/from-subdir/test.py
@@ -3,30 +3,20 @@ Test that running `alr test` from a subdirectory other than the root and the
 `tests` directory works as expected.
 """
 
-import os
 from drivers.alr import init_local_crate, run_alr
 from drivers.asserts import assert_substring
+from drivers.helpers import mkcd
 
 # Initialize a local crate with a test
 init_local_crate("xxx", with_test=True)
 
-# Run the test from the root directory to verify it works
-p = run_alr("test")
-assert_substring("[ PASS ]", p.out)
-
 # Create a subdirectory and run the test from there
-os.makedirs("subdir", exist_ok=True)
-os.chdir("subdir")
-
-# Run the test from the subdirectory
+mkcd("subdir")
 p = run_alr("test")
 assert_substring("[ PASS ]", p.out)
 
 # Create another level of subdirectory
-os.makedirs("deeper", exist_ok=True)
-os.chdir("deeper")
-
-# Run the test from the deeper subdirectory
+mkcd("subsubdir")
 p = run_alr("test")
 assert_substring("[ PASS ]", p.out)
 

--- a/testsuite/tests/test/from-subdir/test.yaml
+++ b/testsuite/tests/test/from-subdir/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
Verify that `alr test` works from subdirs (others than the test dir itself). This arises, for example, when running tests for `alr` itself from `testsuite/` (tests are in `testsuite/tests_ada`).

Fixes #1892

##### PR creation checklist
- [x] A test is included, if required by the changes.
