### PR TITLE
fix: regenerate config before cleaning

### DIFF
--- a/src/alr/alr-commands-clean.adb
+++ b/src/alr/alr-commands-clean.adb
@@ -1,5 +1,6 @@
 with Ada.Directories;
 
+with Alire.Builds;
 with Alire.Settings.Edit;
 with Alire.Directories;
 with Alire.Paths;
@@ -124,6 +125,15 @@ package body Alr.Commands.Clean is
       if not (Cmd.Cache or else Cmd.Temp) then
          Cmd.Requires_Workspace;
          Cmd.Root.Export_Build_Environment;
+
+         --  We also want to leave the workspace ready to edit, so generate the
+         --  configuratin that would be used by an `alr build`.
+
+         if not Cmd.Root.Build (Args, Stop_After => Alire.Builds.Generation)
+         then
+            Trace.Warning
+              ("Failed to generate build configuration, cleaning anyway...");
+         end if;
 
          Trace.Detail ("Cleaning project and dependencies...");
 

--- a/src/alr/alr-commands-clean.adb
+++ b/src/alr/alr-commands-clean.adb
@@ -127,7 +127,7 @@ package body Alr.Commands.Clean is
          Cmd.Root.Export_Build_Environment;
 
          --  We also want to leave the workspace ready to edit, so generate the
-         --  configuratin that would be used by an `alr build`.
+         --  configuration that would be used by an `alr build`.
 
          if not Cmd.Root.Build (Args, Stop_After => Alire.Builds.Generation)
          then

--- a/src/alr/alr-commands-clean.adb
+++ b/src/alr/alr-commands-clean.adb
@@ -129,7 +129,9 @@ package body Alr.Commands.Clean is
          --  We also want to leave the workspace ready to edit, so generate the
          --  configuration that would be used by an `alr build`.
 
-         if not Cmd.Root.Build (Args, Stop_After => Alire.Builds.Generation)
+         if not Cmd.Root.Build
+           (AAA.Strings.Empty_Vector,
+            Stop_After => Alire.Builds.Generation)
          then
             Trace.Warning
               ("Failed to generate build configuration, cleaning anyway...");

--- a/testsuite/tests/clean/regen-config/test.py
+++ b/testsuite/tests/clean/regen-config/test.py
@@ -1,0 +1,29 @@
+"""
+Verify that `alr clean` succeeds even when the config dir has been removed
+before the clean. The config dir should be regenerated as part of the clean.
+"""
+
+import os
+import shutil
+
+from drivers.alr import init_local_crate, run_alr
+from drivers.asserts import assert_file_exists
+
+init_local_crate()
+
+# Build the crate so the config dir is generated
+run_alr("build")
+
+assert_file_exists("config")
+
+# Remove the config dir to simulate the situation where it was deleted
+shutil.rmtree("config")
+assert_file_exists("config", wanted=False)
+
+# alr clean should regenerate the config dir and succeed
+run_alr("clean")
+
+# The config dir should have been recreated
+assert_file_exists("config")
+
+print('SUCCESS')

--- a/testsuite/tests/clean/regen-config/test.py
+++ b/testsuite/tests/clean/regen-config/test.py
@@ -11,19 +11,21 @@ from drivers.asserts import assert_file_exists
 
 init_local_crate()
 
+config_gpr = os.path.join("config", "xxx_config.gpr")
+
 # Build the crate so the config dir is generated
 run_alr("build")
 
-assert_file_exists("config")
+assert_file_exists(config_gpr)
 
 # Remove the config dir to simulate the situation where it was deleted
 shutil.rmtree("config")
-assert_file_exists("config", wanted=False)
+assert_file_exists(config_gpr, wanted=False)
 
 # alr clean should regenerate the config dir and succeed
 run_alr("clean")
 
 # The config dir should have been recreated
-assert_file_exists("config")
+assert_file_exists(config_gpr)
 
 print('SUCCESS')

--- a/testsuite/tests/clean/regen-config/test.yaml
+++ b/testsuite/tests/clean/regen-config/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
As described in #2018, it can be convenient and more intuitive to have `alr clean` leave the workspace ready for edition (that is, with all project files generated). Incidentally, if there are missing project files, `alr clean` would fail as the call to `gprclean` will fail to find all required projects.

Closes #2018.

##### PR creation checklist
- [x] A test is included, if required by the changes.
