### PR TITLE
Discard built-in testsuite in 2.1 without erroring

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,7 +1,7 @@
 name = "alr"
 description = "Command-line tool from the Alire project"
 
-version = "2.1.0"
+version = "2.1.1-dev"
 
 authors = ["Alejandro R. Mosteo", "Fabien Chouteau", "Pierre-Marie de Rodat"]
 maintainers = ["alejandro@mosteo.com", "chouteau@adacore.com"]

--- a/src/alire/alire-properties-from_toml.ads
+++ b/src/alire/alire-properties-from_toml.ads
@@ -2,6 +2,7 @@ with Alire.Conditional;
 with Alire.Conditional_Trees.TOML_Load;
 with Alire.Crates;
 with Alire.Properties.Actions;
+with Alire.Properties.Bool;
 with Alire.Properties.Configurations;
 with Alire.Properties.Environment;
 with Alire.Properties.Build_Profiles;
@@ -9,7 +10,7 @@ with Alire.Properties.Build_Switches;
 with Alire.Properties.Labeled;
 with Alire.Properties.Licenses;
 with Alire.Properties.Scenarios;
-with Alire.Properties.Bool;
+with Alire.Properties.Tests;
 with Alire.TOML_Adapters;
 
 package Alire.Properties.From_TOML is
@@ -38,6 +39,7 @@ package Alire.Properties.From_TOML is
                           Notes,
                           Project_Files,
                           Tags,
+                          Test, -- In 3.0
                           Version,
                           Website);
    --  These enum values must match the toml key they represent with '-' => '_'
@@ -130,7 +132,8 @@ package Alire.Properties.From_TOML is
       Project_Files      |
       Tags               |
       Version            |
-      Website        => Labeled.From_TOML'Access);
+      Website        => Labeled.From_TOML'Access,
+      Test           => Tests.From_TOML'Access);
    --  This loader applies to a normal release manifest
 
    --  The following array determines which properties accept dynamic

--- a/src/alire/alire-properties-tests.adb
+++ b/src/alire/alire-properties-tests.adb
@@ -1,0 +1,42 @@
+with Alire.Warnings;
+
+package body Alire.Properties.Tests is
+
+   -------------
+   -- To_TOML --
+   -------------
+
+   overriding
+   function To_TOML (S : Settings) return TOML.TOML_Value is
+   begin
+      --  Just an empty array
+      return TOML.Create_Array;
+   end To_TOML;
+
+   ---------------
+   -- From_TOML --
+   ---------------
+
+   function From_TOML
+     (From : TOML_Adapters.Key_Queue) return Conditional.Properties
+   is
+      use TOML;
+      Raw : TOML_Value;
+   begin
+      if From.Unwrap.Kind /= TOML_Table then
+         From.Checked_Error
+           ("test: table with assignments expected, but got: "
+            & From.Unwrap.Kind'Img);
+      end if;
+
+      if From.Pop_Single_Table (Raw, TOML_Table) /= TOML_Keys.Test then
+         raise Program_Error;
+         --  Can't happen, unless the dispatch to us itself was erroneous
+      end if;
+
+      Warnings.Warn_Once
+        ("Discarding future feature in manifest: built-in testsuite");
+
+      return Conditional.No_Properties;
+   end From_TOML;
+end Alire.Properties.Tests;

--- a/src/alire/alire-properties-tests.ads
+++ b/src/alire/alire-properties-tests.ads
@@ -1,0 +1,39 @@
+with Alire.Conditional;
+with Alire.TOML_Adapters;
+with Alire.TOML_Keys;
+
+package Alire.Properties.Tests
+  with Preelaborate
+is
+
+   type Settings is new Properties.Property with private;
+
+   overriding
+   function Key (S : Settings) return String
+   is (TOML_Keys.Test);
+
+   overriding
+   function Image (S : Settings) return String;
+
+   overriding
+   function To_TOML (S : Settings) return TOML.TOML_Value;
+
+   overriding
+   function To_Yaml (S : Settings) return String;
+
+   function From_TOML
+     (From : TOML_Adapters.Key_Queue) return Conditional.Properties;
+
+private
+
+   type Settings is new Properties.Property with null record;
+
+   overriding
+   function Image (S : Settings) return String
+   is ("test runner (ignored future feature)");
+
+   overriding
+   function To_Yaml (S : Settings) return String
+   is ("");
+
+end Alire.Properties.Tests;

--- a/src/alire/alire-toml_keys.ads
+++ b/src/alire/alire-toml_keys.ads
@@ -44,6 +44,7 @@ package Alire.TOML_Keys with Preelaborate is
    Provides       : constant String := "provides";
    Tag            : constant String := "tags";
    Target         : constant String := "target";
+   Test           : constant String := "test";
    Toolchain      : constant String := "toolchain";
    Version        : constant String := "version";
    Version_Cmd    : constant String := "version-command";

--- a/src/alire/alire-version.ads
+++ b/src/alire/alire-version.ads
@@ -12,7 +12,7 @@ private
 
    --  Remember to update Alire.Index branch if needed too
 
-   Current_Str : constant String := "2.1.0";
+   Current_Str : constant String := "2.1.1-dev";
    --  2.1.0:     new solver and other internal largish refactorings, bugfixes
    --  2.0.2:     quarterly bugfix maintenance release
    --  2.0.1:     fix `alr install` and minor fixes

--- a/testsuite/tests/test/future-testsuite/test.py
+++ b/testsuite/tests/test/future-testsuite/test.py
@@ -1,0 +1,34 @@
+"""
+Check that we can safely ignore the 3.0 built-in testsuite
+"""
+
+from drivers.alr import init_local_crate, run_alr, alr_manifest
+from drivers.asserts import assert_substring
+
+TELLTALE = "Discarding future feature in manifest: built-in testsuite"
+
+init_local_crate()
+
+# Manually write the testsuite table
+with open(alr_manifest(), "a") as f:
+    f.write("""
+[test]
+runner = "alire"
+""")
+
+assert_substring(TELLTALE, run_alr("show", quiet=False).out)
+
+# Same with an array
+
+init_local_crate("yyy")
+with open(alr_manifest(), "a") as f:
+    f.write("""
+[[test]]
+runner = "alire"
+""")
+p = run_alr("show", quiet=False)
+assert_substring("yyy", p.out)
+assert_substring(TELLTALE, p.out)
+
+
+print("SUCCESS")

--- a/testsuite/tests/test/future-testsuite/test.yaml
+++ b/testsuite/tests/test/future-testsuite/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
In the line of #1965, this will allow 2.1.1 to discard the `[test]` entry in a manifest (with a warning). Now that the new testsuite starts to pop up in more places, this can reduce some friction.

Also with this patch, 2.1.1 will be able to build 3.0.

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
