### PR TITLE
fix: use copy/delete for renames by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,12 @@
     "terminal.integrated.env.linux": {
         "ALIRE_OS": "linux",
     },
+    "workspaceKeybindings.alireGprbuild.enabled": true,
+    "workspaceKeybindings.alireBuildFile.enabled": true,
+    "triggerTaskOnSave.tasks": {
+        "Alire: Compile current file": [
+            "*.ads",
+            "*.adb",
+        ],
+    }
 }

--- a/scripts/ci-github.sh
+++ b/scripts/ci-github.sh
@@ -140,5 +140,5 @@ fi
 
 mkdir bak && cp bin/alr* bak
 echo Running Ada test suite now:
-bak/alr -vv -d test || { echo Ada test suite failures, unstable build!; exit 1; }
+bak/alr test || { echo Ada test suite failures, unstable build!; exit 1; }
 rm -rf bin/alr* && mv bak/alr* bin

--- a/scripts/ci-github.sh
+++ b/scripts/ci-github.sh
@@ -140,5 +140,5 @@ fi
 
 mkdir bak && cp bin/alr* bak
 echo Running Ada test suite now:
-bak/alr test || { echo Ada test suite failures, unstable build!; exit 1; }
+bak/alr -vv -d test || { echo Ada test suite failures, unstable build!; exit 1; }
 rm -rf bin/alr* && mv bak/alr* bin

--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -391,7 +391,7 @@ package body Alire.Directories is
             Remove_From_Source    => False,
             Silent                => True);
 
-         Delete_Tree (Source);
+         Delete_Tree (Den.Filesystem.Absolute (Source));
       else
          Adirs.Rename (Source, Destination);
       end if;
@@ -881,9 +881,13 @@ package body Alire.Directories is
       Trace.Debug ("Merging "  & Src & " (" & Kind (Src)'Image
                    & ") into " & Dst & " (" & Kind (Dst)'Image & ")");
 
-      Traverse_Tree (Start   => Src,
-                     Doing   => Merge'Access,
-                     Recurse => True);
+      if Kind (Src) = File then
+         Den.Filesystem.Copy (Src, Dst);
+      else
+         Traverse_Tree (Start   => Src,
+                        Doing   => Merge'Access,
+                        Recurse => True);
+      end if;
 
       --  This is space-inefficient since we use 2x the actual size, but this
       --  is the only way we have unless we want to go into platform-dependent

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -7,8 +7,6 @@ with Alire.OS_Lib;
 
 private with Ada.Finalization;
 
-with Den;
-
 with GNAT.OS_Lib;
 
 package Alire.Directories is
@@ -79,8 +77,6 @@ package Alire.Directories is
 
    function Exists (Path : Any_Path) return Boolean;
    --  Path designates something, be it file, dir or symbolic link
-
-   function Kind (Path : Any_Path) return Den.Kinds;
 
    function Is_Directory (Path : Any_Path) return Boolean;
    --  Returns false for non-existing paths too

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -100,8 +100,13 @@ package Alire.Directories is
    --  the top-level only contains "doinstall", "README" and so on that
    --  are unusable and would be confusing in a binary prefix.
 
-   procedure Rename (Source, Destination : Any_Path);
-   --  Renames files/directories
+   procedure Rename (Source,
+                     Destination : Any_Path;
+                     Copy_Delete : Boolean := True);
+   --  Renames files/directories. If Copy_Delete, use copy and delete (should
+   --  work across filesystems when move not supported). Since we create
+   --  temporary files possibly on user-designated locations, at least in
+   --  these cases we should be wary of using a direct rename without copying.
 
    procedure Touch (File : File_Path; Create_Tree : Boolean := False)
      with Pre => Create_Tree or else Is_Directory (Parent (File));

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -7,6 +7,8 @@ with Alire.OS_Lib;
 
 private with Ada.Finalization;
 
+with Den;
+
 with GNAT.OS_Lib;
 
 package Alire.Directories is
@@ -78,6 +80,8 @@ package Alire.Directories is
    function Exists (Path : Any_Path) return Boolean;
    --  Path designates something, be it file, dir or symbolic link
 
+   function Kind (Path : Any_Path) return Den.Kinds;
+
    function Is_Directory (Path : Any_Path) return Boolean;
    --  Returns false for non-existing paths too
 
@@ -87,13 +91,17 @@ package Alire.Directories is
    procedure Merge_Contents (Src, Dst              : Any_Path;
                              Skip_Top_Level_Files  : Boolean;
                              Fail_On_Existing_File : Boolean;
-                             Remove_From_Source    : Boolean);
+                             Remove_From_Source    : Boolean;
+                             Silent                : Boolean := True);
    --  Move all contents from Src into Dst, recursively. Dirs already existing
    --  on Dst tree will be merged. For existing regular files, either log
    --  at debug level or fail. If Skip, discard files at the Src top-level.
    --  This is what we want when manually unpacking binary releases, as
    --  the top-level only contains "doinstall", "README" and so on that
    --  are unusable and would be confusing in a binary prefix.
+
+   procedure Rename (Source, Destination : Any_Path);
+   --  Renames files/directories
 
    procedure Touch (File : File_Path; Create_Tree : Boolean := False)
      with Pre => Create_Tree or else Is_Directory (Parent (File));

--- a/src/alire/alire-directories.ads
+++ b/src/alire/alire-directories.ads
@@ -97,12 +97,11 @@ package Alire.Directories is
    --  are unusable and would be confusing in a binary prefix.
 
    procedure Rename (Source,
-                     Destination : Any_Path;
-                     Copy_Delete : Boolean := True);
-   --  Renames files/directories. If Copy_Delete, use copy and delete (should
-   --  work across filesystems when move not supported). Since we create
-   --  temporary files possibly on user-designated locations, at least in
-   --  these cases we should be wary of using a direct rename without copying.
+                     Destination : Any_Path);
+   --  Renames files/directories. Will try first with a plain rename, and
+   --  fallback to copy/delete if rename fails. As we sometimes create
+   --  temporary files in user-supplied locations, depending on the underlying
+   --  move system call, these might fail across filesystems.
 
    procedure Touch (File : File_Path; Create_Tree : Boolean := False)
      with Pre => Create_Tree or else Is_Directory (Parent (File));

--- a/src/alire/alire-origins-deployers.adb
+++ b/src/alire/alire-origins-deployers.adb
@@ -101,7 +101,9 @@ package body Alire.Origins.Deployers is
                            / Directories.Temp_Name);
       --  We use a temporary location to fetch and verify, as otherwise any
       --  failure before final deployment may result in considering a crate
-      --  already deployed.
+      --  already deployed. This folder is a sibling of the final destination
+      --  so a simple renaming should work (space already taken in the same
+      --  drive).
 
       The_Deployer  : constant Deployer'Class := New_Deployer (From);
       Result        : Outcome;
@@ -136,8 +138,9 @@ package body Alire.Origins.Deployers is
 
          Trace.Debug ("Renaming into place " & TTY.URL (Temp_Dir.Filename)
                       & " as " & TTY.URL (Folder));
-         Ada.Directories.Rename (Old_Name => Temp_Dir.Filename,
-                                 New_Name => Folder);
+         Directories.Rename (Source      => Temp_Dir.Filename,
+                             Destination => Folder,
+                             Copy_Delete => False);
       end if;
 
       --  Add an info file for monorepos to make explicit where a release is

--- a/src/alire/alire-origins-deployers.adb
+++ b/src/alire/alire-origins-deployers.adb
@@ -139,8 +139,7 @@ package body Alire.Origins.Deployers is
          Trace.Debug ("Renaming into place " & TTY.URL (Temp_Dir.Filename)
                       & " as " & TTY.URL (Folder));
          Directories.Rename (Source      => Temp_Dir.Filename,
-                             Destination => Folder,
-                             Copy_Delete => False);
+                             Destination => Folder);
       end if;
 
       --  Add an info file for monorepos to make explicit where a release is

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -287,9 +287,9 @@ package body Alire.Releases is
                     (Directories.Full_Name (Upstream_File));
                end if;
                --  And rename the original manifest into upstream
-               Ada.Directories.Rename
-                 (Old_Name => Paths.Crate_File_Name,
-                  New_Name => Upstream_File);
+               Directories.Rename
+                 (Source      => Paths.Crate_File_Name,
+                  Destination => Upstream_File);
             end;
          end if;
       end Backup_Upstream_Manifest;

--- a/src/alire/alire-roots-editable.adb
+++ b/src/alire/alire-roots-editable.adb
@@ -475,8 +475,8 @@ package body Alire.Roots.Editable is
             Directories.Delete_Tree (Destination);
          end if;
 
-         Adirs.Rename (Old_Name => Temp_Pin.Filename,
-                       New_Name => Destination);
+         Directories.Rename (Source      => Temp_Pin.Filename,
+                             Destination => Destination);
 
          --  Finally add the new pin to the manifest
 

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -1599,7 +1599,7 @@ package body Alire.Roots is
          else
             Put_Info ("Migrating lockfile from "
                       & TTY.URL (Old_Path) & " to " & TTY.URL (Path));
-            Adirs.Rename (Old_Path, Path);
+            Directories.Rename (Old_Path, Path);
          end if;
       end if;
 

--- a/src/alire/alire-user_pins.adb
+++ b/src/alire/alire-user_pins.adb
@@ -209,8 +209,7 @@ package body Alire.User_Pins is
          --  Successful checkout, rename into final destination
 
          Directories.Rename (Temp.Filename,
-                             Destination,
-                             Copy_Delete => False);
+                             Destination);
       end Checkout;
 
       ------------

--- a/src/alire/alire-user_pins.adb
+++ b/src/alire/alire-user_pins.adb
@@ -208,8 +208,9 @@ package body Alire.User_Pins is
 
          --  Successful checkout
 
-         Adirs.Rename (Temp.Filename, Destination);
-         Temp.Keep;
+         Directories.Rename (Temp.Filename, 
+                             Destination,
+                             Copy_Delete => False);
       end Checkout;
 
       ------------

--- a/src/alire/alire-user_pins.adb
+++ b/src/alire/alire-user_pins.adb
@@ -164,7 +164,7 @@ package body Alire.User_Pins is
 
          --  Ensure the temporary pin location is in the same directory as the
          --  final one, so a plain rename should always succeed.
-         Temp : Directories.Temp_File :=
+         Temp : constant Directories.Temp_File :=
                   Directories.With_Name
                     (Adirs.Containing_Directory (Destination)
                      / Directories.Temp_Name);
@@ -206,9 +206,9 @@ package body Alire.User_Pins is
                & " failed, re-run with -vv -d for details");
          end if;
 
-         --  Successful checkout
+         --  Successful checkout, rename into final destination
 
-         Directories.Rename (Temp.Filename, 
+         Directories.Rename (Temp.Filename,
                              Destination,
                              Copy_Delete => False);
       end Checkout;


### PR DESCRIPTION
Some temporary renamings are failing seemingly because the temporary location is in a different filesystem. Copy/delete is a safer alternative by default. When we are positive that temporary and destination are in the same filesystem, we still can do cheap renames (e.g. pins, releases in the vault, releases under the workspace).

This PR adds an `Alire.Directories.Rename` that can do both regular renaming and copy/delete. Uses of `Ada.Directories.Rename` are replaced with the Alire one.

Also, for attribute changing on Windows, we use our own recursion now as Window's `attrib` with `/R` fails for certain looping softlinks (as evidenced in the `den` crate test cases).
