### PR TITLE
Make `alr test` search for a test runner in parent dirs

### DIFF
--- a/src/alr/alr-commands-test.ads
+++ b/src/alr/alr-commands-test.ads
@@ -37,6 +37,7 @@ private
    type Command is new Commands.Command with record
       Jobs : aliased Integer := 0;
       By_Id : aliased GNAT.Strings.String_Access;
+      Legacy : aliased Boolean := False;
    end record;
 
 end Alr.Commands.Test;

--- a/testsuite/tests/test/from-subdir/test.py
+++ b/testsuite/tests/test/from-subdir/test.py
@@ -1,6 +1,5 @@
 """
-Test that running `alr test` from a subdirectory other than the root and the
-`tests` directory works as expected.
+Test that running `alr test` from a subdirectory works as expected.
 """
 
 from drivers.alr import init_local_crate, run_alr
@@ -19,5 +18,16 @@ assert_substring("[ PASS ]", p.out)
 mkcd("subsubdir")
 p = run_alr("test")
 assert_substring("[ PASS ]", p.out)
+
+# create a subcrate two levels down without a `test` section
+init_local_crate("yyy", with_test=False)
+p = run_alr("test")
+assert_substring("[ PASS ]", p.out)
+
+# check that using `--legacy` does not run the testsuite from
+# the toplevel crate
+p = run_alr("test", "--legacy", quiet=False)
+assert "[ PASS ]" not in p.out
+assert_substring("Successful actions run", p.out)
 
 print("SUCCESS")


### PR DESCRIPTION
When running `alr test` in a crate without a `test` section, it will search for the first parent crate that defines a `test` section in the manifest. When it cannot find one, it will fall back to running the legacy actions in the current crate.

A switch was added to the `test` command to override this behaviour: using `--legacy` will now always run the legacy test actions, even if a parent crate has a test runner.

Fixes #1930

##### PR creation checklist
- [x] A test is included, if required by the changes.
