### PR TITLE
backport: add flag to fail curl commands on HTTP error

### DIFF
--- a/src/alire/alire-origins-deployers-source_archive.adb
+++ b/src/alire/alire-origins-deployers-source_archive.adb
@@ -150,8 +150,8 @@ package body Alire.Origins.Deployers.Source_Archive is
       --  verbosity if warranted by the logging level.
       Download_Cmd : constant String :=
         (if Log_Level >= Trace.Info
-           and then Configured_Download_Cmd = "curl ${URL} -L -s -o ${DEST}"
-         then "curl ${URL} -L --progress-bar -o ${DEST}"
+           and then Configured_Download_Cmd = "curl ${URL} -sSfL -o ${DEST}"
+         then "curl ${URL} -fL --progress-bar -o ${DEST}"
          else Configured_Download_Cmd);
 
       procedure Exec_Check (Exec : String) is

--- a/src/alire/alire-os_lib-download.adb
+++ b/src/alire/alire-os_lib-download.adb
@@ -32,7 +32,7 @@ package body Alire.OS_Lib.Download is
            URL &
            "--location" &  -- allow for redirects at the remote host
            (if Log_Level < Trace.Info
-            then Empty_Vector & "--silent"
+            then Empty_Vector & "--silent" & "--show-error"
             else Empty_Vector & "--progress-bar") &
            "--output" &
            Archive_File);

--- a/src/alire/alire-os_lib-download.ads
+++ b/src/alire/alire-os_lib-download.ads
@@ -7,7 +7,8 @@ package Alire.OS_Lib.Download is
                   return Outcome;
    --  Download a single file using `curl`
    --
-   --  Specifically, uses 'curl <URL> --location --silent --output <DEST>'
+   --  Specifically, uses
+   --  'curl <URL> --location --fail --silent --show-error --output <DEST>'
    --  (except that --silent may be replaced by --progress-bar depending on the
    --  log level).
    --

--- a/src/alire/alire-settings-builtins.ads
+++ b/src/alire/alire-settings-builtins.ads
@@ -118,7 +118,7 @@ package Alire.Settings.Builtins is
    Origins_Archive_Download_Cmd : constant Builtin := New_Builtin
      (Key         => "origins.archive.download_cmd",
       Kind        => Stn_String,
-      Def         => "curl ${URL} -L -s -o ${DEST}",
+      Def         => "curl ${URL} -sSfL -o ${DEST}",
       Global_Only => True,
       Help        =>
         "The command used to download crates which are published as archives."

--- a/testsuite/tests/get/custom-download-command/test.py
+++ b/testsuite/tests/get/custom-download-command/test.py
@@ -37,7 +37,7 @@ with mock_curl, mock_download_cmd:
     assert_match(
         (
             r'.*Command \["curl", "https://some\.host/path/to/archive\.tgz",'
-            r' "-L", "-s", "-o", "[^"]*archive.tgz"\] exited with code 1'
+            r' "-sSfL", "-o", "[^"]*archive.tgz"\] exited with code 1'
         ),
         p.out
     )
@@ -48,7 +48,7 @@ with mock_curl, mock_download_cmd:
     assert_match(
         (
             r'.*Command \["curl", "https://some\.host/path/to/archive\.tgz",'
-            r' "-L", "--progress-bar", "-o", "[^"]*archive.tgz"\] exited with '
+            r' "-fL", "--progress-bar", "-o", "[^"]*archive.tgz"\] exited with '
             r'code 1'
         ),
         p.out


### PR DESCRIPTION
Backport #2038 to upcoming bugfix release