### PR TITLE
dev: detect pin/submodule mismatches

### DIFF
--- a/.github/workflows/ci-integrity.yml
+++ b/.github/workflows/ci-integrity.yml
@@ -1,0 +1,17 @@
+# This workflow verifies that all pinned dependencies match the submodule
+# versions.
+
+name: Integrity Checks
+on:
+  pull_request:
+
+jobs:
+  verify-pins:
+    name: Pins & Submodules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify pinned dependencies
+        run: scripts/verify-pins.sh

--- a/alire.toml
+++ b/alire.toml
@@ -58,7 +58,7 @@ url    = "https://github.com/mosteo/aaa"
 commit = "73d99ae1ff2f5210dc41c2ea7afebe600f9e9916"
 
 [pins.ada_toml]
-url    = "https://github.com/pmderodat/ada-toml"
+url    = "https://github.com/mosteo/ada-toml"
 commit = "33eaab64b9d531e240c3f525ad80a1f3eb8b9633"
 
 [pins.ansiada]

--- a/alire.toml
+++ b/alire.toml
@@ -59,7 +59,7 @@ commit = "73d99ae1ff2f5210dc41c2ea7afebe600f9e9916"
 
 [pins.ada_toml]
 url    = "https://github.com/pmderodat/ada-toml"
-commit = "e760110ad2b5b776a44dace31b8421532e429fbb"
+commit = "33eaab64b9d531e240c3f525ad80a1f3eb8b9633"
 
 [pins.ansiada]
 url    = "https://github.com/mosteo/ansi-ada"
@@ -107,7 +107,7 @@ commit = "4861e32bd8a2f0df038d3ecc9a72b6381e7a34cc"
 
 [pins.simple_logging]
 url    = "https://github.com/alire-project/simple_logging"
-commit = "a8561d302beb037887cb9980319039c5f86ad9c8"
+commit = "f45bf378588dc1d0479cc24eb0eb41dc99f69cb4"
 
 [pins.si_units]
 url    = "https://github.com/mosteo/si_units"

--- a/scripts/verify-pins.sh
+++ b/scripts/verify-pins.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Verify that all pins in alire.toml match the submodule versions.
+# Must be run from the repository root
+
+# Install tomlq if not already installed
+if ! command -v tomlq &> /dev/null; then
+    sudo apt-get install -y yq
+fi
+
+# Iterate over pins getting their commit hashes
+exit_code=0
+submodules=$(git submodule)
+while read -r dep_name commit_hash; do
+    if echo "$submodules" | grep -q $commit_hash; then
+        echo "OK:    $commit_hash $dep_name"
+    else
+        echo "ERROR: $commit_hash $dep_name"
+        exit_code=1
+    fi
+done < <(tomlq -r '.pins[] | to_entries[] | "\(.key) \(.value.commit)"' alire.toml)
+
+exit $exit_code


### PR DESCRIPTION
Workflow to ensure we never use different submodule versions in pins and git submodules, even for successful builds.