### PR TITLE
Missing space on info message when there is an Id

### DIFF
--- a/src/alire/alire-properties-tests.ads
+++ b/src/alire/alire-properties-tests.ads
@@ -59,7 +59,7 @@ private
    overriding
    function Image (S : Settings) return String
    is (" test runner"
-       & (if Id (S) = "" then "" else ("'" & Id (S) & "'"))
+       & (if Id (S) = "" then "" else (" '" & Id (S) & "'"))
        & ": "
        & (case S.Runner.Kind is
             when Alire_Runner => "alire",


### PR DESCRIPTION
<!-- Description of the changes -->

Fix message:
> running test with test runner'example'

##### PR creation checklist
- [ ] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
