### PR TITLE
feat: structured test runner output

### DIFF
--- a/src/alire/alire-toml_keys.ads
+++ b/src/alire/alire-toml_keys.ads
@@ -67,6 +67,7 @@ package Alire.TOML_Keys with Preelaborate is
    Test_Report_Status   : constant String := "status";
    Test_Report_Reason   : constant String := "reason";
    Test_Report_Output   : constant String := "output";
+   Test_Report_Duration : constant String := "duration";
    Test_Report_Summary  : constant String := "summary";
    Test_Report_Total    : constant String := "total";
    Test_Report_Failures : constant String := "failures";

--- a/src/alire/alire-toml_keys.ads
+++ b/src/alire/alire-toml_keys.ads
@@ -63,4 +63,12 @@ package Alire.TOML_Keys with Preelaborate is
    Index_Name     : constant String := "name";
    Index_Priority : constant String := "priority";
 
+   Test_Report_Cases    : constant String := "tests";
+   Test_Report_Status   : constant String := "status";
+   Test_Report_Reason   : constant String := "reason";
+   Test_Report_Output   : constant String := "output";
+   Test_Report_Summary  : constant String := "summary";
+   Test_Report_Total    : constant String := "total";
+   Test_Report_Failures : constant String := "failures";
+
 end Alire.TOML_Keys;

--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -328,26 +328,26 @@ package body Alire.Utils is
       I, F : Long_Integer;
 
       --  account for rounding up
-      SECONDS_MAX : constant := 59.9995;
-      MINUTES_MAX : constant := 3599.5;
+      Seconds_Max : constant := 59.9995;
+      Minutes_Max : constant := 3599.5;
    begin
       if D < 0.0 then
          return "-" & Format_Duration (-D);
-      elsif D < SECONDS_MAX then
+      elsif D < Seconds_Max then
          I := Long_Integer (D * 1000.0);
          F := I mod 1000;
          I := I / 1000;
          return Trim (I'Image) & "s" & Left_Pad (Trim (F'Image), 3, '0');
       else
          I :=
-           (if D < MINUTES_MAX
+           (if D < Minutes_Max
             then Long_Integer (D)
             else Long_Integer (D / 60.0));
          F := I mod 60;
          I := I / 60;
          return
            Trim (I'Image)
-           & (if D < MINUTES_MAX then "m" else "h")
+           & (if D < Minutes_Max then "m" else "h")
            & Left_Pad (Trim (F'Image), 2, '0');
       end if;
    end Format_Duration;

--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -294,4 +294,30 @@ package body Alire.Utils is
       return False;
    end Has_Duplicates;
 
+   ------------------
+   -- Strip_Prefix --
+   ------------------
+
+   function Strip_Prefix (Src, Prefix : String) return String is
+   begin
+      if AAA.Strings.Has_Prefix (Src, Prefix) then
+         return Src (Src'First + Prefix'Length .. Src'Last);
+      else
+         return Src;
+      end if;
+   end Strip_Prefix;
+
+   ------------------
+   -- Strip_Suffix --
+   ------------------
+
+   function Strip_Suffix (Src, Suffix : String) return String is
+   begin
+      if AAA.Strings.Has_Suffix (Src, Suffix) then
+         return Src (Src'First .. Src'Last - Suffix'Length);
+      else
+         return Src;
+      end if;
+   end Strip_Suffix;
+
 end Alire.Utils;

--- a/src/alire/alire-utils.adb
+++ b/src/alire/alire-utils.adb
@@ -320,4 +320,36 @@ package body Alire.Utils is
       end if;
    end Strip_Suffix;
 
+   ---------------------
+   -- Format_Duration --
+   ---------------------
+
+   function Format_Duration (D : Duration) return String is
+      I, F : Long_Integer;
+
+      --  account for rounding up
+      SECONDS_MAX : constant := 59.9995;
+      MINUTES_MAX : constant := 3599.5;
+   begin
+      if D < 0.0 then
+         return "-" & Format_Duration (-D);
+      elsif D < SECONDS_MAX then
+         I := Long_Integer (D * 1000.0);
+         F := I mod 1000;
+         I := I / 1000;
+         return Trim (I'Image) & "s" & Left_Pad (Trim (F'Image), 3, '0');
+      else
+         I :=
+           (if D < MINUTES_MAX
+            then Long_Integer (D)
+            else Long_Integer (D / 60.0));
+         F := I mod 60;
+         I := I / 60;
+         return
+           Trim (I'Image)
+           & (if D < MINUTES_MAX then "m" else "h")
+           & Left_Pad (Trim (F'Image), 2, '0');
+      end if;
+   end Format_Duration;
+
 end Alire.Utils;

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -114,6 +114,14 @@ package Alire.Utils with Preelaborate is
       Transform : access function (S : String) return String := null)
       return Boolean;
 
+   function Strip_Prefix (Src, Prefix : String) return String;
+   --  Return the string Src without the given Prefix if it exists.
+   --  Only removes the prefix once.
+
+   function Strip_Suffix (Src, Suffix : String) return String;
+   --  Return the string Src without the given Suffix if it exists.
+   --  Only removes the suffix once.
+
 private
 
    function Quote (S : String) return String

--- a/src/alire/alire-utils.ads
+++ b/src/alire/alire-utils.ads
@@ -122,9 +122,35 @@ package Alire.Utils with Preelaborate is
    --  Return the string Src without the given Suffix if it exists.
    --  Only removes the suffix once.
 
+   function Left_Pad
+     (Src : String; Length : Natural; Char : Character := ' ') return String;
+   --  Pad the string Src to the left with Char so that the resulting string
+   --  is at least Length characters.
+   --  Unlike Ada.Strings.Fixed.Tail, it does not truncate.
+
+   function Right_Pad
+     (Src : String; Length : Natural; Char : Character := ' ') return String;
+   --  Pad the string Src to the right with Char so that the resulting string
+   --  is at least Length characters.
+   --  Unlike Ada.Strings.Fixed.Head, it does not truncate.
+
+   function Format_Duration (D : Duration) return String;
+   --  Format (small) durations in a human readable way:
+   --  under one minute: <seconds>s<milliseconds>
+   --  under one hour:   <minutes>m<seconds>
+   --  above:            <hours>h<minutes>
+
 private
 
    function Quote (S : String) return String
    is ("""" & S & """");
+
+   function Left_Pad
+     (Src : String; Length : Natural; Char : Character := ' ') return String
+   is ((1 .. Length - Natural'Min (Src'Length, Length) => Char) & Src);
+
+   function Right_Pad
+     (Src : String; Length : Natural; Char : Character := ' ') return String
+   is (Src & (1 .. Length - Natural'Min (Src'Length, Length) => Char));
 
 end Alire.Utils;

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -66,7 +66,6 @@ package body Alr.Commands.Test is
 
       All_Settings : Alire.Properties.Vector;
    begin
-      Cmd.Forbids_Structured_Output;
       Cmd.Requires_Workspace;
 
       All_Settings :=
@@ -126,7 +125,8 @@ package body Alr.Commands.Test is
          then
             declare
                function Get_Args return AAA.Strings.Vector
-               is (if All_Settings.Length = 1 then Args
+               is (if All_Settings.Length = 1
+                   then Args
                    else AAA.Strings.Empty_Vector);
                --  Only forward arguments if the runner is the only one.
 
@@ -136,8 +136,8 @@ package body Alr.Commands.Test is
                Guard : Dirs.Guard (Enter (Cmd.Root.Path / S.Directory))
                with Unreferenced;
 
-               Test_Root : Alire.Roots.Optional.Root
-                 := Alire.Roots.Optional.Detect_Root
+               Test_Root : Alire.Roots.Optional.Root :=
+                 Alire.Roots.Optional.Detect_Root
                    (Cmd.Root.Path / S.Directory);
             begin
                if All_Settings.Length > 1 then
@@ -150,7 +150,9 @@ package body Alr.Commands.Test is
                         Alire.Raise_Checked_Error
                           ("cannot detect a proper crate in test directory '"
                            & S.Directory
-                           & "' (error: " & Test_Root.Message & ")");
+                           & "' (error: "
+                           & Test_Root.Message
+                           & ")");
                      end if;
 
                      Failures :=
@@ -159,7 +161,9 @@ package body Alr.Commands.Test is
                           Get_Args,
                           (if Cmd.Jobs < 0 then S.Jobs else Cmd.Jobs));
 
-                  when External =>
+                  when External     =>
+                     Cmd.Forbids_Structured_Output
+                       ("Cannot output structured output for external runner");
                      Failures :=
                        Alire.OS_Lib.Subprocess.Unchecked_Spawn
                          (S.Runner.Command.First_Element,
@@ -170,7 +174,8 @@ package body Alr.Commands.Test is
 
                if Failures /= 0 then
                   Reportaise_Command_Failed
-                    (if S.Runner.Kind = Alire_Runner then ""
+                    (if S.Runner.Kind = Alire_Runner
+                     then ""
                      else "test failure");
                end if;
             end;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -311,9 +311,14 @@ package body Alr.Commands is
    -- Forbids_Structured_Output --
    -------------------------------
 
-   procedure Forbids_Structured_Output (Cmd : in out Command'Class) is
+   procedure Forbids_Structured_Output (Cmd : in out Command'Class;
+                                        Custom_Msg : String := "")
+   is
    begin
       if Alire.Formatting.Structured_Output then
+         if Custom_Msg /= "" then
+            Trace.Error (Custom_Msg);
+         end if;
          Reportaise_Wrong_Arguments
            ("Command " & TTY.Terminal (Cmd.Name) & " does not support the "
             & TTY.Terminal ("--format") & " switch");

--- a/src/alr/alr-commands.ads
+++ b/src/alr/alr-commands.ads
@@ -70,7 +70,8 @@ package Alr.Commands is
    --  performing a silent update. If not Sync, only a minimal empty lockfile
    --  is created. If Error, replace the first generic error message with it.
 
-   procedure Forbids_Structured_Output (Cmd : in out Command'Class);
+   procedure Forbids_Structured_Output (Cmd : in out Command'Class;
+                                        Custom_Msg : String := "");
    --  Use this to mark that the output of a command is not (yet) compatible
    --  with global flag --format.
 

--- a/testsuite/tests/test/conditional-tests/test.py
+++ b/testsuite/tests/test/conditional-tests/test.py
@@ -7,7 +7,7 @@ import os
 import shutil
 from drivers.alr import alr_manifest, init_local_crate, init_local_crate, run_alr
 from drivers.helpers import append_to_file
-from drivers.asserts import assert_substring
+from drivers.asserts import assert_substring, assert_match
 
 CRATE="xxx"
 
@@ -31,7 +31,7 @@ for mode in ["table", "array"]:
 
     # Verify the test runs in all platforms
     p = run_alr("test")
-    assert_substring("[ PASS ] tests", p.out)
+    assert_match(".*\[ PASS \] *\d+[smh]\d+ tests.*", p.out)
 
     # Verify the crate can be shown after resolving conditional expressions (this is
     # equivalent to exporting the crate). `--system` is the key flag to force evaluation.

--- a/testsuite/tests/test/crate-init/test.py
+++ b/testsuite/tests/test/crate-init/test.py
@@ -9,7 +9,7 @@ from drivers.asserts import assert_match
 init_local_crate(with_test=True)
 
 p = run_alr("test")
-assert_match(".*\[ PASS \] assertions_enabled.*", p.out)
+assert_match(".*\[ PASS \] *\d+[smh]\d+ assertions_enabled.*", p.out)
 # default test after init always fails
 
 print('SUCCESS')

--- a/testsuite/tests/test/default-failure/test.py
+++ b/testsuite/tests/test/default-failure/test.py
@@ -19,7 +19,7 @@ end Xxx_Tests.Assertions_Enabled;
 """)
 
 p = run_alr("test", complain_on_error=False)
-assert_match(".*\[ FAIL \] assertions_enabled.*", p.out)
+assert_match(".*\[ FAIL \] *\d+[smh]\d+ assertions_enabled.*", p.out)
 
 # Check with plain assertion (verify that assertions are evaluated)
 
@@ -31,6 +31,6 @@ end Xxx_Tests.Assertions_Enabled;
 """)
 
 p = run_alr("test", complain_on_error=False)
-assert_match(".*\[ FAIL \] assertions_enabled.*", p.out)
+assert_match(".*\[ FAIL \] *\d+[smh]\d+ assertions_enabled.*", p.out)
 
 print('SUCCESS')

--- a/testsuite/tests/test/nested-tests/test.py
+++ b/testsuite/tests/test/nested-tests/test.py
@@ -40,7 +40,7 @@ begin
 end Xxx_Tests.Failing_Test;
 """)
 
-p = run_alr("test", complain_on_error=False)
+p = run_alr("test", complain_on_error=False, quiet=False)
 # We check piecemeal as exact output varies between OSes (macOS in particular)
 assert_substring("[ FAIL ] nested/failing_test", p.out)
 assert_substring("raised PROGRAM_ERROR : xxx_tests-failing_test.adb", p.out)

--- a/testsuite/tests/test/nested-tests/test.py
+++ b/testsuite/tests/test/nested-tests/test.py
@@ -6,7 +6,7 @@ and the name printed keeps the prefix inside "src".
 from os import makedirs
 
 from drivers.alr import init_local_crate, run_alr
-from drivers.asserts import assert_substring
+from drivers.asserts import assert_substring, assert_match
 from drivers.helpers import mkcd
 
 # Initialize a local crate with a test
@@ -27,8 +27,8 @@ end Xxx_Tests.Nested_Test;
 # Run `alr test` and check that two PASS lines exist with the proper test names
 
 p = run_alr("test")
-assert_substring("[ PASS ] assertions_enabled", p.out)
-assert_substring("[ PASS ] nested/nested_test", p.out)
+assert_match(".*\[ PASS \] *\d+[smh]\d+ assertions_enabled.*", p.out)
+assert_match(".*\[ PASS \] *\d+[smh]\d+ nested/nested_test.*", p.out)
 
 # Create a third failing test to check its failure and output are reported
 
@@ -42,7 +42,7 @@ end Xxx_Tests.Failing_Test;
 
 p = run_alr("test", complain_on_error=False, quiet=False)
 # We check piecemeal as exact output varies between OSes (macOS in particular)
-assert_substring("[ FAIL ] nested/failing_test", p.out)
+assert_match(".*\[ FAIL \] *\d+[smh]\d+ nested/failing_test.*", p.out)
 assert_substring("raised PROGRAM_ERROR : xxx_tests-failing_test.adb", p.out)
 
 print("SUCCESS")

--- a/testsuite/tests/test/structured-output/test.py
+++ b/testsuite/tests/test/structured-output/test.py
@@ -5,6 +5,7 @@ Run a some tests and check the expected structured output
 import os
 import json
 import yaml
+import toml
 
 from drivers.alr import init_local_crate, run_alr
 
@@ -59,11 +60,7 @@ data = yaml.safe_load(p.out)
 structure_tests(data)
 
 p = run_alr("--format=toml", "test", complain_on_error=False)
-try:
-    import tomllib
-    data = tomllib.loads(p.out)
-    structure_tests(data)
-except ModuleNotFoundError:
-    pass
+data = toml.loads(p.out)
+structure_tests(data)
 
 print("SUCCESS")

--- a/testsuite/tests/test/structured-output/test.py
+++ b/testsuite/tests/test/structured-output/test.py
@@ -31,7 +31,13 @@ def structure_tests(data):
     assert sorted(list(data.keys())) == ["summary", "tests"]
 
     assert sorted(list(data["tests"].keys())) == ["failing_test", "passing_test"]
+    print(data["tests"]["passing_test"])
+    assert sorted(list(data["tests"]["passing_test"].keys())) == [
+        "duration",
+        "status",
+    ]
     assert sorted(list(data["tests"]["failing_test"].keys())) == [
+        "duration",
         "output",
         "reason",
         "status",

--- a/testsuite/tests/test/structured-output/test.py
+++ b/testsuite/tests/test/structured-output/test.py
@@ -4,7 +4,6 @@ Run a some tests and check the expected structured output
 
 import os
 import json
-import tomllib
 import yaml
 
 from drivers.alr import init_local_crate, run_alr
@@ -49,12 +48,16 @@ p = run_alr("--format=json", "test", complain_on_error=False)
 data = json.loads(p.out)
 structure_tests(data)
 
-p = run_alr("--format=toml", "test", complain_on_error=False)
-data = tomllib.loads(p.out)
-structure_tests(data)
-
 p = run_alr("--format=yaml", "test", complain_on_error=False)
 data = yaml.safe_load(p.out)
 structure_tests(data)
+
+p = run_alr("--format=toml", "test", complain_on_error=False)
+try:
+    import tomllib
+    data = tomllib.loads(p.out)
+    structure_tests(data)
+except ModuleNotFoundError:
+    pass
 
 print("SUCCESS")

--- a/testsuite/tests/test/structured-output/test.py
+++ b/testsuite/tests/test/structured-output/test.py
@@ -1,0 +1,60 @@
+"""
+Run a some tests and check the expected structured output
+"""
+
+import os
+import json
+import tomllib
+import yaml
+
+from drivers.alr import init_local_crate, run_alr
+
+init_local_crate("xxx", with_test=True)
+
+os.remove("./tests/src/xxx_tests-assertions_enabled.adb")
+
+with open("./tests/src/xxx_tests-failing_test.adb", "w+") as f:
+    f.write("""procedure Xxx_Tests.Failing_Test is
+begin
+   raise Program_Error;
+end Xxx_Tests.Failing_Test;
+""")
+
+with open("./tests/src/xxx_tests-passing_test.adb", "w+") as f:
+    f.write("""procedure Xxx_Tests.Passing_Test is
+begin
+   null;
+end Xxx_Tests.Passing_Test;
+""")
+
+
+def structure_tests(data):
+    assert sorted(list(data.keys())) == ["summary", "tests"]
+
+    assert sorted(list(data["tests"].keys())) == ["failing_test", "passing_test"]
+    assert sorted(list(data["tests"]["failing_test"].keys())) == [
+        "output",
+        "reason",
+        "status",
+    ]
+    assert data["tests"]["failing_test"]["status"] == "fail"
+    assert data["tests"]["passing_test"]["status"] == "pass"
+
+    assert sorted(list(data["summary"].keys())) == ["failures", "total"]
+    assert data["summary"]["total"] == 2
+    assert data["summary"]["failures"] == 1
+
+
+p = run_alr("--format=json", "test", complain_on_error=False)
+data = json.loads(p.out)
+structure_tests(data)
+
+p = run_alr("--format=toml", "test", complain_on_error=False)
+data = tomllib.loads(p.out)
+structure_tests(data)
+
+p = run_alr("--format=yaml", "test", complain_on_error=False)
+data = yaml.safe_load(p.out)
+structure_tests(data)
+
+print("SUCCESS")

--- a/testsuite/tests/test/structured-output/test.yaml
+++ b/testsuite/tests/test/structured-output/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    compiler_only_index: {}

--- a/testsuite/tests/test/suppress-output/test.py
+++ b/testsuite/tests/test/suppress-output/test.py
@@ -1,0 +1,27 @@
+"""
+Run a failing test and check its output is suppressed when using -q
+"""
+
+from drivers.alr import init_local_crate, run_alr
+from drivers.asserts import assert_substring
+
+init_local_crate("xxx", with_test=True)
+
+with open("./tests/src/xxx_tests-assertions_enabled.adb", "w") as f:
+    f.write("""procedure Xxx_Tests.Assertions_Enabled is
+begin
+   raise Program_Error;
+end Xxx_Tests.Assertions_Enabled;
+""")
+
+# check that when -q is set to false, the failing test output is displayed
+p = run_alr("test", complain_on_error=False, quiet=False)
+assert_substring("[ FAIL ] assertions_enabled", p.out)
+assert_substring("raised PROGRAM_ERROR : xxx_tests-assertions_enabled.adb", p.out)
+
+# check that when -q is passed, the failing test output is suppressed
+p = run_alr("test", complain_on_error=False, quiet=True)
+assert_substring("[ FAIL ] assertions_enabled", p.out)
+assert "raised PROGRAM_ERROR : xxx_tests-assertions_enabled.adb" not in p.out
+
+print("SUCCESS")

--- a/testsuite/tests/test/suppress-output/test.py
+++ b/testsuite/tests/test/suppress-output/test.py
@@ -3,7 +3,7 @@ Run a failing test and check its output is suppressed when using -q
 """
 
 from drivers.alr import init_local_crate, run_alr
-from drivers.asserts import assert_substring
+from drivers.asserts import assert_substring, assert_match
 
 init_local_crate("xxx", with_test=True)
 
@@ -16,12 +16,12 @@ end Xxx_Tests.Assertions_Enabled;
 
 # check that when -q is set to false, the failing test output is displayed
 p = run_alr("test", complain_on_error=False, quiet=False)
-assert_substring("[ FAIL ] assertions_enabled", p.out)
+assert_match(".*\[ FAIL \] *\d+[smh]\d+ assertions_enabled.*", p.out)
 assert_substring("raised PROGRAM_ERROR : xxx_tests-assertions_enabled.adb", p.out)
 
 # check that when -q is passed, the failing test output is suppressed
 p = run_alr("test", complain_on_error=False, quiet=True)
-assert_substring("[ FAIL ] assertions_enabled", p.out)
+assert_match(".*\[ FAIL \] *\d+[smh]\d+ assertions_enabled.*", p.out)
 assert "raised PROGRAM_ERROR : xxx_tests-assertions_enabled.adb" not in p.out
 
 print("SUCCESS")

--- a/testsuite/tests/test/suppress-output/test.yaml
+++ b/testsuite/tests/test/suppress-output/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    compiler_only_index: {}

--- a/testsuite/tests_ada/src/alr_tests-format_duration.adb
+++ b/testsuite/tests_ada/src/alr_tests-format_duration.adb
@@ -1,0 +1,34 @@
+with Alire.Utils;
+
+procedure Alr_Tests.Format_Duration is
+   function F (D : Duration) return String renames Utils.Format_Duration;
+begin
+   --  small values
+   pragma Assert (F (0.0) = "0s000");
+   pragma Assert (F (0.5) = "0s500");
+
+   --  rounding normal values
+   pragma Assert (F (12.679) = "12s679");
+   pragma Assert (F (12.6799) = "12s680");
+
+   --  seconds/minutes boundary
+   pragma Assert (F (59.999) = "59s999");
+   pragma Assert (F (59.9994) = "59s999");
+   pragma Assert (F (59.9995) = "1m00");
+   pragma Assert (F (60.0) = "1m00");
+
+   --  minutes/hours boundary
+   pragma Assert (F (3599.0) = "59m59");
+   pragma Assert (F (3599.4) = "59m59");
+   pragma Assert (F (3599.5) = "1h00");
+   pragma Assert (F (3600.0) = "1h00");
+
+   --  last value
+   pragma Assert (F (Duration'Last) = "2562047h47");
+
+   --  negative values
+   pragma Assert (F (-0.5) = "-" & F (0.5));
+   pragma Assert (F (-12.679) = "-" & F (12.679));
+   pragma Assert (F (-60.0) = "-" & F (60.0));
+   pragma Assert (F (-3601.0) = "-" & F (3601.0));
+end Alr_Tests.Format_Duration;

--- a/testsuite/tests_ada/src/alr_tests-string_utils.adb
+++ b/testsuite/tests_ada/src/alr_tests-string_utils.adb
@@ -1,0 +1,20 @@
+with Alire.Utils; use Alire.Utils;
+
+procedure Alr_Tests.String_Utils is
+begin
+   pragma Assert (Strip_Prefix ("aaabbb", "aaa") = "bbb");
+   pragma Assert (Strip_Prefix ("aaabbb", "aa") = "abbb");
+   pragma Assert (Strip_Prefix ("aabbb", "aaa") = "aabbb");
+
+   pragma Assert (Strip_Suffix ("aaabbb", "bbb") = "aaa");
+   pragma Assert (Strip_Suffix ("aaabbb", "bb") = "aaab");
+   pragma Assert (Strip_Suffix ("aaabb", "bbb") = "aaabb");
+
+   pragma Assert (Left_Pad ("xxx", 5) = "  xxx");
+   pragma Assert (Left_Pad ("xxxxx", 3) = "xxxxx");
+   pragma Assert (Left_Pad ("x", 4, 'y') = "yyyx");
+
+   pragma Assert (Right_Pad ("xxx", 5) = "xxx  ");
+   pragma Assert (Right_Pad ("xxxxx", 3) = "xxxxx");
+   pragma Assert (Right_Pad ("x", 4, 'y') = "xyyy");
+end Alr_Tests.String_Utils;


### PR DESCRIPTION
POC PR: this is a proposed structured output format for the built-in test runner.

It works but I don't know if we want something else (some standard format?). The structured output is still disabled for external runners.

Also added test duration in regular and structured output.