### PR TITLE
`alr toolchain`: validate duplicated release args

### DIFF
--- a/src/alire/alire-meta.ads
+++ b/src/alire/alire-meta.ads
@@ -6,8 +6,8 @@ package Alire.Meta with Preelaborate is
 
    package Working_Tree is
 
-      Commit  : constant String := "unknown";
-      Changes : constant String := "unknown";
+      Commit  : constant String := "7507d3fff57dfa4916e81aa80a876e9cb1e06908";
+      Changes : constant String := "dirty";
 
       Main_Branch : constant String := "master";
       --  In case some day we rename the master branch in the repo

--- a/src/alire/alire-meta.ads
+++ b/src/alire/alire-meta.ads
@@ -6,8 +6,8 @@ package Alire.Meta with Preelaborate is
 
    package Working_Tree is
 
-      Commit  : constant String := "7507d3fff57dfa4916e81aa80a876e9cb1e06908";
-      Changes : constant String := "dirty";
+      Commit  : constant String := "unknown";
+      Changes : constant String := "unknown";
 
       Main_Branch : constant String := "master";
       --  In case some day we rename the master branch in the repo

--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -272,15 +272,22 @@ package body Alire.Utils is
    -- Has_Duplicates --
    --------------------
 
-   function Has_Duplicates (V : AAA.Strings.Vector) return Boolean is
+   function Has_Duplicates
+     (V         : AAA.Strings.Vector;
+      Transform : access function (S : String) return String)
+      return Boolean is
       Seen : AAA.Strings.Set := AAA.Strings.Empty_Set;
    begin
       for Elt of V loop
-         if Seen.Contains (Elt) then
-            return True;
-         else
-            Seen.Insert (Elt);
-         end if;
+         declare
+            Transformed : constant String := Transform.all (Elt);
+         begin
+            if Seen.Contains (Transformed) then
+               return True;
+            else
+               Seen.Insert (Transformed);
+            end if;
+         end;
       end loop;
       return False;
    end Has_Duplicates;

--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -268,4 +268,21 @@ package body Alire.Utils is
       Last_Chance_Handler (E);
    end Finalize_Exception;
 
+   --------------------
+   -- Has_Duplicates --
+   --------------------
+
+   function Has_Duplicates (V : AAA.Strings.Vector) return Boolean is
+      Seen : AAA.Strings.Set := AAA.Strings.Empty_Set;
+   begin
+      for Elt of V loop
+         if Seen.Contains (Elt) then
+            return True;
+         else
+            Seen.Insert (Elt);
+         end if;
+      end loop;
+      return False;
+   end Has_Duplicates;
+
 end Alire.Utils;

--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -274,13 +274,15 @@ package body Alire.Utils is
 
    function Has_Duplicates
      (V         : AAA.Strings.Vector;
-      Transform : access function (S : String) return String)
+      Transform : access function (S : String) return String := null)
       return Boolean is
       Seen : AAA.Strings.Set := AAA.Strings.Empty_Set;
    begin
       for Elt of V loop
          declare
-            Transformed : constant String := Transform.all (Elt);
+            Transformed : constant String := (if Transform /= null
+                                                then Transform (Elt)
+                                                else Elt);
          begin
             if Seen.Contains (Transformed) then
                return True;

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -105,7 +105,10 @@ package Alire.Utils with Preelaborate is
    --         Alire.Utils.Finalize_Exception (E);
    --   end Finalize;
 
-   function Has_Duplicates (V : AAA.Strings.Vector) return Boolean;
+   function Has_Duplicates
+     (V         : AAA.Strings.Vector;
+      Transform : access function (S : String) return String)
+      return Boolean;
 
 private
 

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -105,6 +105,8 @@ package Alire.Utils with Preelaborate is
    --         Alire.Utils.Finalize_Exception (E);
    --   end Finalize;
 
+   function Has_Duplicates (V : AAA.Strings.Vector) return Boolean;
+
 private
 
    function Quote (S : String) return String

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -107,7 +107,7 @@ package Alire.Utils with Preelaborate is
 
    function Has_Duplicates
      (V         : AAA.Strings.Vector;
-      Transform : access function (S : String) return String)
+      Transform : access function (S : String) return String := null)
       return Boolean;
 
 private

--- a/src/alr/alr-commands-toolchain.adb
+++ b/src/alr/alr-commands-toolchain.adb
@@ -352,7 +352,6 @@ package body Alr.Commands.Toolchain is
       --  We do not want tools that are later in the command-line to be taken
       --  into account prematurely for compatibility of origins. We store here
       --  crates still to be dealt with.
-
    begin
 
       --  Validation
@@ -367,10 +366,18 @@ package body Alr.Commands.Toolchain is
            ("--local requires --select or --disable-assistant");
       end if;
 
-      if Cmd.S_Select and then Alire.Utils.Has_Duplicates (Args) then
-         Reportaise_Wrong_Arguments
-           ("Release arguments contain duplicates");
-      end if;
+      declare
+         function As_Crate (S : String) return String is
+            (Alire.Dependencies.From_String (S).Crate.As_String);
+      begin
+         if Cmd.S_Select
+           and then
+            Alire.Utils.Has_Duplicates (Args, As_Crate'Access)
+         then
+            Reportaise_Wrong_Arguments
+              ("Release arguments contain duplicated crates");
+         end if;
+      end;
 
       --  Dispatch to subcommands
 

--- a/src/alr/alr-commands-toolchain.adb
+++ b/src/alr/alr-commands-toolchain.adb
@@ -8,6 +8,7 @@ with Alire.Origins.Deployers;
 with Alire.Releases.Containers;
 with Alire.Solver;
 with Alire.Toolchains;
+with Alire.Utils;
 with Alire.Utils.Tables;
 with Alire.Utils.TTY;
 with Alire.Warnings;
@@ -364,6 +365,11 @@ package body Alr.Commands.Toolchain is
       if Cmd.Local and then not (Cmd.S_Select or else Cmd.Disable) then
          Reportaise_Wrong_Arguments
            ("--local requires --select or --disable-assistant");
+      end if;
+
+      if Cmd.S_Select and then Alire.Utils.Has_Duplicates (Args) then
+         Reportaise_Wrong_Arguments
+           ("Release arguments contain duplicates");
       end if;
 
       --  Dispatch to subcommands

--- a/testsuite/tests/toolchain/select/test.py
+++ b/testsuite/tests/toolchain/select/test.py
@@ -13,10 +13,9 @@ p = run_alr("index")
 print(p.out)
 
 # Validation duplicated release arguments
-p = run_alr("toolchain", "--select", "gnat_native", "gnat_native",
+p = run_alr("toolchain", "--select", "gnat_native=1.2.3", "gnat_native=4.5.6",
             complain_on_error=False)
-assert p.status != 0, "Call should have failed"
-assert_match(".*Release arguments contain duplicates", p.out)
+assert_match(".*Release arguments contain duplicated crates", p.out)
 
 # Activate the default compiler
 p = run_alr("toolchain", "--select")

--- a/testsuite/tests/toolchain/select/test.py
+++ b/testsuite/tests/toolchain/select/test.py
@@ -12,6 +12,12 @@ from drivers.asserts import assert_eq, assert_match
 p = run_alr("index")
 print(p.out)
 
+# Validation duplicated release arguments
+p = run_alr("toolchain", "--select", "gnat_native", "gnat_native",
+            complain_on_error=False)
+assert p.status != 0, "Call should have failed"
+assert_match(".*Release arguments contain duplicates", p.out)
+
 # Activate the default compiler
 p = run_alr("toolchain", "--select")
 


### PR DESCRIPTION
Resolves #1052

Added validation, so we show an error in case of duplicated release args:

![Screenshot 2025-04-26 at 23 32 37](https://github.com/user-attachments/assets/8951276e-494a-4cb8-9752-f0f8955e7afb)

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
