### PR TITLE
Remove test list gpr [Don't merge]

### DIFF
--- a/src/alire/alire-properties-tests.adb
+++ b/src/alire/alire-properties-tests.adb
@@ -139,9 +139,16 @@ package body Alire.Properties.Tests is
 
             if Local.Pop (TOML_Keys.Test_Id, Val) then
                if Val.Kind /= TOML_String
-                  or else Id_Set.Contains (Val.As_String)
+                 or else Id_Set.Contains (Val.As_String)
                then
                   Local.Checked_Error ("id must be a non-empty unique string");
+               end if;
+               if (for some C of Val.As_String =>
+                     C not in 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-')
+               then
+                  Local.Checked_Error
+                    ("id must only have characters in range 'a'..'z' |"
+                     & " 'A'..'Z' | '0'..'9' | '_' | '-'.");
                end if;
                Id_Set.Insert (Val.As_String);
                Res.Id := Val.As_Unbounded_String;

--- a/src/alire/alire-properties-tests.ads
+++ b/src/alire/alire-properties-tests.ads
@@ -45,6 +45,8 @@ is
 
    function Id (S : Settings) return String;
 
+   function Short_Image (S : Settings) return String;
+
    function Default return Settings;
 
 private
@@ -58,16 +60,20 @@ private
 
    overriding
    function Image (S : Settings) return String
-   is (" test runner"
-       & (if Id (S) = "" then "" else (" '" & Id (S) & "'"))
+   is ("Test runner "
+       & S.Short_Image
+       & ", directory: "
+       & Directory (S)
+       & (if S.Runner.Kind = Alire_Runner
+          then (", jobs:" & S.Jobs'Image)
+          else ""));
+
+   function Short_Image (S : Settings) return String
+   is ((if Id (S) = "" then "<NO ID>" else "'" & Id (S) & "'")
        & ": "
        & (case S.Runner.Kind is
             when Alire_Runner => "alire",
-            when External => "`" & S.Runner.Command.Flatten & "`")
-       & ", directory: "
-       & Directory (S)
-       & (if S.Runner.Kind = Alire_Runner then (", jobs:" & S.Jobs'Image)
-          else ""));
+            when External     => "`" & S.Runner.Command.Flatten & "`"));
 
    overriding
    function To_Yaml (S : Settings) return String
@@ -75,7 +81,7 @@ private
        & Alire.Utils.YAML.YAML_Stringify
            (case S.Runner.Kind is
               when Alire_Runner => "alire",
-              when External => S.Runner.Command.Flatten)
+              when External     => S.Runner.Command.Flatten)
        & New_Line
        & "directory: "
        & Alire.Utils.YAML.YAML_Stringify (Directory (S))

--- a/src/alire/alire-test_runner.ads
+++ b/src/alire/alire-test_runner.ads
@@ -11,4 +11,10 @@ package Alire.Test_Runner is
    --  Run all .adb files in the `src` folder of the given root as
    --  separate tests. Return the number of failing tests.
 
+   procedure Show_List
+     (Root   : Roots.Root;
+      Filter : AAA.Strings.Vector := AAA.Strings.Empty_Vector);
+   --  Print a list of matching tests without running them. Respects structured
+   --  output.
+
 end Alire.Test_Runner;

--- a/src/alire/alire-toml_keys.ads
+++ b/src/alire/alire-toml_keys.ads
@@ -68,6 +68,7 @@ package Alire.TOML_Keys with Preelaborate is
    Test_Report_Reason   : constant String := "reason";
    Test_Report_Output   : constant String := "output";
    Test_Report_Duration : constant String := "duration";
+   Test_Report_Path     : constant String := "path";
    Test_Report_Summary  : constant String := "summary";
    Test_Report_Total    : constant String := "total";
    Test_Report_Failures : constant String := "failures";

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -149,29 +149,37 @@ package body Alr.Commands.Test is
          end;
       end if;
 
-      if All_Settings.Length > 1
-        and then not (Args.Is_Empty and then Cmd.Jobs = -1)
-      then
-         Trace.Warning
-           ("arguments cannot be forwarded to test runners when several "
-            & "exist.");
+      if All_Settings.Length > 1 then
+         if Cmd.List then
+            Trace.Error
+              ("The --list flag cannot be used for multiple runners. Select"
+               & " a single test runner with --id. Available runners:");
+            for E of All_Settings loop
+               Trace.Always ("- " & Settings (E).Short_Image);
+            end loop;
+            Reportaise_Command_Failed ("");
+         end if;
+         if not (Args.Is_Empty and then Cmd.Jobs = -1) then
+            Trace.Warning
+              ("arguments cannot be forwarded to test runners when multiple"
+               & " exist.");
+         end if;
       end if;
 
       if All_Settings.Length = 1
         and then Settings (All_Settings.First_Element).Runner.Kind = External
-        and then Cmd.Jobs >= 0
       then
          if Cmd.Jobs >= 0 then
             Trace.Warning
-              ("the --jobs flag is not forwarded to external commands. If you "
-               & "intended to pass it to an external test runner, put it after"
-               & " ""--"" in the command line.");
+              ("the --jobs flag is not forwarded to external commands. If you"
+               & " intended to pass it to an external test runner, put it"
+               & " after ""--"" in the command line.");
          end if;
          if Cmd.List then
             Trace.Warning
-              ("the --list flag is not forwarded to external commands. If you "
-               & "intended to pass it to an external test runner, put it after"
-               & " ""--"" in the command line.");
+              ("the --list flag is not forwarded to external commands. If you"
+               & " intended to pass it to an external test runner, put it"
+               & " after ""--"" in the command line.");
          end if;
       end if;
 
@@ -197,7 +205,7 @@ package body Alr.Commands.Test is
                    (Cmd.Root.Path / S.Directory);
             begin
                if All_Settings.Length > 1 then
-                  Alire.Put_Info ("running test with" & S.Image);
+                  Alire.Put_Info ("running test with " & S.Image);
                end if;
 
                case S.Runner.Kind is
@@ -242,7 +250,7 @@ package body Alr.Commands.Test is
                end if;
             end;
          else
-            Trace.Error ("while running" & (Settings (Test_Setting).Image));
+            Trace.Error ("while running " & (Settings (Test_Setting).Image));
             Reportaise_Command_Failed
               ("directory '"
                & (Cmd.Root.Path / Settings (Test_Setting).Directory)
@@ -263,15 +271,19 @@ package body Alr.Commands.Test is
          ("Run the test runner as defined in the manifest.")
          .Append ("")
          .Append
-            ("The builtin test runner takes an extra --jobs parameter, "
-             & "that defines the maximum number of tests to run in "
-             & "parallel.")
+            ("The built-in test runner takes an extra --jobs parameter, that"
+             & " defines the maximum number of tests to run in parallel.")
          .Append ("")
          .Append
-            ("Extra arguments are passed to the runner as-is; "
-             & "in the case of the builtin runner, a basic filtering mechanism"
-             & " only compiles and runs the tests whose names contain one of"
-             & " the arguments."));
+            ("Extra arguments are passed to the runner as-is; in the case of"
+             & " the built-in runner, a basic filtering mechanism only"
+             & " compiles and runs the tests whose names contain one of the"
+             & " arguments.")
+         .Append ("")
+         .Append
+            ("When using a built-in runner, one can pass `--list` to get"
+             & " ahead of time a list of tests (optionally matching the"
+             & " command line filter)."));
 
    --------------------
    -- Setup_Switches --

--- a/src/alr/alr-commands-test.ads
+++ b/src/alr/alr-commands-test.ads
@@ -35,9 +35,10 @@ package Alr.Commands.Test is
 private
 
    type Command is new Commands.Command with record
-      Jobs : aliased Integer := 0;
-      By_Id : aliased GNAT.Strings.String_Access;
+      Jobs   : aliased Integer := 0;
+      By_Id  : aliased GNAT.Strings.String_Access;
       Legacy : aliased Boolean := False;
+      List   : aliased Boolean := False;
    end record;
 
 end Alr.Commands.Test;

--- a/templates/crate_test/tests/crate_test_tests.gpr
+++ b/templates/crate_test/tests/crate_test_tests.gpr
@@ -1,12 +1,11 @@
 with "config/@_NAME_@_tests_config.gpr";
-with "config/@_NAME_@_tests_list_config.gpr";
 
 project @_CAPITALIZE:NAME_@_Tests is
    for Source_Dirs use ("src/**", "common/", "config/");
    for Object_Dir use "obj/" & @_CAPITALIZE:NAME_@_Tests_Config.Build_Profile;
    for Create_Missing_Dirs use "True";
    for Exec_Dir use "bin";
-   for Main use @_CAPITALIZE:NAME_@_Tests_List_Config.Test_Files;
+   for Main use ();
 
    package Compiler is
       for Default_Switches ("Ada") use


### PR DESCRIPTION
While trying #2082 I realized that to build an executable with gprbuild you can just pass the source file on the command line:
```
# gprbuild main.adb
```
So I did a quick check and it turns out you can do this even if main.adb is not listed in `for Main use ();` in the GPR file.

Using this feature, we can get rid of the system that produces a GPR file with the list of tests to build.

Advantages:

- Less code
- The test crate is "buildable" right away (see below). No need to run Alire to create the missing GPR file
- The less GPR files there are, the happier I am ^^
 
Drawbacks:

- Building the tests crate without passing args will not build any executable...

So it's not clear whether or not this a positive change. I just wanted to record this option.

Ping @AldanTanneo 