### PR TITLE
fix: don't choke on other OS path separators

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -76,7 +76,7 @@ commit = "56bbdc008e16996b6f76e443fd0165a240de1b13"
 
 [pins.den]
 url    = "https://github.com/mosteo/den"
-commit = "8b41f056e3215e8805f83f23712a5efba0ce557d"
+commit = "bab6ef56b74b3b348daf402f09f4b04c304bc280"
 
 [pins.dirty_booleans]
 url    = "https://github.com/mosteo/dirty_booleans"

--- a/alire.toml
+++ b/alire.toml
@@ -20,7 +20,7 @@ ajunitgen = "^1.0.1"
 ansiada = "^1.1"
 c_strings = "^1.0"
 clic = "~0.3"
-den = "~0.1"
+den = "~0.2"
 dirty_booleans = "~0.1"
 diskflags = "~0.1"
 gnatcoll = "^21"
@@ -76,7 +76,7 @@ commit = "56bbdc008e16996b6f76e443fd0165a240de1b13"
 
 [pins.den]
 url    = "https://github.com/mosteo/den"
-commit = "7732f9247f7436cd264a10a7e2a8a16c47a0fb57"
+commit = "8b41f056e3215e8805f83f23712a5efba0ce557d"
 
 [pins.dirty_booleans]
 url    = "https://github.com/mosteo/dirty_booleans"

--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -212,6 +212,8 @@ package body Alire.Directories is
             return Find_Candidate_Folder
               (Den.Parent (Path));
          else
+            Trace.Debug
+              ("Root directory reached without finding alire metadata");
             return ""; -- No containing folder
          end if;
       end Find_Candidate_Folder;

--- a/src/alire/alire-directories.adb
+++ b/src/alire/alire-directories.adb
@@ -198,20 +198,22 @@ package body Alire.Directories is
                                       return Any_Path
       is
       begin
+         if Path /= Den.Scrub (Path) then
+            return Find_Candidate_Folder (Den.Scrub (Path));
+         end if;
+
          Trace.Debug ("Looking for alire metadata at: " & Path);
          if
            Exists (Path / Paths.Crate_File_Name) and then
            Kind (Path / Paths.Crate_File_Name) = File
          then
             return Path;
+         elsif Den.Has_Parent (Path) then
+            return Find_Candidate_Folder
+              (Den.Parent (Path));
          else
-            return Find_Candidate_Folder (Adirs.Containing_Directory (Path));
+            return ""; -- No containing folder
          end if;
-      exception
-         when Adirs.Use_Error =>
-            Trace.Debug
-              ("Root directory reached without finding alire metadata");
-            return ""; -- There's no containing folder (hence we're at root)
       end Find_Candidate_Folder;
 
    begin
@@ -514,7 +516,9 @@ package body Alire.Directories is
    ------------
 
    function Exists (Path : Any_Path) return Boolean
-   is (Den.Exists (Den.Scrub (Path)));
+   is (Den.Exists
+       (Den.Scrub
+          (Path)));
 
    ------------------
    -- Is_Directory --

--- a/testsuite/drivers/asserts.py
+++ b/testsuite/drivers/asserts.py
@@ -139,7 +139,7 @@ def match_deploy_dir(crate : str, path_fragment : str):
 
 def assert_substring(target: str, text: str):
     """
-    Check that a string is contained in another string
+    Check that a target string is contained in a given text
     """
     assert target in text, \
         f"Missing expected string '{target}' in text:\n{text}"

--- a/testsuite/tests/misc/other-slash-in-path/test.py
+++ b/testsuite/tests/misc/other-slash-in-path/test.py
@@ -1,0 +1,31 @@
+"""
+Check that slashes from other OSes in paths are handled correctly.
+Fix for issue #1984
+"""
+
+import os
+from drivers.alr import run_alr
+from drivers.asserts import assert_eq, assert_substring
+from drivers.helpers import on_windows
+
+BAD_SLASH = '/' if on_windows() else '\\'
+BAD_DIR = f"test{BAD_SLASH}crate"
+START_DIR = os.getcwd()
+
+# Initialize a crate in place within a directory with the contrary slash
+# to the one used by the current OS.
+
+os.mkdir(BAD_DIR)
+os.chdir(BAD_DIR)
+run_alr("init", "testcrate", "--bin", "--in-place")
+
+# Check we are were we expect to be
+assert_eq(os.getcwd(), os.path.join(START_DIR, BAD_DIR))
+
+# Check that it can be shown
+p = run_alr("show")
+
+# Verify the crate name is in the output
+assert_substring("testcrate=0.1.0-dev", p.out)
+
+print("SUCCESS")

--- a/testsuite/tests/misc/other-slash-in-path/test.yaml
+++ b/testsuite/tests/misc/other-slash-in-path/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    compiler_only_index: {}

--- a/testsuite/tests/misc/other-slash-in-path/test.yaml
+++ b/testsuite/tests/misc/other-slash-in-path/test.yaml
@@ -1,3 +1,6 @@
 driver: python-script
+control:
+    - [SKIP, "skip_unix", "Test is Unix-only"]
+    # Windows won't allow either '\' or '/' in filenames and directory names
 indexes:
     compiler_only_index: {}


### PR DESCRIPTION
Fixes #1984

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
