### PR TITLE
replace --no-color with a more versatile --color=WHEN switch

### DIFF
--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -17,7 +17,7 @@ The new global switch allows specifying `--color=always`, for instance when
 one wants to keep color output in a redirection. The default value is `auto`,
 which has the same behavior as before without the `--no-color` switch.
 
-Disabling colors in done with the `never` value. It also follows the
+Disabling colors is done with the `never` value. It also follows the
 `NO_COLOR` environment variable, like before, but the `always` value has
 priority.
 

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -11,6 +11,19 @@ stay on top of `alr` new features.
 The solver timeout has been increased from 5 seconds to 10 seconds by default.
 This should avoid hitting it on complex dependencies on slower machines.
 
+### Replace `--no-color` with a new `--color[=WHEN]` switch
+
+The new global switch allows specifying `--color=always`, for instance when
+one wants to keep color output in a redirection. The default value is `auto`,
+which as the same behavior a before with the `--no-color` switch.
+
+Disabling colors in done with the `never` value. It also follows the
+`NO_COLOR` environment variable, like before, but the `always` value has
+priority.
+
+The `--no-color` switch will still work, but is deprecated and will be removed
+in the next version.
+
 ### Gentoo support
 
 Add Gentoo's Portage support via sudo, if the base package contains a section for gentoo, see libsdl2 for example, emerge will be called if the package is not installed.

--- a/doc/user-changes.md
+++ b/doc/user-changes.md
@@ -15,7 +15,7 @@ This should avoid hitting it on complex dependencies on slower machines.
 
 The new global switch allows specifying `--color=always`, for instance when
 one wants to keep color output in a redirection. The default value is `auto`,
-which as the same behavior a before with the `--no-color` switch.
+which has the same behavior as before without the `--no-color` switch.
 
 Disabling colors in done with the `never` value. It also follows the
 `NO_COLOR` environment variable, like before, but the `always` value has

--- a/src/alire/alire-features.ads
+++ b/src/alire/alire-features.ads
@@ -15,6 +15,10 @@ package Alire.Features is
    --  former with a warning during our next major release to ease transition.
    --  Likewise for the -c/--config switch
 
+   No_Color_Deprecated : constant On_Version := +"3.0";
+   --  Deprecate the --no-color switch in favour of a more versatile
+   --  --color=WHEN option.
+
    Self_Update_Cmd : constant On_Version := +"3.0.0-dev";
    --  Used to warn when users downgrade alr using the `self-update` command
 

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -149,19 +149,24 @@ package body Alr.Commands is
 
    procedure Set_Color_Config (Switch, Value : String) is
       Stripped_Value : constant String :=
-         AAA.Strings.To_Lower_Case (AAA.Strings.Trim (Value, '='));
+        AAA.Strings.To_Lower_Case (AAA.Strings.Trim (Value, '='));
+
+      function Suggest is new
+        Alire.Utils.Did_You_Mean.Enum_Suggestion
+          (Color_Config_Values,
+           Alire.Utils.Did_You_Mean.Lower_Case);
    begin
       if Stripped_Value = "always" then
          Color_Config := Always;
-
       elsif Stripped_Value = "never" then
          Color_Config := Never;
-
       elsif Stripped_Value /= "auto" and then Stripped_Value /= "" then
          Trace.Warning
-           ("Unknown value '" & Stripped_Value & "' passed for "
-            & TTY.Terminal (Switch) & ". Defaulting to 'auto'.");
-
+           ("Unknown argument in "
+            & TTY.Terminal (Switch)
+            & Value
+            & ". Defaulting to 'auto'."
+            & Suggest (Stripped_Value));
       end if;
    end Set_Color_Config;
 


### PR DESCRIPTION
The `--color` switch accepts `always`, `auto` and `never`.

`--color=always` is useful when one wants to keep color output in a redirection. Notably: in GitHub actions?

The default value is `auto`, which has the same behaviour as before without the `--no-color` switch.

Disabling colors is done with the `never` value. It also follows the `NO_COLOR` environment variable, like before, but the `always` value has priority.

The `--no-color` switch will still work, but is deprecated.

##### PR creation checklist
- [x] `doc/user-changes.md` has been updated, if there are user-visible changes.
