### PR TITLE
fix: avoid spurious blank line on `alr exec` when ANSI enabled

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,12 +25,17 @@
             "justMyCode": false
         },
         {
-            "name": "(gdb) Launch alr at /tmp/a/xxx",
+            "name": "Alire: debug ./bin/alr at /tmp/a/xxx",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/bin/alr",
-            "args": ["-d", "-vv", "with", "libfoo"],
-            "stopAtEntry": true,
+            "args": [
+                "exec",
+                "--",
+                "echo",
+                "blah"
+            ],
+            "stopAtEntry": false,
             "cwd": "/tmp/a/xxx",
             "environment": [],
             "externalConsole": false,
@@ -42,8 +47,8 @@
                     "ignoreFailures": true
                 },
                 {
-                    "description": "Set Disassembly Flavor to Intel",
-                    "text": "-gdb-set disassembly-flavor intel",
+                    "description": "Disable questions on multiple matches",
+                    "text": "set multiple-symbols cancel",
                     "ignoreFailures": true
                 }
             ]

--- a/src/alire/alire-os_lib-subprocess.adb
+++ b/src/alire/alire-os_lib-subprocess.adb
@@ -210,10 +210,11 @@ package body Alire.OS_Lib.Subprocess is
             and then CLIC.TTY.Color_Enabled
          then
             --  We cannot use Ada.Text_IO here, as it mandates endlines,
-            --  and the Ada runtime flushes this with and extra '\n' on
+            --  and the Ada runtime flushes this with an extra '\n' on
             --  finalization if this is the last output, creating an extra
             --  empty line in e.g. `alr exec echo whatever`. GNAT.IO is
             --  uncooked so it works as expected.
+            Ada.Text_IO.Flush; -- So we don't mix bufferings
             GNAT.IO.Put (Style (Dim, State));
          end if;
       end Dim;

--- a/src/alire/alire-os_lib-subprocess.adb
+++ b/src/alire/alire-os_lib-subprocess.adb
@@ -6,6 +6,7 @@ with AnsiAda; use AnsiAda;
 
 with CLIC.TTY;
 
+with GNAT.IO;
 with GNAT.OS_Lib;
 
 package body Alire.OS_Lib.Subprocess is
@@ -208,7 +209,12 @@ package body Alire.OS_Lib.Subprocess is
             and then CLIC.TTY.Is_TTY
             and then CLIC.TTY.Color_Enabled
          then
-            Ada.Text_IO.Put (Style (Dim, State));
+            --  We cannot use Ada.Text_IO here, as it mandates endlines,
+            --  and the Ada runtime flushes this with and extra '\n' on
+            --  finalization if this is the last output, creating an extra
+            --  empty line in e.g. `alr exec echo whatever`. GNAT.IO is
+            --  uncooked so it works as expected.
+            GNAT.IO.Put (Style (Dim, State));
          end if;
       end Dim;
 

--- a/src/alr/alr-commands-exec.adb
+++ b/src/alr/alr-commands-exec.adb
@@ -18,7 +18,6 @@ package body Alr.Commands.Exec is
       use GNAT.Strings;
       use Ada.Containers;
       use AAA.Strings;
-
    begin
       Cmd.Forbids_Structured_Output;
 

--- a/src/alr/alr-main.adb
+++ b/src/alr/alr-main.adb
@@ -1,7 +1,9 @@
 with Ada.Exceptions;
 
+with Alire.Directories;
 with Alire_Early_Elaboration; pragma Elaborate_All (Alire_Early_Elaboration);
 with Alire.Errors;
+with Alire.OS_Lib;
 
 with Alr.Commands;
 with Alr.Last_Chance_Handler;
@@ -11,6 +13,28 @@ begin
    Trace.Debug ("alr platform configured");
 
    Commands.Execute;
+
+   --  If we let the program end by its own means, there's a spurious blank
+   --  line printed sometimes. Debugging traces it to a call to
+   --
+   --  procedure s_stalib_adafinal;
+   --  pragma Import (Ada, s_stalib_adafinal,
+   --                 "system__standard_library__adafinal");
+   --
+   --  in the generated b__alr-main.adb
+   --
+   --  Since this doesn't always happen, it might be some thing we're doing in
+   --  those cases that comes back at finalization time. Cursory check of our
+   --  Finalize procedures didn't turn anything up. That call cannot be stepped
+   --  into, which difficults things. To be investigated...
+   --
+   --  Sample trigger: `alr exec echo whatever`
+
+   Alire.Directories.Delete_Temporaries;
+   --  Should not be needed as any temporary is now out of scope, but just in
+   --  case we call as if we were ending prematurely.
+
+   Alire.OS_Lib.Bailout (0); -- See previous paragraph
 exception
    when E : Program_Error =>
       Alire.Log_Exception (E);

--- a/src/alr/alr-main.adb
+++ b/src/alr/alr-main.adb
@@ -1,9 +1,7 @@
 with Ada.Exceptions;
 
-with Alire.Directories;
 with Alire_Early_Elaboration; pragma Elaborate_All (Alire_Early_Elaboration);
 with Alire.Errors;
-with Alire.OS_Lib;
 
 with Alr.Commands;
 with Alr.Last_Chance_Handler;
@@ -13,28 +11,6 @@ begin
    Trace.Debug ("alr platform configured");
 
    Commands.Execute;
-
-   --  If we let the program end by its own means, there's a spurious blank
-   --  line printed sometimes. Debugging traces it to a call to
-   --
-   --  procedure s_stalib_adafinal;
-   --  pragma Import (Ada, s_stalib_adafinal,
-   --                 "system__standard_library__adafinal");
-   --
-   --  in the generated b__alr-main.adb
-   --
-   --  Since this doesn't always happen, it might be some thing we're doing in
-   --  those cases that comes back at finalization time. Cursory check of our
-   --  Finalize procedures didn't turn anything up. That call cannot be stepped
-   --  into, which difficults things. To be investigated...
-   --
-   --  Sample trigger: `alr exec echo whatever`
-
-   Alire.Directories.Delete_Temporaries;
-   --  Should not be needed as any temporary is now out of scope, but just in
-   --  case we call as if we were ending prematurely.
-
-   Alire.OS_Lib.Bailout (0); -- See previous paragraph
 exception
    when E : Program_Error =>
       Alire.Log_Exception (E);

--- a/src/alr/alr-utils-temp_file.adb
+++ b/src/alr/alr-utils-temp_file.adb
@@ -12,9 +12,7 @@ package body Alr.Utils.Temp_File is
    begin
       if Exists (This.Name) then
          Delete_File (This.Name);
-         null;
       end if;
-
    exception
       when E : others =>
          Alire.Utils.Finalize_Exception (E);

--- a/testsuite/tests/exec/no-extra-line/test.py
+++ b/testsuite/tests/exec/no-extra-line/test.py
@@ -8,7 +8,6 @@ added in the non-interactive case.
 
 from drivers.alr import run_alr, init_local_crate
 from drivers.asserts import assert_eq
-# from drivers.asserts import assert_eq, assert_match
 
 # Initialize a crate, enter it, and run an echo through exec. Check the output.
 

--- a/testsuite/tests/exec/no-extra-line/test.py
+++ b/testsuite/tests/exec/no-extra-line/test.py
@@ -1,0 +1,20 @@
+"""
+Check that `alr exec` does not add an extra line at the end of the output.
+Fix for issue #2004. This test is more or less moot, since the bug can only be
+observed when running interactively with ANSI coloring, which is disabled in
+the testsuite and cannot be forced on. At least, it checks that no extra line is
+added in the non-interactive case.
+"""
+
+from drivers.alr import run_alr, init_local_crate
+from drivers.asserts import assert_eq
+# from drivers.asserts import assert_eq, assert_match
+
+# Initialize a crate, enter it, and run an echo through exec. Check the output.
+
+init_local_crate()
+
+p = run_alr("exec", "--", "echo", "HELLO", quiet=False)
+assert_eq("HELLO\n", p.out)  # Note: only one newline at the end
+
+print("SUCCESS")

--- a/testsuite/tests/exec/no-extra-line/test.yaml
+++ b/testsuite/tests/exec/no-extra-line/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
Fixes #2004

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
