### PR TITLE
fix: ensure -C/--prefix is applied before other processings

### DIFF
--- a/src/alire/alire-settings-edit.adb
+++ b/src/alire/alire-settings-edit.adb
@@ -190,6 +190,7 @@ package body Alire.Settings.Edit is
 
       for Lvl in Level loop
          if Lvl /= Local or else Directories.Detect_Root_Path /= "" then
+            Trace.Debug ("Loading settings from " & Filepath (Lvl));
             CLIC.Config.Load.From_TOML (C      => DB_Instance,
                                         Origin => Lvl'Img,
                                         Path   => Filepath (Lvl),

--- a/src/alire/alire_early_elaboration.adb
+++ b/src/alire/alire_early_elaboration.adb
@@ -142,7 +142,8 @@ package body Alire_Early_Elaboration is
                Early_Error ("Switch " & Switch & " requires argument.");
             elsif not Adirs.Exists (Path) then
                Early_Error
-                 ("Invalid non-existing directory for --chdir: " & Path);
+                 ("switch " & Switch & ": directory """ & Path
+                  & """ does not exist.");
             elsif Adirs.Kind (Path) not in Adirs.Directory then
                Early_Error
                  ("Given --chdir path is not a directory: " & Path);

--- a/src/alire/alire_early_elaboration.adb
+++ b/src/alire/alire_early_elaboration.adb
@@ -1,5 +1,6 @@
 with AAA.Strings;
 
+with Ada.Command_Line;
 with Ada.Directories;
 
 with Alire.Features;
@@ -316,11 +317,26 @@ package body Alire_Early_Elaboration is
    end TTY_Detection;
 
 begin
+   --  Custom log level for this earliest of messages
+   if (for some I in 1 .. Ada.Command_Line.Argument_Count =>
+         Ada.Command_Line.Argument (I) = "-vv")
+     or else
+      (for some I in 1 .. Ada.Command_Line.Argument_Count =>
+         Ada.Command_Line.Argument (I) = "-v" and then
+         (for some J in 1 .. Ada.Command_Line.Argument_Count =>
+            Ada.Command_Line.Argument (J) = "-v" and then J /= I))
+   then
+      Simple_Logging.Always ("-->> Early elaboration started");
+   end if;
+
    Simple_Logging.Stdout_Level := Simple_Logging.Info;
    --  Display warnings and errors to stderr
 
    TTY_Detection;
+
    Early_Switch_Detection;
 
    r.Init; -- Register all embedded resources
+
+   Simple_Logging.Debug ("Early elaboration finished");
 end Alire_Early_Elaboration;

--- a/src/alire/alire_early_elaboration.adb
+++ b/src/alire/alire_early_elaboration.adb
@@ -22,8 +22,8 @@ package body Alire_Early_Elaboration is
    Real_Starting_Dir : constant Alire.Absolute_Path :=
      Ada.Directories.Current_Directory;
 
-   Effective_Starting_Dir : access Alire.Absolute_Path :=
-     new Alire.Absolute_Path'(Ada.Directories.Current_Directory);
+   Effective_Starting_Dir : Alire.Unbounded_Absolute_Path :=
+     Alire."+" (Ada.Directories.Current_Directory);
 
    ----------------------
    -- Get_Starting_Dir --
@@ -39,8 +39,9 @@ package body Alire_Early_Elaboration is
    -----------------------
 
    function Get_Effective_Dir return Alire.Absolute_Path is
+      use Alire;
    begin
-      return Effective_Starting_Dir.all;
+      return +Effective_Starting_Dir;
    end Get_Effective_Dir;
 
    -----------------
@@ -137,6 +138,7 @@ package body Alire_Early_Elaboration is
 
          procedure Set_Chdir_Dir (Switch, Path : String) is
             package Adirs renames Ada.Directories;
+            use Alire;
          begin
             if Path = "" then
                Early_Error ("Switch " & Switch & " requires argument.");
@@ -148,8 +150,7 @@ package body Alire_Early_Elaboration is
                Early_Error
                  ("Given --chdir path is not a directory: " & Path);
             else
-               Effective_Starting_Dir :=
-                 new Alire.Any_Path'(Adirs.Full_Name (Path));
+               Effective_Starting_Dir := +Adirs.Full_Name (Path);
                Adirs.Set_Directory (Path);
             end if;
          end Set_Chdir_Dir;

--- a/src/alire/alire_early_elaboration.ads
+++ b/src/alire/alire_early_elaboration.ads
@@ -1,5 +1,7 @@
 with Ada.Calendar;
 
+with Alire;
+
 package Alire_Early_Elaboration with Elaborate_Body is
 
    --  This body should be elaborated among the first ones.
@@ -23,5 +25,13 @@ package Alire_Early_Elaboration with Elaborate_Body is
 
    Start : constant Ada.Calendar.Time := Ada.Calendar.Clock;
    --  Out of curiosity
+
+   function Get_Starting_Dir return Alire.Absolute_Path;
+   --  The cwd from which `alr` was called, before any -C/--chdir processing
+
+   function Get_Effective_Dir return Alire.Absolute_Path;
+   --  The effective starting directory: the one set by -C/--chdir, or else
+   --  the one where `alr` was run from. This is used during the latter pro-
+   --  cessing of switches, to verify that we are at the intended location.
 
 end Alire_Early_Elaboration;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -595,11 +595,19 @@ package body Alr.Commands is
 
       procedure Check_Starting_Dir is
          use Alire.Directories.Operators;
+         package Adirs renames Ada.Directories;
+
+         ------------------------
+         -- Effective_Dir_Late --
+         ------------------------
+
          function Effective_Dir_Late return Alire.Absolute_Path
          is (if Alire.Check_Absolute_Path (Command_Line_Chdir_Target_Path.all)
-             then Command_Line_Chdir_Target_Path.all
-             else Alire_Early_Elaboration.Get_Starting_Dir
-                  / Command_Line_Chdir_Target_Path.all);
+             then Adirs.Full_Name (Command_Line_Chdir_Target_Path.all)
+             else Adirs.Full_Name (Alire_Early_Elaboration.Get_Starting_Dir
+                                   / Command_Line_Chdir_Target_Path.all));
+         --  Take full name to ensure . and .. are resolved
+
       begin
          if Command_Line_Chdir_Target_Path /= null and then
             Command_Line_Chdir_Target_Path.all /= ""

--- a/testsuite/tests/debug/logging-scopes/test.py
+++ b/testsuite/tests/debug/logging-scopes/test.py
@@ -18,11 +18,13 @@ assert_eq('Filtering mode: BLACKLIST\n'
 
 # Check empty whitelist lets nothing through
 p = run_alr('-vv', '-d+', 'dev', quiet=False)
-assert_eq('Filtering mode: WHITELIST', p.out.strip())
+assert_eq('-->> Early elaboration started\n'
+          'Filtering mode: WHITELIST', p.out.strip())
 
 # Check whitelisting
 p = run_alr('-vv', '-d+dev', 'dev', '--filter', quiet=False)
-assert_match('Filtering mode: WHITELIST\n'
+assert_match('-->> Early elaboration started\n'
+             'Filtering mode: WHITELIST\n'
              'Filtering substring: dev\n'
              '\[Alr.Commands.Dev.Execute\] \(alr-commands-dev.adb:[0-9]* \)'
              ' -->> In dev --filter',
@@ -30,14 +32,16 @@ assert_match('Filtering mode: WHITELIST\n'
 
 # Check whitelisting with exception
 p = run_alr('-vv', '-d+dev-exec', 'dev', '--filter', quiet=False)
-assert_eq('Filtering mode: WHITELIST\n'
+assert_eq('-->> Early elaboration started\n'
+          'Filtering mode: WHITELIST\n'
           'Filtering substring: dev\n'
           'Filtering exception: exec',
           p.out.strip())
 
 # Check blacklisting with exception
 p = run_alr('-vv', '-d-a+main', 'dev', quiet=False)
-assert_match('Filtering mode: BLACKLIST\n'
+assert_match('-->> Early elaboration started\n'
+             'Filtering mode: BLACKLIST\n'
              'Filtering substring: a\n'
              'Filtering exception: main\n'
              '\[Alr.Main                \] \(alr-main.adb:.*',

--- a/testsuite/tests/run/chdir-no-rebuild/test.py
+++ b/testsuite/tests/run/chdir-no-rebuild/test.py
@@ -1,0 +1,44 @@
+"""
+Verify that build/run using --chdir doesn't cause an unexpected change of
+profile (and hence a rebuild). This was issue #2015.
+"""
+
+import os
+from drivers.alr import run_alr, init_local_crate
+from drivers.asserts import assert_in_file
+
+# We will initialize a crate and build it in non-default profile (f.e. release)
+# Then we run it and observe that the profile hasn't changed
+
+TELLTALE = "Build_Profile : constant Build_Profile_Kind := release;"
+
+
+def assert_profile(prefix="xxx"):
+    """
+    Check that the profile in the configuration file is release
+    """
+    assert_in_file(os.path.join(prefix, "config", "xxx_config.ads"), TELLTALE)
+
+
+init_local_crate()
+run_alr("build", "--release")
+
+# Check the release profile in configuration
+assert_profile(prefix=".")
+
+# Pull out and run from outside
+os.chdir("..")
+run_alr("--chdir=xxx", "run")
+assert_profile()
+run_alr("-C", "xxx", "run")
+assert_profile()
+
+# As a bonus, test . and .. (the check is new in this bugfix)
+run_alr("--chdir=./xxx", "run")
+assert_profile()
+run_alr("--chdir=xxx/../xxx", "run")
+assert_profile()
+run_alr(f"--chdir={os.getcwd()}/xxx/.", "run")
+assert_profile()
+
+print("SUCCESS")

--- a/testsuite/tests/run/chdir-no-rebuild/test.yaml
+++ b/testsuite/tests/run/chdir-no-rebuild/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
Fixes #2015.

Before, the local configuration was not being properly loaded, leading to `run` from outside of the crate using the default build profile instead of the last build profile (and likely other effects where configuration could be involved).

##### PR creation checklist
- [x] A test is included, if required by the changes.
