### PR TITLE
feat: add suggested solutions to untrusted site message

### DIFF
--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -943,18 +943,20 @@ package body Alire.Publish is
                          & URI.Host (URL));
          else
             Raise_Checked_Error
-              ("Origin host '"
-               & URI.Host (URL)
-               & "' is not a trusted site."
-               & New_Line
-               & (if Context.Options.For_Private_Index
-                  then
-                    "This can be configured using the "
-                    & "'origins.git.trusted_sites' setting."
-                  else
-                    "Please open an issue at "
-                    & "https://github.com/alire-project/alire/issues/new if "
-                    & "you think it should be added to the list."));
+              (Errors.New_Wrapper.Wrap
+                 ("Origin host '"
+                  & URI.Host (URL)
+                  & "' is not a trusted site.")
+                 .Wrap
+                    (if Context.Options.For_Private_Index
+                     then
+                       "This can be configured using the "
+                       & "'origins.git.trusted_sites' setting."
+                     else
+                       "Please open an issue at "
+                       & "https://github.com/alire-project/alire/issues/new "
+                       & "if you think it should be added to the list.")
+                 .Get);
          end if;
       end if;
 

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -942,8 +942,19 @@ package body Alire.Publish is
             Put_Success ("Origin is hosted on trusted site: "
                          & URI.Host (URL));
          else
-            Raise_Checked_Error ("Origin is hosted on unknown site: "
-                                 & URI.Host (URL));
+            Raise_Checked_Error
+              ("Origin host '"
+               & URI.Host (URL)
+               & "' is not a trusted site."
+               & New_Line
+               & (if Context.Options.For_Private_Index
+                  then
+                    "This can be configured using the "
+                    & "'origins.git.trusted_sites' setting."
+                  else
+                    "Please open an issue at "
+                    & "https://github.com/alire-project/alire/issues/new if "
+                    & "you think it should be added to the list."));
          end if;
       end if;
 

--- a/src/alire/alire-settings-builtins.ads
+++ b/src/alire/alire-settings-builtins.ads
@@ -145,7 +145,8 @@ package Alire.Settings.Builtins is
       & " 'alr index --check' and 'alr publish --for-private-index'. If set to"
       & " '...', all origins are trusted. Note that this does not have any"
       & " effect when using 'alr publish' for submissions to the community"
-      & " index (which only permits the default list).");
+      & " index (which only permits the default list, due to vulnerabilities"
+      & " identified in Git's use of SHA1).");
 
    --  SOLVER
 

--- a/testsuite/tests/publish/check-trusted/test.py
+++ b/testsuite/tests/publish/check-trusted/test.py
@@ -11,7 +11,7 @@ for domain in ["badsite.com", "ggithub.com", "github.comm"]:
                 "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
                 "--skip-submit",
                 complain_on_error=False)
-    assert_match(f".*Origin is hosted on unknown site: {domain}.*", p.out)
+    assert_match(f".*Origin host '{domain}' is not a trusted site.*", p.out)
 
 # Try that having credentials doesn't interfere with the previous check and
 # that the domain was recognized properly.
@@ -25,6 +25,6 @@ for domain in ["badsite.com", "ggithub.com", "github.comm"]:
                     "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
                     "--for-private-index",
                     complain_on_error=False)
-        assert_match(f".*Origin is hosted on unknown site: {domain}.*", p.out)
+        assert_match(f".*Origin host '{domain}' is not a trusted site.*", p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/publish/private-indexes/test.py
+++ b/testsuite/tests/publish/private-indexes/test.py
@@ -279,7 +279,7 @@ for force_arg in ([], ["--force"]):
         url="https://trusted.host/some_user/repo-name",
         maint_logins='["github-username"]',
         num_confirms=1,
-        output=[r".*Origin is hosted on unknown site: trusted\.host.*"],
+        output=[r".*Origin host 'trusted\.host' is not a trusted site:"],
         gen_manifest=None,
         expect_success=False
     )
@@ -288,7 +288,7 @@ for force_arg in ([], ["--force"]):
         url="https://trusted.host/some_user/repo-name",
         maint_logins='["github-username"]',
         num_confirms=1,
-        output=[r".*Origin is hosted on unknown site: trusted\.host.*"],
+        output=[r".*Origin host 'trusted\.host' is not a trusted site:"],
         gen_manifest=None,
         expect_success=False
     )
@@ -312,14 +312,28 @@ for force_arg in ([], ["--force"]):
     # because it uses an origin with an untrusted host, which the user has not
     # configured as trusted:
     #
-    # "alr publish [--skip-submit | --for-private-index]" should all fail.
+    # "alr publish [--skip-submit | --for-private-index]" should all fail, with
+    # different suggested solutions dependent on the presence of
+    # --for-private-index.
     for switch in ([], ["--skip-submit"], ["--for-private-index"]):
+        suggestion = (
+            "This can be configured using the 'origins.git.trusted_sites' setting."
+            if switch == ["--for-private-index"]
+            else
+            (
+                "Please open an issue at https://github.com/alire-project/"
+                "alire/issues/new if you think it should be added to the list."
+            )
+        )
         test(
             args=force_arg + ["publish"] + switch,
             url="https://untrusted.host/some_user/repo-name",
             maint_logins='["github-username"]',
             num_confirms=1,
-            output=[r".*Origin is hosted on unknown site: untrusted\.host.*"],
+            output=[
+                r".*Origin host 'untrusted\.host' is not a trusted site:",
+                rf".*{re.escape(suggestion)}",
+            ],
             gen_manifest=None,
             expect_success=False
         )

--- a/testsuite/tests/publish/ssh-remote-origin/test.py
+++ b/testsuite/tests/publish/ssh-remote-origin/test.py
@@ -28,9 +28,9 @@ for url in urls:
 # the untrusted host, not because the URLs appear private.
 for url in urls:
     p = run_alr(
-        "publish", "--for-private-index", url, commit,complain_on_error=False
+        "publish", "--for-private-index", url, commit, complain_on_error=False
     )
-    assert_match(r".*Origin is hosted on unknown site: host\.invalid.*", p.out)
+    assert_match(r".*Origin host 'host\.invalid' is not a trusted site:.*", p.out)
 
 
 print("SUCCESS")


### PR DESCRIPTION
Closes #1985

When `alr publish` fails due to an untrusted origin, the message now has the form
```
error: Could not complete the publishing assistant:
error:    Origin host 'untrusted.site' is not a trusted site:
error:    Please open an issue at https://github.com/alire-project/alire/issues/new if you think it should be added to the list.
```
or, if `--for-private-index` is specified,
```
error: Could not complete the publishing assistant:
error:    Origin host 'untrusted.site' is not a trusted site:
error:    This can be configured using the 'origins.git.trusted_sites' setting.
```

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
