### PR TITLE
dev: make version patcher skip updating when commit is identical

### DIFF
--- a/support/version_patcher/src/version_patcher.adb
+++ b/support/version_patcher/src/version_patcher.adb
@@ -12,7 +12,6 @@ with GNAT.OS_Lib;
 
 procedure Version_Patcher is
 
-
    ------------------
    -- Replace_Info --
    ------------------
@@ -32,11 +31,11 @@ procedure Version_Patcher is
 
       type Hit_Kind is (
          Replaced,
-         -- A hit was recorded and a replacement is needed
+         --  A hit was recorded and a replacement is needed
          Identical,
-         -- A hit was recorded but no replacement is necessary
+         --  A hit was recorded but no replacement is necessary
          None
-         -- No hit recorded
+         --  No hit recorded
       );
       Hit : Hit_Kind := None;
    begin

--- a/support/version_patcher/src/version_patcher.adb
+++ b/support/version_patcher/src/version_patcher.adb
@@ -12,6 +12,7 @@ with GNAT.OS_Lib;
 
 procedure Version_Patcher is
 
+
    ------------------
    -- Replace_Info --
    ------------------
@@ -28,7 +29,16 @@ procedure Version_Patcher is
       F : Ada.Text_IO.File_Type;
       O : Ada.Text_IO.File_Type;
       use Ada.Text_IO;
-      Hit : Boolean := False;
+
+      type Hit_Kind is (
+         Replaced,
+         -- A hit was recorded and a replacement is needed
+         Identical,
+         -- A hit was recorded but no replacement is necessary
+         None
+         -- No hit recorded
+      );
+      Hit : Hit_Kind := None;
    begin
       Open (F, In_File, Filename);
       Create (O, Out_File, Filename & ".new");
@@ -36,7 +46,7 @@ procedure Version_Patcher is
          declare
             Line : constant String := Get_Line (F);
          begin
-            if not Hit and then
+            if Hit = None and then
               (for some I in Line'Range =>
                  I + Trigger'Length - 1 <= Line'Last and then
                Line (I .. I + Trigger'Length - 1) = Trigger)
@@ -68,7 +78,12 @@ procedure Version_Patcher is
                      Line (Line'First .. Ini)
                      & Replacement
                      & Line (Fin .. Line'Last));
-                  Hit := True;
+
+                  if Line (Ini + 1 .. Fin - 1) = Replacement then
+                     Hit := Identical;
+                  else
+                     Hit := Replaced;
+                  end if;
                end;
             else
                Put_Line (O, Line);
@@ -79,13 +94,18 @@ procedure Version_Patcher is
       Close (F);
       Close (O);
 
-      if not Hit then
-         raise Constraint_Error
-           with "Trigger not found in file: " & Trigger;
-      end if;
+      case Hit is
+         when None =>
+            raise Constraint_Error
+              with "Trigger not found in file: " & Trigger;
 
-      Ada.Directories.Delete_File (Filename);
-      Ada.Directories.Rename (Filename & ".new", Filename);
+         when Replaced =>
+            Ada.Directories.Delete_File (Filename);
+            Ada.Directories.Rename (Filename & ".new", Filename);
+
+         when Identical =>
+            Ada.Directories.Delete_File (Filename & ".new");
+      end case;
 
    end Replace_Info;
 


### PR DESCRIPTION
avoids unwanted rebuilds when the `alire-meta.ads` file didn't actually change