### PR TITLE
fix: update documented `curl` commands

### DIFF
--- a/doc/private-crates.md
+++ b/doc/private-crates.md
@@ -131,7 +131,7 @@ from a URL to a local filesystem location.
 
 The command used to fetch such files is specified by the [settings](settings)
 key `origins.archive.download_cmd`. By default `alr` uses the command
-`curl ${URL} -L -s -o ${DEST}`, which does not attempt any form of
+`curl ${URL} -sSfL -o ${DEST}`, which does not attempt any form of
 authentication, but this can be changed to any equivalent alternative which
 implements a desired authentication scheme. The command should download the file
 to `${DEST}` (the full file path, not a directory), and must not pollute the
@@ -144,7 +144,7 @@ user's home directory and attempt to authenticate with any credentials found
 there (see `man curl` and `man netrc` for more detail). This is achieved by
 invoking
 ```sh
-alr settings --set --global origins.archive.download_cmd 'curl ${URL} -n -L -s -o ${DEST}'
+alr settings --set --global origins.archive.download_cmd 'curl ${URL} -n -sSfL -o ${DEST}'
 ```
 Note that most terminals will perform substitutions on double-quoted strings
 containing `${SOMETHING}`, so it is important to enclose the value in


### PR DESCRIPTION
Updates some references to the default `curl` command in the documentation, in line with #2038.

There is also a reference [here](https://github.com/alire-project/alire/blob/master/doc/user-changes.md#custom-download-command-for-archive-crates), but I'm guessing the policy is to leave these as they were at the time the change was first merged.