### PR TITLE
fix: adjust 'DISTRIBUTION_UNKNOWN' string in testsuite

### DIFF
--- a/testsuite/drivers/helpers.py
+++ b/testsuite/drivers/helpers.py
@@ -87,7 +87,7 @@ def on_windows():
 def distribution():
 
     if 'ALIRE_TESTSUITE_DISABLE_DISTRO' in os.environ:
-        return 'DISTRO_UNKNOWN'
+        return 'DISTRIBUTION_UNKNOWN'
 
     known_distro = ["debian", "ubuntu", "msys2", "arch", "rhel", "centos", "fedora"]
 
@@ -103,7 +103,7 @@ def distribution():
                         if split[0].lower() == key and val in known_distro:
                             return val
 
-        return 'DISTRO_UNKNOWN'
+        return 'DISTRIBUTION_UNKNOWN'
 
     elif on_macos():
         if shutil.which('brew'):
@@ -111,12 +111,12 @@ def distribution():
         elif shutil.which('port'):
             return 'MACPORTS'
         else:
-            return 'DISTRO_UNKNOWN'
+            return 'DISTRIBUTION_UNKNOWN'
 
     elif on_windows():
         return 'MSYS2'
     else:
-        return 'DISTRO_UNKNOWN'
+        return 'DISTRIBUTION_UNKNOWN'
 
 
 def path_separator():


### PR DESCRIPTION
In #1590 `testsuite/drivers/helpers.py` wasn't properly adjusted to match the new name used for unknown distributions.
