### PR TITLE
POC: test case detection with headers

### DIFF
--- a/src/alire/alire-test_runner.adb
+++ b/src/alire/alire-test_runner.adb
@@ -1,5 +1,8 @@
+pragma Ada_2022;
+
+with AAA.Enum_Tools;
 with Ada.Containers.Indefinite_Ordered_Maps;
-with Ada.Containers.Indefinite_Vectors;
+with Ada.Containers.Vectors;
 with Ada.Strings.Fixed;
 with Ada.Text_IO;
 with GNAT.OS_Lib;
@@ -11,6 +14,8 @@ with Alire.Paths;
 with Alire.Utils.Text_Files;
 with Alire.VFS;
 
+with TOML;
+
 with CLIC.TTY;
 
 with Den.Walk;
@@ -19,13 +24,22 @@ package body Alire.Test_Runner is
 
    use Alire.Utils;
 
+   type Test_Case is record
+      Name : Ada.Strings.Unbounded.Unbounded_String;
+      Source_File : Ada.Strings.Unbounded.Unbounded_String;
+      Timeout : Natural := 30;
+      Should_Fail : Boolean := False;
+   end record;
+
    protected Driver is
       --  Protected driver for synchronising stats and output
 
       procedure Pass (Msg : String);
       --  Report a passing test with a message
 
-      procedure Fail (Msg : String; Output : AAA.Strings.Vector);
+      procedure Fail (Msg         : String;
+                      Output      : AAA.Strings.Vector;
+                      Should_Fail : Boolean);
       --  Report a failing test with a message and its output
 
       function Total_Count return Natural;
@@ -54,10 +68,16 @@ package body Alire.Test_Runner is
       -- Fail --
       ----------
 
-      procedure Fail (Msg : String; Output : AAA.Strings.Vector) is
+      procedure Fail (Msg         : String;
+                      Output      : AAA.Strings.Vector;
+                      Should_Fail : Boolean)
+      is
+         Status : constant String := (if Should_Fail
+                                      then "SHOULD FAIL"
+                                      else "FAIL");
       begin
          Failed := Failed + 1;
-         Trace.Always ("[ " & CLIC.TTY.Error ("FAIL") & " ] " & Msg);
+         Trace.Always ("[ " & CLIC.TTY.Error (Status) & " ] " & Msg);
          if not Output.Is_Empty then
             Trace.Always ("*** Test output ***");
             for L of Output loop
@@ -81,6 +101,207 @@ package body Alire.Test_Runner is
       function Fail_Count return Natural
       is (Failed);
    end Driver;
+
+   ---------------------------
+   -- Load_Test_Case_Header --
+   ---------------------------
+
+   function Load_Test_Case_Pragma (Filename : Relative_Path;
+                                   Lines : AAA.Strings.Vector;
+                                   TC    : in out Test_Case)
+                                   return Boolean
+   is
+      use AAA.Strings;
+      Result : AAA.Strings.Vector;
+
+      Prefix : constant String := "pragma alire_test (";
+      Sufix : constant String := ");";
+
+      At_Least_One_Pragma : Boolean := False;
+   begin
+      for Line of Lines loop
+         declare
+            Lower : constant String := To_Lower_Case (Line);
+         begin
+            if Has_Prefix (Lower, Prefix)
+              and then
+                Has_Suffix (Lower, Sufix)
+            then
+               Result.Append (Trim (Line (Line'First + Prefix'Length ..
+                                    Line'Last - Sufix'Length)));
+            else
+               exit;
+            end if;
+         end;
+      end loop;
+
+      for Line of Result loop
+         if Line'Length /= 0 then
+            declare
+               Elts : constant Vector := Split (Line, ',', Trim => True);
+
+               type Test_Pragma_Kind is (Name, Timeout, Should_Fail);
+
+               function Check_Args (Kind : Test_Pragma_Kind) return Boolean is
+                  Expected : constant Natural := (case Kind is
+                                                     when Name => 1,
+                                                     when Timeout => 1,
+                                                     when Should_Fail => 0);
+                  Actual : constant Natural := Natural (Elts.Length) - 1;
+               begin
+                  if Actual /= Expected then
+                     Trace.Always
+                       (Filename & ": Invalid number of arguments for '" &
+                          Prefix & Kind'Img & "' got" & Actual'Img &
+                          ", " & Expected'Img & " expected");
+
+                     return False;
+                  else
+                     return True;
+                  end if;
+               end Check_Args;
+
+               function Is_Valid
+               is new AAA.Enum_Tools.Is_Valid (Test_Pragma_Kind);
+               Cmd : Test_Pragma_Kind;
+            begin
+               if Is_Valid (Elts (1)) then
+                  Cmd := Test_Pragma_Kind'Value (Elts (1));
+
+                  if Check_Args (Cmd) then
+                     case Cmd is
+                     when Name =>
+                        --  TODO: Insert Ada string escape handling here
+                        TC.Name := +Trim (Elts (2), '"');
+                     when Timeout =>
+                        --  TODO: Handle proper parsing of integer literals
+                        TC.Timeout := Natural'Value (Elts (2));
+                     when Should_Fail =>
+                        TC.Should_Fail := True;
+                     end case;
+
+                     At_Least_One_Pragma := True;
+                  end if;
+               else
+                  Trace.Always ("Invalid Alire_Test pragma: '" &
+                                  Elts (1) & "'");
+               end if;
+            end;
+         end if;
+      end loop;
+      return At_Least_One_Pragma;
+   end Load_Test_Case_Pragma;
+
+   ---------------------------------
+   -- Load_Test_Case_Front_Matter --
+   ---------------------------------
+
+   function Load_Test_Case_Front_Matter (Filename : Relative_Path;
+                                         Lines : in out AAA.Strings.Vector;
+                                         TC    : in out Test_Case)
+                                         return Boolean
+   is
+      use AAA.Strings;
+      use Ada.Strings.Unbounded;
+      FM : Ada.Strings.Unbounded.Unbounded_String;
+
+      In_Header : Boolean := True;
+   begin
+      --  First line already supposed to be the front-matter delimiter
+      Lines.Delete_First;
+
+      for Line of Lines loop
+         if Has_Prefix (Line, "--") then
+            declare
+               L : constant String :=
+                 Trim (Line (Line'First + 2 .. Line'Last));
+            begin
+               if L = "+++" then
+                  In_Header := False;
+                  exit;
+               else
+                  Append (FM, L);
+                  Append (FM, ASCII.LF);
+               end if;
+            end;
+         end if;
+      end loop;
+
+      if In_Header then
+         Trace.Error ("Malformed front-matter in " & Filename);
+         return False;
+      end if;
+
+      declare
+         use TOML;
+         Res : constant Read_Result := TOML.Load_String (+FM);
+
+         function Check_Field (Name : String;
+                               Kind : TOML.Any_Value_Kind;
+                               Val  : out TOML_Value)
+                               return Boolean
+         is
+         begin
+            if Res.Value.Has (Name) then
+               if Res.Value.Get (Name).Kind = Kind then
+                  Val := Res.Value.Get (Name);
+                  return True;
+               else
+                  Raise_Checked_Error
+                    ("Invalid TOML type for '" & Name &
+                       "' got '" & Res.Value.Get (Name).Kind'Img &
+                       "' expected '" & Kind'Img & "'");
+               end if;
+            end if;
+            return False;
+         end Check_Field;
+
+         Val : TOML_Value;
+      begin
+         if not Res.Success then
+            Raise_Checked_Error (+Res.Message);
+         end if;
+
+         if Check_Field ("name", TOML_String, Val) then
+            TC.Name := +Val.As_String;
+         end if;
+
+         if Check_Field ("timeout", TOML_Integer, Val) then
+            TC.Timeout := Natural (Val.As_Integer);
+         end if;
+
+         if Check_Field ("should-fail", TOML_Boolean, Val) then
+            TC.Should_Fail := Val.As_Boolean;
+         end if;
+      end;
+      return True;
+   end Load_Test_Case_Front_Matter;
+
+   ---------------------------
+   -- Load_Test_Case_Header --
+   ---------------------------
+
+   function Load_Test_Case_Header (TC : in out Test_Case) return Boolean
+   is
+      use AAA.Strings;
+
+      Filename : constant Relative_Path := +TC.Source_File;
+      File : constant Alire.Utils.Text_Files.File :=
+        Alire.Utils.Text_Files.Load (Filename);
+      Lines : AAA.Strings.Vector := File.Lines.all;
+   begin
+      if not Lines.Is_Empty then
+         if Has_Prefix (Lines.First_Element, "pragma Alire") then
+            return Load_Test_Case_Pragma (Filename, Lines, TC);
+         elsif Trim (Lines.First_Element) = "--  +++" then
+            return Load_Test_Case_Front_Matter (Filename, Lines, TC);
+         end if;
+      else
+         Trace.Debug ("Empty file? '" & Filename & "'");
+      end if;
+
+      return False;
+   end Load_Test_Case_Header;
 
    -----------------
    -- Root_Prefix --
@@ -134,15 +355,15 @@ package body Alire.Test_Runner is
       end if;
    end Display_Name;
 
-   package Portable_Path_Vectors is new
-     Ada.Containers.Indefinite_Vectors (Positive, Portable_Path);
-   subtype Portable_Path_Vector is Portable_Path_Vectors.Vector;
+   package Test_Case_Vectors
+   is new Ada.Containers.Vectors (Positive, Test_Case);
 
    ---------------------
    -- Create_Gpr_List --
    ---------------------
 
-   procedure Create_Gpr_List (Root : Roots.Root; List : Portable_Path_Vector)
+   procedure Create_Gpr_List (Root : Roots.Root;
+                              List : Test_Case_Vectors.Vector)
      --  Create a gpr file containing a list of the test files
      --  (named `Test_Files`).
 
@@ -165,7 +386,7 @@ package body Alire.Test_Runner is
       Lines.Append_Line ("abstract project " & Root_Name & "_List_Config is");
       Lines.Append_Line (Indent & "Test_Files := (");
 
-      for Name of List loop
+      for TC of List loop
          Lines.Append_Line (Indent & Indent);
          if First then
             Lines.Append_To_Last_Line (" ");
@@ -173,7 +394,8 @@ package body Alire.Test_Runner is
          else
             Lines.Append_To_Last_Line (",");
          end if;
-         Lines.Append_To_Last_Line ("""" & VFS.Simple_Name (Name) & """");
+         Lines.Append_To_Last_Line
+           ("""" & VFS.Simple_Name (Portable_Path (+TC.Source_File)) & """");
       end loop;
 
       Lines.Append_Line (Indent & ");");
@@ -184,8 +406,9 @@ package body Alire.Test_Runner is
    -- Run_All_Tests --
    -------------------
 
-   procedure Run_All_Tests
-     (Root : Roots.Root; Test_List : Portable_Path_Vector; Jobs : Positive)
+   procedure Run_All_Tests (Root       : Roots.Root;
+                            Test_Cases : Test_Case_Vectors.Vector;
+                            Jobs       : Positive)
    is
       use GNAT.OS_Lib;
 
@@ -196,32 +419,36 @@ package body Alire.Test_Runner is
       function Cmp (A, B : Process_Id) return Boolean
       is (Pid_To_Integer (A) < Pid_To_Integer (B));
 
+      package PID_TC_Maps is new
+        Ada.Containers.Indefinite_Ordered_Maps
+          (Process_Id,
+           Test_Case,
+           "<" => Cmp);
+      Running_Tests : PID_TC_Maps.Map;
+      --  Contains simple names without extension with prefix from src, e.g.:
+      --  crate_tests-some_test
+      --  nested/crate_tests-some_other_test
+
       package PID_Name_Maps is new
         Ada.Containers.Indefinite_Ordered_Maps
           (Process_Id,
            String,
            "<" => Cmp);
 
-      Running_Tests : PID_Name_Maps.Map;
-      --  Contains simple names without extension with prefix from src, e.g.:
-      --  crate_tests-some_test
-      --  nested/crate_tests-some_other_test
-
       Output_Files : PID_Name_Maps.Map;
-
-      Crate_Prefix : constant String := Root_Prefix (Root);
 
       ----------------
       -- Spawn_Test --
       ----------------
 
-      procedure Spawn_Test (Test_Name : Portable_Path) is
+      procedure Spawn_Test (TC : Test_Case) is
          Simple_Name : constant String :=
-           Strip_Suffix (VFS.Simple_Name (Test_Name), ".adb");
+           Strip_Suffix (VFS.Simple_Name (Portable_Path (+TC.Source_File)),
+                         ".adb");
          --  Contains package name, e.g. crate_tests-my_test
 
          Full_Print_Name : constant String :=
-           Display_Name (Test_Name, Crate_Prefix);
+           +TC.Name;
          --  Full portable name without package prefix, e.g. nested/my_test
 
          Exe_Name : constant String := Simple_Name & OS_Lib.Exe_Suffix;
@@ -229,7 +456,7 @@ package body Alire.Test_Runner is
          Out_Filename : constant String :=
            Root.Working_Folder / ("output_" & Simple_Name & ".tmp");
 
-         Args : constant Argument_List := (1 .. 0 => <>);
+         Args : constant Argument_List := [1 .. 0 => <>];
          Pid  : Process_Id;
       begin
          Pid :=
@@ -240,10 +467,11 @@ package body Alire.Test_Runner is
               Err_To_Out => True);
          if Pid = Invalid_Pid then
             Driver.Fail
-              (String (Test_Name) & " (failed to start!)",
-               AAA.Strings.Empty_Vector);
+              (String (Full_Print_Name) & " (failed to start!)",
+               AAA.Strings.Empty_Vector,
+               Should_Fail => False);
          else
-            Running_Tests.Insert (Pid, Full_Print_Name);
+            Running_Tests.Insert (Pid, TC);
             Output_Files.Insert (Pid, Out_Filename);
          end if;
       end Spawn_Test;
@@ -251,7 +479,7 @@ package body Alire.Test_Runner is
       Pid     : Process_Id;
       Success : Boolean;
 
-      Remaining : Portable_Path_Vector := Test_List;
+      Remaining : Test_Case_Vectors.Vector := Test_Cases;
       Completed : Long_Integer := 0; -- Tests already completed
 
       ------------------
@@ -262,7 +490,8 @@ package body Alire.Test_Runner is
          --  convenience function to print a percentage box when running
          --  in a terminal
          use Ada.Strings.Fixed;
-         Len        : constant Long_Integer := Long_Integer (Test_List.Length);
+         Len        : constant Long_Integer :=
+           Long_Integer (Test_Cases.Length);
          --  rounding division
          Percentage : constant Long_Integer :=
            (if Len = 0 then 0 else (Completed * 100 + Len / 2) / Len);
@@ -276,7 +505,7 @@ package body Alire.Test_Runner is
    begin
 
       --  start the first `Jobs` tests
-      for I in 1 .. Natural'Min (Jobs, Natural (Test_List.Length)) loop
+      for I in 1 .. Natural'Min (Jobs, Natural (Test_Cases.Length)) loop
          Spawn_Test (Remaining.Last_Element);
          Remaining.Delete_Last;
       end loop;
@@ -295,16 +524,20 @@ package body Alire.Test_Runner is
             exit;
          end if;
 
-         if Success then
-            Driver.Pass (Running_Tests (Pid));
-         else
-            declare
-               use Utils.Text_Files;
-               Output : File := Load (Output_Files (Pid), False);
-            begin
-               Driver.Fail (Running_Tests (Pid), Output.Lines.all);
-            end;
-         end if;
+         declare
+            TC : constant Test_Case := Running_Tests (Pid);
+         begin
+            if Success = not TC.Should_Fail then
+               Driver.Pass (+TC.Name);
+            else
+               declare
+                  use Utils.Text_Files;
+                  Output : File := Load (Output_Files (Pid), False);
+               begin
+                  Driver.Fail (+TC.Name, Output.Lines.all, TC.Should_Fail);
+               end;
+            end if;
+         end;
 
          Delete_File (Output_Files (Pid), Success);
          Running_Tests.Delete (Pid);
@@ -336,8 +569,6 @@ package body Alire.Test_Runner is
 
       Crate_Prefix : constant String := Root_Prefix (Root);
 
-      Test_List : Portable_Path_Vector;
-
       --------------------
       -- Matches_Filter --
       --------------------
@@ -356,41 +587,62 @@ package body Alire.Test_Runner is
                => AAA.Strings.Contains (Filtering_Name, F));
          end;
       end Matches_Filter;
+      pragma Unreferenced (Matches_Filter);
 
-      ------------
-      -- Append --
-      ------------
+      ---------------------
+      -- Find_Test_Cases --
+      ---------------------
 
-      procedure Append
-        (This         : Den.Walk.Item;
-         Unused_Enter : in out Boolean;
-         Unused_Stop  : in out Boolean)
-      is
-         --  Helper function to append all .adb files in a tree
-         --  to the `Test_List` vector
+      function Find_Test_Cases return Test_Case_Vectors.Vector is
+         Result : Test_Case_Vectors.Vector;
 
-         Name : constant Portable_Path :=
-           VFS.To_Portable
-             (Strip_Prefix
-                (This.Path,
-                 Prefix => (Root.Path / "src") & OS_Lib.Dir_Separator));
+         procedure For_All_Adb
+           (This         : Den.Walk.Item;
+            Unused_Enter : in out Boolean;
+            Unused_Stop  : in out Boolean)
+         is
+            --  Helper function to append all .adb files in a tree
+            --  to the `Test_List` vector
+
+            Name : constant Portable_Path :=
+              VFS.To_Portable
+                (Strip_Prefix
+                   (This.Path,
+                    Prefix => (Root.Path / "src") & OS_Lib.Dir_Separator));
+         begin
+            if AAA.Strings.Has_Suffix (String (Name), ".adb") then
+               declare
+                  Src : constant String := Root.Path / "src" / String (Name);
+                  TC : Test_Case := (Name => +String (Name),
+                                     Source_File => +Src,
+                                     others => <>);
+                  Valid : constant Boolean :=
+                    Load_Test_Case_Header (TC);
+               begin
+                  if Valid then
+                     Trace.Always ("Adding " & (+TC.Name));
+                     Result.Append (TC);
+                  else
+                     Trace.Always ("Rejected " & (+TC.Name));
+                  end if;
+               end;
+            end if;
+         end For_All_Adb;
       begin
-         if AAA.Strings.Has_Suffix (String (Name), ".adb")
-           and then Matches_Filter (Name)
-         then
-            Test_List.Append (Name);
-         end if;
-      end Append;
+         Den.Walk.Find (This => Path / "src", Action => For_All_Adb'Access);
+         return Result;
+      end Find_Test_Cases;
 
+      Test_Cases : constant Test_Case_Vectors.Vector := Find_Test_Cases;
    begin
-      Den.Walk.Find (This => Path / "src", Action => Append'Access);
+      Trace.Always (Test_Cases'Img);
 
-      Create_Gpr_List (Root, Test_List);
+      Create_Gpr_List (Root, Test_Cases);
 
       Trace.Info ("Building tests");
       if Roots.Build (Root, AAA.Strings.Empty_Vector) then
-         Trace.Info ("Running" & Test_List.Length'Image & " tests");
-         Run_All_Tests (Root, Test_List, Job_Count);
+         Trace.Info ("Running" & Test_Cases.Length'Image & " tests");
+         Run_All_Tests (Root, Test_Cases, Job_Count);
 
          Trace.Always ("Total:" & Driver.Total_Count'Image & " tests");
          Ada.Text_IO.Flush;


### PR DESCRIPTION
This is just a proof of concept to play with a detection of test cases based on a header in the .adb source file of the test for #1881. 

This patch implements both pragmas and TOML front-matter headers:
```ada
pragma Alire_Test (Name, "This is a test");
pragma Alire_Test (Should_Fail, True);
```
```ada
--  +++
--  name = "This is a test"
--  should-fail = true
--  +++
```

Both solutions are relatively similar in code size, **but** the pragma version implemented here is quite incomplete as we would need a proper parser for Ada strings and integer literals (maybe real literals at some point...).

