### PR TITLE
fix: recognition of hash specified with `--commit=`

### DIFF
--- a/src/alire/alire-vcss-git.adb
+++ b/src/alire/alire-vcss-git.adb
@@ -587,7 +587,7 @@ package body Alire.VCSs.Git is
                            Ref  : String := "HEAD") return String
    is
       Output : constant AAA.Strings.Vector :=
-                 Run_Git_And_Capture (Empty_Vector & "ls-remote" & From);
+        Run_Git_And_Capture (Empty_Vector & "ls-remote" & Repo_URL (From));
    begin
       --  Sample output from git (space is tab):
       --  95818710c1a2bea0cbfa617a67972fe984761227        HEAD

--- a/src/alire/alire-vcss-git.ads
+++ b/src/alire/alire-vcss-git.ads
@@ -12,7 +12,8 @@ package Alire.VCSs.Git is
        (for all Char of Git_Commit => Char in Utils.Hexadecimal_Character);
 
    function Is_Valid_Commit (S : String) return Boolean
-   is (S in Git_Commit);
+   is (S'Length = Git_Commit'Length and then
+         (for all Char of S => Char in Utils.Hexadecimal_Character));
 
    No_Commit : constant Git_Commit := (others => '0');
    --  This is actually returned by e.g. `git worktree`, even if it could be a

--- a/src/alire/alire-vcss-hg.ads
+++ b/src/alire/alire-vcss-hg.ads
@@ -7,7 +7,8 @@ package Alire.VCSs.Hg is
        (for all Char of Hg_Commit => Char in Utils.Hexadecimal_Character);
 
    function Is_Valid_Commit (S : String) return Boolean
-   is (S in Hg_Commit);
+   is (S'Length = Hg_Commit'Length and then
+         (for all Char of S => Char in Utils.Hexadecimal_Character));
 
    type VCS (<>) is new VCSs.VCS with private;
 

--- a/testsuite/tests/pin/remote/test.py
+++ b/testsuite/tests/pin/remote/test.py
@@ -55,6 +55,10 @@ init_local_crate()  # This leaves us inside the new crate
 run_alr("with", "--use", URL, "--commit", head)
 verify(head)
 
+# Add using with directly, using --arg=value
+run_alr("with", f"--use={URL}", f"--commit={head}")
+verify(head)
+
 # Add using with, without head commit
 run_alr("with", "--use", URL)
 verify()
@@ -62,6 +66,11 @@ verify()
 # Pin afterwards, with commit
 run_alr("with", "upstream", force=True)  # force, as it is unsolvable
 run_alr("pin", "upstream", "--use", URL, "--commit", head)
+verify(head)
+
+# Pin afterwards, with commit, using --arg=value
+run_alr("with", "upstream", force=True)
+run_alr("pin", "upstream", f"--use={URL}", f"--commit={head}")
 verify(head)
 
 # Pin afterwards, without commit

--- a/testsuite/tests/with/git-reference/test.py
+++ b/testsuite/tests/with/git-reference/test.py
@@ -27,8 +27,46 @@ alr_with("remote", delete=True, manual=False)
 p = run_alr("pin")
 assert_eq("There are no pins\n", p.out)
 
+# Verify that pinning to a valid reference also succeeds with the --arg=value
+# form
+run_alr("with", "--use=../remote", "--commit=v1")
+p = run_alr("pin")
+assert_match("remote file:alire/cache/pins/remote_.{,8} ../remote#.{,8}",
+             p.out)
+
+# Remove dependency for next test
+alr_with("remote", delete=True, manual=False)
+p = run_alr("pin")
+assert_eq("There are no pins\n", p.out)
+
+# Verify that pinning to a valid reference also succeeds with an explicit URL
+alr_with(url="git+file:../remote", commit="v1", manual=False)
+p = run_alr("pin")
+assert_match(
+    r"remote file:alire/cache/pins/remote_.{,8} git\+file:\.\./remote#.{,8}",
+    p.out
+)
+
+# Remove dependency for next test
+alr_with("remote", delete=True, manual=False)
+p = run_alr("pin")
+assert_eq("There are no pins\n", p.out)
+
 # Verify that pinning to an invalid reference fails
 p = run_alr("with", "--use", "../remote", "--commit", "v2",
+            complain_on_error=False)
+assert_match(".*Requested remote reference v2 not found in repository.*",
+             p.out)
+
+# Verify that pinning to an invalid reference also fails with the
+# --arg=value form
+p = run_alr("with", "--use=../remote", "--commit=v2",
+            complain_on_error=False)
+assert_match(".*Requested remote reference v2 not found in repository.*",
+             p.out)
+
+# Verify that pinning to an invalid reference also fails with an explicit URL
+p = run_alr("with", "--use=git+file:../remote", "--commit=v2",
             complain_on_error=False)
 assert_match(".*Requested remote reference v2 not found in repository.*",
              p.out)


### PR DESCRIPTION
Closes #1938 (another _Chesterton's Fence_ dismantled by #1736).

Also fixes a bug in `Alire.VCSs.Git.Remote_Commit` discovered in the process.

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
