### PR TITLE
fix: multiple built-in test runners

### DIFF
--- a/src/alire/alire-test_runner.adb
+++ b/src/alire/alire-test_runner.adb
@@ -387,6 +387,13 @@ package body Alire.Test_Runner is
 
       Create_Gpr_List (Root, Test_List);
 
+      --  Ensure a void solution on first test run
+      if not Root.Has_Lockfile then
+         Root.Update (Silent   => True,
+                      Interact => False,
+                      Allowed  => Roots.Allow_All_Crates);
+      end if;
+
       Trace.Info ("Building tests");
       if Roots.Build (Root, AAA.Strings.Empty_Vector) then
          Trace.Info ("Running" & Test_List.Length'Image & " tests");

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -135,20 +135,27 @@ package body Alr.Commands.Test is
 
                Guard : Dirs.Guard (Enter (Cmd.Root.Path / S.Directory))
                with Unreferenced;
-            begin
-               Cmd.Optional_Root.Discard;
 
+               Test_Root : Alire.Roots.Optional.Root
+                 := Alire.Roots.Optional.Detect_Root
+                   (Cmd.Root.Path / S.Directory);
+            begin
                if All_Settings.Length > 1 then
                   Alire.Put_Info ("running test with" & S.Image);
                end if;
 
                case S.Runner.Kind is
                   when Alire_Runner =>
-                     Cmd.Requires_Workspace;
+                     if not Test_Root.Is_Valid then
+                        Alire.Raise_Checked_Error
+                          ("cannot detect a proper crate in test directory '"
+                           & S.Directory
+                           & "' (error: " & Test_Root.Message & ")");
+                     end if;
 
                      Failures :=
                        Alire.Test_Runner.Run
-                         (Cmd.Root,
+                         (Test_Root.Value,
                           Get_Args,
                           (if Cmd.Jobs < 0 then S.Jobs else Cmd.Jobs));
 

--- a/testsuite/tests/test/multiple-builtin/test.py
+++ b/testsuite/tests/test/multiple-builtin/test.py
@@ -1,0 +1,41 @@
+"""
+Check that having two built-in test runners works properly
+"""
+
+import os
+from drivers.alr import alr_manifest, init_local_crate, run_alr
+from drivers.asserts import assert_substring
+
+init_local_crate()
+
+# Initialize two crates for the tests
+init_local_crate("tests_1", enter=False)
+init_local_crate("tests_2", enter=False)
+
+# Create two built-in runners
+with open(alr_manifest(), "a") as f:
+    f.write("""
+[[test]]
+runner = 'alire'
+directory = 'tests_1'
+
+[[test]]
+runner = 'alire'
+directory = 'tests_2'
+""")
+
+# Run the tests and verify both runners ran properly
+p = run_alr("test", quiet=False)
+assert_substring("directory: tests_1", p.out)
+assert_substring("directory: tests_2", p.out)
+assert_substring("Successful test run", p.out)
+
+# Test error when the test directory isn't a crate
+os.remove("tests_1/alire.toml")
+p = run_alr("test", complain_on_error=False)
+assert_substring(
+    "cannot detect a proper crate in test directory 'tests_1' "
+    "(error: Could not detect an alire.toml manifest",
+    p.out)
+
+print("SUCCESS")

--- a/testsuite/tests/test/multiple-builtin/test.yaml
+++ b/testsuite/tests/test/multiple-builtin/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
Before this fix, each runner would try to enter a directory inside the previous runner directory.

##### PR creation checklist
- [x] A test is included, if required by the changes.
