### PR TITLE
dev: placeholder for easily ignoring future properties

### DIFF
--- a/src/alire/alire-properties-from_toml.ads
+++ b/src/alire/alire-properties-from_toml.ads
@@ -6,6 +6,7 @@ with Alire.Properties.Configurations;
 with Alire.Properties.Environment;
 with Alire.Properties.Build_Profiles;
 with Alire.Properties.Build_Switches;
+with Alire.Properties.Future;
 with Alire.Properties.Labeled;
 with Alire.Properties.Licenses;
 with Alire.Properties.Scenarios;
@@ -28,6 +29,7 @@ package Alire.Properties.From_TOML is
                           Description,
                           Environment,
                           Executables,
+                          Future, -- Placeholder for unknown future properties
                           GPR_Externals,
                           GPR_Set_Externals,
                           Hint,
@@ -102,6 +104,7 @@ package Alire.Properties.From_TOML is
                     Description        => Unique,
                     Environment        => Unique,
                     Executables        => Multiple,
+                    Future             => Multiple,
                     GPR_Externals      => Unique,
                     GPR_Set_Externals  => Unique,
                     Hint               => Unique,
@@ -157,6 +160,7 @@ package Alire.Properties.From_TOML is
       Environment    =>
         Properties.Environment.From_TOML'Access,
       Executables    => Labeled.From_TOML'Access,
+      Future         => Properties.Future.From_TOML'Access,
       GPR_Externals |
       GPR_Set_Externals
                      => Scenarios.From_TOML'Access,
@@ -183,6 +187,7 @@ package Alire.Properties.From_TOML is
          Configuration     |
          Environment       |
          Executables       |
+         Future            |
          GPR_Set_Externals |
          Hint              |
          Project_Files     |

--- a/src/alire/alire-properties-future.adb
+++ b/src/alire/alire-properties-future.adb
@@ -1,6 +1,11 @@
+with Ada.Environment_Variables;
+
+with Alire.Environment;
 with Alire.Warnings;
 
 package body Alire.Properties.Future is
+
+   Future_Key : constant String := "future";
 
    ---------------
    -- From_TOML --
@@ -29,6 +34,17 @@ package body Alire.Properties.Future is
          Raw : TOML_Value;
          Key : constant String := From.Pop (Raw);
       begin
+
+         --  We use the "future" key in the testsuite, but it should not be
+         --  allowed during regular use:
+
+         if Key = Future_Key and then
+           not Ada.Environment_Variables.Exists (Alire.Environment.Testsuite)
+         then
+            Raise_Checked_Error ("Forbidden property outside of testing: "
+                                 & Future_Key);
+         end if;
+
          Warnings.Warn_Once
            ("Discarding future property in manifest: " & Key
             & "(" & Raw.Kind'Image & ")");

--- a/src/alire/alire-properties-future.adb
+++ b/src/alire/alire-properties-future.adb
@@ -1,0 +1,43 @@
+with Alire.Warnings;
+
+package body Alire.Properties.Future is
+
+   ---------------
+   -- From_TOML --
+   ---------------
+
+   function From_TOML (From : TOML_Adapters.Key_Queue)
+                       return Conditional.Properties
+   is
+      use TOML;
+      use type Conditional.Properties;
+   begin
+
+      --  Pop first the key.value table artificially constructed by the parser
+
+      if From.Unwrap.Kind /= TOML_Table then
+         From.Checked_Error
+           ("future: table with assignments expected, but got: "
+            & From.Unwrap.Kind'Img);
+      end if;
+
+      --  Now, the value can be an actual table or an scalar, depending on the
+      --  actual manifest schema. For future properties we do not want to be
+      --  overly picky as things might change, so accept whatever.
+
+      declare
+         Raw : TOML_Value;
+         Key : constant String := From.Pop (Raw);
+      begin
+         Warnings.Warn_Once
+           ("Discarding future property in manifest: " & Key
+            & "(" & Raw.Kind'Image & ")");
+
+         return Conditional.No_Properties
+           and Property'(Name_Len => Key'Length,
+                         Name     => Key,
+                         Object   => Raw);
+      end;
+   end From_TOML;
+
+end Alire.Properties.Future;

--- a/src/alire/alire-properties-future.ads
+++ b/src/alire/alire-properties-future.ads
@@ -1,0 +1,50 @@
+with Alire.Conditional;
+with Alire.TOML_Adapters;
+
+package Alire.Properties.Future with Preelaborate is
+
+   --  A loader that simply discards a given property, because we don't support
+   --  it yet but know of its existence.
+
+   type Property (<>) is new Properties.Property with private;
+
+   overriding
+   function Image (V : Property) return String;
+
+   overriding
+   function To_YAML (V : Property) return String;
+
+   overriding
+   function Key (V : Property) return String;
+
+   function From_TOML (From : TOML_Adapters.Key_Queue)
+                       return Conditional.Properties;
+
+private
+
+   type Property (Name_Len : Positive) is new Properties.Property with record
+      Name   : String (1 .. Name_Len);
+      Object : TOML.TOML_Value;
+   end record;
+
+   overriding
+   function To_TOML (V : Property) return TOML.TOML_Value;
+
+   overriding
+   function Image (V : Property) return String
+   is (AAA.Strings.To_Mixed_Case (V.Name)
+       & ": <unknown future property>");
+
+   overriding
+   function To_YAML (V : Property) return String
+   is ("");
+
+   overriding
+   function To_TOML (V : Property) return TOML.TOML_Value
+   is (V.Object);
+
+   overriding
+   function Key (V : Property) return String
+   is (V.Name);
+
+end Alire.Properties.Future;

--- a/testsuite/tests/index/future-compatibility/test.py
+++ b/testsuite/tests/index/future-compatibility/test.py
@@ -50,4 +50,16 @@ unknowns = "aren't scary"
 p = run_alr("show", quiet=False, complain_on_error=False)
 assert_substring("invalid property: 'unknowns'", p.out)
 
+# Ensure we are not leaking a "hidden" property
+
+os.chdir(start_path)
+del os.environ["ALR_TESTSUITE"]
+init_local_crate("vvv")
+with open(alr_manifest(), "a") as f:
+    f.write("""
+future = "bleak"
+""")
+p = run_alr("show", quiet=False, complain_on_error=False)
+assert_substring("Forbidden property outside of testing: future", p.out)
+
 print("SUCCESS")

--- a/testsuite/tests/index/future-compatibility/test.py
+++ b/testsuite/tests/index/future-compatibility/test.py
@@ -1,0 +1,53 @@
+"""
+Check that we can safely ignore known future entries in manifests
+"""
+
+import os
+
+from drivers.alr import init_local_crate, run_alr, alr_manifest
+from drivers.asserts import assert_substring
+
+TELLTALE = "Discarding future property in manifest: future"
+
+start_path = os.getcwd()
+
+def test_future_property(crate_name, future_content):
+    """Test that future properties are safely ignored with proper warning"""
+    os.chdir(start_path)
+    init_local_crate(crate_name)
+    with open(alr_manifest(), "a") as f:
+        f.write(future_content)
+
+    p = run_alr("show", quiet=False)
+    assert_substring(crate_name, p.out)
+    assert_substring(TELLTALE, p.out)
+
+# Test table
+test_future_property("xxx", """
+[future]
+unknown = "property"
+""")
+
+# Test array
+test_future_property("yyy", """
+[[future]]
+unknown = "property"
+""")
+
+# Test scalar
+test_future_property("zzz", """
+future = "is bright"
+""")
+
+# Ensure that actually unknown properties are still rejected
+
+os.chdir(start_path)
+init_local_crate("qqq")
+with open(alr_manifest(), "a") as f:
+    f.write("""
+unknowns = "aren't scary"
+""")
+p = run_alr("show", quiet=False, complain_on_error=False)
+assert_substring("invalid property: 'unknowns'", p.out)
+
+print("SUCCESS")

--- a/testsuite/tests/index/future-compatibility/test.yaml
+++ b/testsuite/tests/index/future-compatibility/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
Rework of #1974 to have it in master for future reuse. Related to #1965.

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
