### PR TITLE
feat: indicate solver timeouts in non-interactive mode

### DIFF
--- a/src/alire/alire-install.adb
+++ b/src/alire/alire-install.adb
@@ -188,13 +188,21 @@ package body Alire.Install is
          --  Look for a regular solution to a dependency as fallback if we
          --  didn't find any binary solution.
          procedure Compute_Regular (Dep : Dependencies.Dependency) is
-            Sol : constant Solutions.Solution := Solver.Resolve (Dep).Solution;
+            Solver_Result : constant Solver.Result := Solver.Resolve (Dep);
+            Sol : constant Solutions.Solution := Solver_Result.Solution;
          begin
             if Sol.Is_Complete then
                Result.Insert (Dep.Crate, Sol);
             else
-               Trace.Error ("Could not find a complete solution for "
-                            & Dep.TTY_Image);
+               if Solver_Result.Timed_Out then
+                  Trace.Error
+                    ("Timed out before finding a complete solution for "
+                     & Dep.TTY_Image);
+               else
+                  Trace.Error
+                    ("Could not find a complete solution for "
+                     & Dep.TTY_Image);
+               end if;
 
                --  If we found a release for the root dependency we can print
                --  the partial solution. Otherwise nothing was solved.

--- a/src/alire/alire-roots-editable.adb
+++ b/src/alire/alire-roots-editable.adb
@@ -46,6 +46,8 @@ package body Alire.Roots.Editable is
                          .Dependencies (Original.Environment),
                          Latter => Release (Edited)
                          .Dependencies (Edited.Environment));
+
+         Solver_Result : Solver.Result;
       begin
 
          --  First show requested changes
@@ -58,13 +60,15 @@ package body Alire.Roots.Editable is
 
          --  Compute the new solution
 
-         Edited.Set (Solution => Edited.Compute_Update);
+         Solver_Result := Edited.Compute_Update;
+         Edited.Set (Solution => Solver_Result.Solution);
 
          --  Then show the effects on the solution
 
          if Alire.Utils.User_Input.Confirm_Solution_Changes
            (Original.Solution.Changes (Edited.Solution),
-            Changed_Only => not Alire.Detailed)
+            Changed_Only => not Alire.Detailed,
+            Timed_Out    => Solver_Result.Timed_Out)
          then
             Edited.Commit;
             Edited.Deploy_Dependencies;

--- a/src/alire/alire-roots-editable.ads
+++ b/src/alire/alire-roots-editable.ads
@@ -56,7 +56,7 @@ package Alire.Roots.Editable is
    procedure Add_Dependency (This          : in out Root;
                              Dep           : Dependencies.Dependency;
                              Allow_Unknown : Boolean := Alire.Force);
-   --  Add a dependency, or raise Checked_Error is Dep is already among direct
+   --  Add a dependency, or raise Checked_Error if Dep is already among direct
    --  dependencies. Recoverable error if Dep is unknown, unless Allow_Unknown.
 
    procedure Remove_Dependency (This  : in out Root;

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -1915,7 +1915,7 @@ package body Alire.Roots is
         Containers.Crate_Name_Sets.Empty_Set;
       Options     : Solver.Query_Options :=
         Solver.Default_Options)
-      return Solutions.Solution
+      return Solver.Result
    is
       use type Conditional.Dependencies;
 
@@ -1945,7 +1945,7 @@ package body Alire.Roots is
         (Deps    => Deps,
          Props   => This.Environment,
          Pins    => This.Pins,
-         Options => Options).Solution;
+         Options => Options);
    end Compute_Update;
 
    -------------------------
@@ -1988,19 +1988,25 @@ package body Alire.Roots is
       end loop;
 
       declare
-         Needed : constant Solutions.Solution   := This.Compute_Update
+         Computed_Update : constant Solver.Result        := This.Compute_Update
            (Allowed, Options);
-         Diff   : constant Solutions.Diffs.Diff := Old.Changes (Needed);
+         Diff            : constant Solutions.Diffs.Diff := Old.Changes
+           (Computed_Update.Solution);
       begin
          --  Early exit when there are no changes
 
          if not Alire.Force and then not Diff.Contains_Changes then
-            if not Needed.Is_Complete then
-               Trace.Warning
-                 ("There are missing dependencies"
-                  & " (use `alr with --solve` for details).");
+            if not Computed_Update.Solution.Is_Complete then
+               if Computed_Update.Timed_Out then
+                  Trace.Warning
+                    ("Dependency resolution timed out with missing "
+                     & "dependencies (use `alr with --solve` for details).");
+               else
+                  Trace.Warning
+                    ("There are missing dependencies"
+                     & " (use `alr with --solve` for details).");
+               end if;
             end if;
-
             This.Sync_Manifest_And_Lockfile_Timestamps;
             --  In case manual changes in manifest do not modify the
             --  solution.
@@ -2022,9 +2028,13 @@ package body Alire.Roots is
                      Trace.Log
                        ("Dependencies automatically updated as follows:",
                         Level);
-                     Diff.Print (Level => Level);
+                     Diff.Print
+                       (Level     => Level,
+                        Timed_Out => Computed_Update.Timed_Out);
                   end;
-               elsif not Utils.User_Input.Confirm_Solution_Changes (Diff) then
+               elsif not Utils.User_Input.Confirm_Solution_Changes
+                           (Diff, Timed_Out => Computed_Update.Timed_Out)
+               then
                   Trace.Detail ("Update abandoned.");
                   return;
                end if;
@@ -2038,7 +2048,7 @@ package body Alire.Roots is
          --  detected, as pin evaluation may have temporarily stored
          --  unsolved dependencies which have been re-solved now.
 
-         This.Set (Solution => Needed);
+         This.Set (Solution => Computed_Update.Solution);
          This.Deploy_Dependencies;
 
          Trace.Detail ("Update completed");

--- a/src/alire/alire-roots.ads
+++ b/src/alire/alire-roots.ads
@@ -447,7 +447,7 @@ private
       Allowed     : Containers.Crate_Name_Sets.Set :=
         Containers.Crate_Name_Sets.Empty_Set;
       Options     : Solver.Query_Options := Solver.Default_Options)
-      return Solutions.Solution;
+      return Solver.Result;
    --  Compute a new solution for the workspace. If Allowed is not empty,
    --  crates not appearing in Allowed are held back at their current version.
    --  This function loads configured indexes from disk. No changes are applied

--- a/src/alire/alire-solutions-diffs.adb
+++ b/src/alire/alire-solutions-diffs.adb
@@ -416,7 +416,8 @@ package body Alire.Solutions.Diffs is
    procedure Print (This         : Diff;
                     Changed_Only : Boolean      := not Alire.Detailed;
                     Prefix       : String       := "   ";
-                    Level        : Trace.Levels := Trace.Info)
+                    Level        : Trace.Levels := Trace.Info;
+                    Timed_Out    : Boolean      := False)
    is
       Table : Utils.Tables.Table;
       Changed    : Boolean := False;
@@ -491,7 +492,10 @@ package body Alire.Solutions.Diffs is
       Trace.Log ("", Level);
 
       if not This.Latter.Is_Complete then
-         Trace.Log (Prefix & "New solution is " & TTY.Warn ("incomplete."),
+         Trace.Log (Prefix
+                    & "New solution is "
+                    & TTY.Warn ("incomplete")
+                    & (if Timed_Out then " (timed out)." else "."),
                     Level);
       elsif This.Latter.Is_Complete and then not This.Former.Is_Complete then
          Trace.Log (Prefix & "New solution is " & TTY.OK ("complete."),

--- a/src/alire/alire-solutions-diffs.ads
+++ b/src/alire/alire-solutions-diffs.ads
@@ -15,9 +15,13 @@ package Alire.Solutions.Diffs is
    procedure Print (This         : Diff;
                     Changed_Only : Boolean      := not Alire.Detailed;
                     Prefix       : String       := "   ";
-                    Level        : Trace.Levels := Trace.Info);
+                    Level        : Trace.Levels := Trace.Info;
+                    Timed_Out    : Boolean      := False);
    --  Print a summary of changes between two solutions. Prefix is prepended to
    --  every line.
+   --
+   --  If `Timed_Out` is `True`, the warning for an incomplete solution
+   --  indicates that a timeout occurred.
 
 private
 

--- a/src/alire/alire-utils-user_input.adb
+++ b/src/alire/alire-utils-user_input.adb
@@ -37,7 +37,8 @@ package body Alire.Utils.User_Input is
    function Confirm_Solution_Changes
      (Changes        : Alire.Solutions.Diffs.Diff;
       Changed_Only   : Boolean            := not Alire.Detailed;
-      Level          : Alire.Trace.Levels := Info)
+      Level          : Alire.Trace.Levels := Info;
+      Timed_Out      : Boolean            := False)
       return Boolean
    is
       package UI renames CLIC.User_Input;
@@ -46,7 +47,7 @@ package body Alire.Utils.User_Input is
 
       if Changes.Contains_Changes then
          Trace.Log ("Changes to dependency solution:", Level);
-         Changes.Print (Changed_Only => Changed_Only);
+         Changes.Print (Changed_Only => Changed_Only, Timed_Out => Timed_Out);
 
          Trace.Log ("", Level);
 

--- a/src/alire/alire-utils-user_input.ads
+++ b/src/alire/alire-utils-user_input.ads
@@ -10,11 +10,15 @@ package Alire.Utils.User_Input is
    function Confirm_Solution_Changes
      (Changes        : Solutions.Diffs.Diff;
       Changed_Only   : Boolean            := not Alire.Detailed;
-      Level          : Alire.Trace.Levels := Info)
+      Level          : Alire.Trace.Levels := Info;
+      Timed_Out      : Boolean            := False)
       return Boolean;
    --  Present a summary of changes and ask the user for confirmation. Returns
    --  True when the user answers positively. Defaults to Yes when the new
    --  solution is complete, or when Alire.Force.
+   --
+   --  If `Timed_Out` is `True`, the warning for an incomplete solution
+   --  indicates that a timeout occurred.
 
    function Approve_Dir (Dir   : Any_Path;
                          Force : Boolean := Alire.Force)

--- a/src/alr/alr-commands-get.adb
+++ b/src/alr/alr-commands-get.adb
@@ -36,14 +36,15 @@ package body Alr.Commands.Get is
       --  resolve the release as part of the dependencies at this point so if
       --  the latest release is not solvable we get another one that is. We
       --  should warn in that case that newer releases exist.
-      Rel      : constant Alire.Index.Release :=
-                   Query.Find (Name, Versions, Query_Policy);
+      Rel              : constant Alire.Index.Release :=
+                           Query.Find (Name, Versions, Query_Policy);
 
-      Diff     : Alire.Solutions.Diffs.Diff;
+      Diff             : Alire.Solutions.Diffs.Diff;
       --  Used to present dependencies to the user
 
-      Build_OK : Boolean := False;
-      Solution : Alire.Solutions.Solution;
+      Build_OK         : Boolean := False;
+      Solver_Timed_out : Boolean := False;
+      Solution         : Alire.Solutions.Solution;
 
       use all type Alire.Origins.Kinds;
    begin
@@ -94,19 +95,28 @@ package body Alr.Commands.Get is
       if not Cmd.Only then
          declare
             use CLIC.User_Input;
+            Solver_Result : constant Query.Result :=
+              Query.Resolve
+                (Rel.Dependencies (Platform.Properties),
+                 Platform.Properties,
+                 Alire.Solutions.Empty_Valid_Solution);
          begin
-            Solution := Query.Resolve
-              (Rel.Dependencies (Platform.Properties),
-               Platform.Properties,
-               Alire.Solutions.Empty_Valid_Solution).Solution;
+            Solver_Timed_out := Solver_Result.Timed_Out;
+            Solution := Solver_Result.Solution;
             Diff := Alire.Solutions.Empty_Valid_Solution.Changes (Solution);
 
             if not Solution.Is_Complete then
                Diff.Print (Changed_Only => False,
-                           Level        => Warning);
+                           Level        => Warning,
+                           Timed_Out    => Solver_Timed_out);
                Trace.Warning ("");
-               Trace.Warning ("Could not find a complete solution for "
-                              & Rel.Milestone.TTY_Image);
+               if Solver_Timed_out then
+                  Trace.Warning ("Timed out before finding a complete "
+                                 & "solution for " & Rel.Milestone.TTY_Image);
+               else
+                  Trace.Warning ("Could not find a complete solution for "
+                                 & Rel.Milestone.TTY_Image);
+               end if;
 
                if CLIC.User_Input.Query
                  (Question =>
@@ -237,7 +247,7 @@ package body Alr.Commands.Get is
 
       if Diff.Contains_Changes then
          Trace.Info ("Dependencies were solved as follows:");
-         Diff.Print (Changed_Only => False);
+         Diff.Print (Changed_Only => False, Timed_Out => Solver_Timed_out);
       else
          Trace.Info ("There are no dependencies.");
       end if;

--- a/src/alr/alr-commands-search.adb
+++ b/src/alr/alr-commands-search.adb
@@ -357,7 +357,7 @@ package body Alr.Commands.Search is
       .Append ("S: the release is available through a system package.")
       .Append ("U: the release is not available in the current platform.")
       .Append ("?: the release has dependencies but solving was skipped "
-               & "(see --solve).")
+               & "(see --solve) or timed out.")
       .Append ("X: the release has dependencies that cannot be resolved.")
       .New_Line
       .Append ("The reasons for unavailability (U) can be ascertained with"

--- a/src/alr/alr-commands-show.adb
+++ b/src/alr/alr-commands-show.adb
@@ -104,15 +104,15 @@ package body Alr.Commands.Show is
 
          if Cmd.Graph or else Cmd.Solve or else Cmd.Tree then
             declare
-               Needed : constant Query.Solution :=
-                          (if Current
-                           then Cmd.Root.Solution
-                           else Query.Resolve
-                             (Rel.Dependencies (Platform.Properties),
-                              Platform.Properties,
-                              Alire.Solutions.Empty_Valid_Solution,
-                              Options => (Age    => Query_Policy,
-                                          others => <>)).Solution);
+               Solver_Result : constant Query.Result :=
+                 (if Current
+                  then (Solution => Cmd.Root.Solution, Timed_Out => False)
+                  else Query.Resolve
+                    (Rel.Dependencies (Platform.Properties),
+                     Platform.Properties,
+                     Alire.Solutions.Empty_Valid_Solution,
+                     Options => (Age => Query_Policy, others => <>)));
+               Needed : constant Query.Solution := Solver_Result.Solution;
             begin
                if Cmd.Solve then
                   Needed.Print (Rel,
@@ -135,7 +135,11 @@ package body Alr.Commands.Show is
                end if;
 
                if not Needed.Is_Complete then
-                  Put_Line ("Dependencies cannot be met");
+                  if Solver_Result.Timed_Out then
+                     Trace.Warning ("Dependency resolution timed out");
+                  else
+                     Trace.Warning ("Dependencies cannot be met");
+                  end if;
                end if;
             end;
          end if;

--- a/testsuite/tests/show/solve-local/test.py
+++ b/testsuite/tests/show/solve-local/test.py
@@ -2,7 +2,7 @@
 Test that the dependencies in a local crate are properly solved
 """
 
-import os.path
+import os
 import re
 
 from drivers.alr import run_alr
@@ -25,6 +25,24 @@ assert_match('.*\n'
              '   libhello=1\.0\.0\n'
              '.*\n',
              p.out, flags=re.S)
+
+# Add a non-existent dependency
+
+run_alr('with', 'unobtanium', force=True)
+
+# Verify that it is properly shown as unsolvable
+
+p = run_alr('show', '--solve', quiet=False)
+assert_match(r'.*\n'
+             r'Dependencies \(solution\):\n'
+             r'   libhello=1\.0\.0\n'
+             r'Dependencies \(missing\):\n'
+             r'   unobtanium\* \(direct,missed:unknown\)\n'
+             r'Dependencies \(graph\):\n'
+             r'   xxx=0\.1\.0-dev --> libhello=1\.0\.0 \(\^1\.0\.0\)\n'
+             r'   xxx=0\.1\.0-dev --> unobtanium\*\n'
+             r'Warning: Dependencies cannot be met\n',
+             p.out)
 
 
 print('SUCCESS')

--- a/testsuite/tests/solver/timeout/test.py
+++ b/testsuite/tests/solver/timeout/test.py
@@ -4,9 +4,22 @@ Test solver timeout behaviors
 
 import re
 from drivers.alr import alr_settings_set, alr_with, init_local_crate, run_alr, run_alr_interactive
-from drivers.asserts import assert_not_substring, assert_substring
+from drivers.asserts import assert_not_substring, assert_substring, assert_match
 
 TELLTALE = "SOLVER: search timeout"
+"""The debug message issued when the solver times out."""
+DIFF_SUMMARY_MSG = "New solution is incomplete (timed out)."
+"""The summary heading for solution diffs when incomplete due to timeout."""
+SHOW_WARNING = "Warning: Dependency resolution timed out"
+"""The warning issued by `alr show` when incomplete due to timeout."""
+UPDATE_NO_CHANGES_WARNING = (
+    "Warning: Dependency resolution timed out with missing dependencies "
+    "(use `alr with --solve` for details).\nNothing to update."
+)
+"""
+The warning `alr update` issues when the solution is incomplete due to a timeout
+but there is no diff to confirm.
+"""
 
 # Configure solver for immediate timeouts
 alr_settings_set("solver.timeout", "0")
@@ -15,45 +28,106 @@ alr_settings_set("solver.grace_period", "0")
 # Configure solver to never find a solution in order to force timeouts
 alr_settings_set("solver.never_finish", "true")
 
-# First, check a regular timeout does happen for non-interactive execution,
-# which completes as expected.
-assert_substring(TELLTALE,
-                 run_alr("-vv", "show", "--solve", "hello", quiet=False).out)
+# First, check a regular timeout does happen for non-interactive execution of
+# `alr show --solve`, with an appropriate warning and a zero exit code.
+assert_substring(TELLTALE, run_alr("-vv", "show", "--solve", "hello", quiet=False).out)
+assert_substring(SHOW_WARNING, run_alr("show", "--solve", "hello", quiet=False).out)
+
+# Check that `alr get` and `alr install` time out with a non-zero exit code.
+for subcmd in ("get", "install"):
+    p_verbose = run_alr("-vv", subcmd, "hello", quiet=False, complain_on_error=False)
+    assert_substring(TELLTALE, p_verbose.out)
+    p = run_alr(subcmd, "hello", quiet=False, complain_on_error=False)
+    assert_substring("Timed out before finding a complete solution for hello", p.out)
+    if subcmd == "get":
+        assert_substring(DIFF_SUMMARY_MSG, p.out)
 
 # Check that plain `search` never asks, as no solving is happening
-assert_not_substring(TELLTALE,
-                     run_alr("-vv", "search", "hello", quiet=False).out)
+assert_not_substring(TELLTALE, run_alr("-vv", "search", "hello", quiet=False).out)
 
 # Check that `search --solve` does not ask even in interactive mode, as it does
 # a best-effort solving. If there were unexpected interactivity, we would get a
 # RuntimeError here. Still, there is an internal solver timeout that we forced.
-assert_substring(\
-    TELLTALE,
-    run_alr_interactive(["-vv", "search", "hello", "--solve"], [], []))
+search_output = run_alr_interactive(["-vv", "search", "hello", "--solve"], [], [])
+assert_substring(TELLTALE, search_output)
+# The crate's status should be `?`.
+assert_match(r".*\nhello\s+\?\s+1\.0\.1", search_output)
 
-# Check other commands that should have interactive timeouts. Enter a crate
-# beforehand to take advantage of commands that require one.
-
+# Enter a new crate to test commands that require one.
 init_local_crate()
-alr_with("hello")
 
-SOLVER_ASKS=re.compile(".*" + \
-                       re.escape("[Y] Yes  [N] No  [A] Always  (default is Yes)") + \
-                       "\s*$")
-WITH_ASKS=re.compile(".*" + \
-                       re.escape("[Y] Yes  [N] No  (default is No)") + \
-                       "\s*$")
+# Check that the timeout is noted in the diff print for non-interactive `with`,
+# `pin`, and `update`, with confirmation defaulting to No and no changes applied.
+assert_substring(DIFF_SUMMARY_MSG, run_alr("with", "hello", quiet=False).out)
+alr_with("hello", manual=True, update=False)
+assert_substring(DIFF_SUMMARY_MSG, run_alr("with", quiet=False).out)
+assert_substring(DIFF_SUMMARY_MSG, run_alr("pin", "hello=1.0.0", quiet=False).out)
+assert_substring(UPDATE_NO_CHANGES_WARNING, run_alr("update", quiet=False).out)
 
-for cmd, output, input in\
-      [(["show", "--solve", "hello"], [SOLVER_ASKS], ["n"]),                   # Exit on 1st timeout
-       (["show", "--solve", "hello"], [SOLVER_ASKS, SOLVER_ASKS], ["y", "n"]), # Exit on 2nd timeout
-       (["show", "--tree", "hello"],  [SOLVER_ASKS], ["n"]),
-       (["update"],                   [SOLVER_ASKS], ["n"]),
-       (["with", "libhello"],         [SOLVER_ASKS, WITH_ASKS], ["n", "n"])
-       # First question is the solver asking for more time to find a solution, 
-       # second is the user being asked to accept an incomplete solution.
-      ]:
-    run_alr_interactive(cmd, output, input)
-                     
+
+# Test interactive timeout prompts.
+
+SHOW_WARNING_RE = ".*" + re.escape(SHOW_WARNING)
+
+SOLVER_ASKS = ".*" + re.escape("[Y] Yes  [N] No  [A] Always  (default is Yes)") + r"\s*$"
+SOLVER_ASKS_INCOMPLETE = (
+    ".*" + re.escape("Warning: Complete solution not found after 0 seconds.") + SOLVER_ASKS
+)
+SOLVER_ASKS_INEXHAUSTIVE = (
+    ".*" + re.escape("Warning: Solution space not fully explored after 0 seconds.") + SOLVER_ASKS
+)
+
+CONFIRM_DIFF = r".*\[Y\] Yes  \[N\] No  \(default is {default}\)\s*$"
+CONFIRM_DIFF_INCOMPLETE = (
+    ".*" + re.escape(DIFF_SUMMARY_MSG) + CONFIRM_DIFF.format(default="No")
+)
+CONFIRM_DIFF_COMPLETE = (
+    ".*" + re.escape("New solution is complete.") + CONFIRM_DIFF.format(default="Yes")
+)
+
+for cmd, output, input in [
+    # `show` with exit on 1st timeout: only trivial solution found, so warns
+    # it's incomplete
+    (["show", "--solve", "hello"], [SOLVER_ASKS_INCOMPLETE, SHOW_WARNING_RE], ["n"]),
+    (["show", "--tree", "hello"], [SOLVER_ASKS_INCOMPLETE, SHOW_WARNING_RE], ["n"]),
+    # `show` with exit on 2nd timeout: complete (albeit not exhaustive) solution
+    # found, so no warning
+    (
+        ["show", "--solve", "hello"],
+        [SOLVER_ASKS_INCOMPLETE, SOLVER_ASKS_INEXHAUSTIVE, rf"(?!{SHOW_WARNING_RE})"],
+        ["y", "n"],
+    ),
+    # `update` with exit on 1st timeout: only trivial solution found, so no
+    # changes to confirm
+    (["update"], [SOLVER_ASKS_INCOMPLETE, ".*" + re.escape(UPDATE_NO_CHANGES_WARNING)], ["n"]),
+    # `update` with exit on 2nd timeout: solved for `hello` but not `libhello`,
+    # so asks for confirmation of incomplete solution
+    (
+        ["update"],
+        [SOLVER_ASKS_INCOMPLETE] * 2 + [CONFIRM_DIFF_INCOMPLETE],
+        ["y", "n", "n"],
+    ),
+    # `update` with exit on 3rd timeout: complete (albeit not exhaustive), so
+    # changes confirmation defaults to yes
+    (
+        ["update"],
+        [SOLVER_ASKS_INCOMPLETE] * 2 + [SOLVER_ASKS_INEXHAUSTIVE, CONFIRM_DIFF_COMPLETE],
+        ["y", "y", "n", "n"],
+    ),
+    # `with` with exit on 1st timeout: only trivial solution found, so asks for
+    # confirmation of incomplete solution
+    (["with", "libhello"], [SOLVER_ASKS_INCOMPLETE, CONFIRM_DIFF_INCOMPLETE], ["n", "n"]),
+    # `with` with exit on 3rd timeout: complete (albeit not exhaustive), so
+    # changes confirmation defaults to yes
+    (
+        ["with", "libhello"],
+        [SOLVER_ASKS_INCOMPLETE] * 2 + [SOLVER_ASKS_INEXHAUSTIVE, CONFIRM_DIFF_COMPLETE],
+        ["y", "y", "n", "n"],
+    ),
+]:
+    tail = run_alr_interactive(cmd, output, input)
+    if len(output) > len(input):
+        assert_match(output[len(input)], tail)
+
 
 print("SUCCESS")

--- a/testsuite/tests/update/missing-deps/test.py
+++ b/testsuite/tests/update/missing-deps/test.py
@@ -7,8 +7,7 @@ import re
 import os
 
 from drivers.alr import run_alr, alr_pin
-from drivers.asserts import assert_match
-from glob import glob
+from drivers.asserts import assert_match, assert_substring
 
 
 # Add a dependency and force it missing by pinning it to non-existing version
@@ -17,8 +16,12 @@ os.chdir('xxx')
 run_alr('with', 'libhello')
 alr_pin('libhello', version="3")
 
-# See that updating succeeds
-run_alr('update')
+# See that updating succeeds, with an appropriate warning
+p = run_alr('update', quiet=False)
+assert_substring(
+    'Warning: There are missing dependencies (use `alr with --solve` for details).',
+    p.out
+)
 
 # Check that the solution is still the expected one, and also that the original
 # dependency is included in the restrictions

--- a/testsuite/tests/with/changes-info/test.py
+++ b/testsuite/tests/with/changes-info/test.py
@@ -5,7 +5,7 @@ Check summary of changes shown to the user when modifying dependencies
 import os
 import re
 
-from drivers.alr import run_alr
+from drivers.alr import alr_with, run_alr
 from drivers.asserts import assert_match
 
 # Initialize a workspace for the test
@@ -51,6 +51,23 @@ assert_match(".*Cannot add crate 'unobtanium' not found in index",
              p.out)
 
 ###############################################################################
+# Check adding a missing crate manually, then running `alr with` without args
+alr_with("unobtanium", update=False, manual=True)
+p = run_alr('with', quiet=False)
+assert_match(".*" +
+             re.escape("""\
+Dependencies automatically updated as follows:
+
+   New solution is incomplete.
+   Missing:
+   +!       unobtanium * (new,missing:unknown)\
+""") + ".*",
+             p.out, flags=re.S)
+
+# Remove the missing crate for following tests
+run_alr("with", "--del", "unobtanium")
+
+###############################################################################
 # Check adding a pinned dir (the dir must exist)
 os.mkdir("local_crate")
 p = run_alr('with', 'local_crate', '--use=local_crate', quiet=False)
@@ -80,6 +97,19 @@ assert_match(".*" +
              re.escape("""Changes to dependency solution:
 
    o libhello 2.0.0 (unpinned)""") + ".*",
+             p.out, flags=re.S)
+
+###############################################################################
+# Pinning a crate to a non-existent version
+p = run_alr('pin', 'libhello=2.999.0', quiet=False)
+assert_match(".*" +
+             re.escape("""\
+Changes to dependency solution:
+
+   New solution is incomplete.
+   Missing:
+   .!       libhello (=2.999.0) & (^2.0.0) (pin=2.999.0,missing:unavailable)\
+""") + ".*",
              p.out, flags=re.S)
 
 ###############################################################################


### PR DESCRIPTION
Closes #2057

Ensures any assertions of incompleteness are qualified with some indication that the solver timed out, even in non-interactive mode.

Simply adding a warning [here](https://github.com/alire-project/alire/blob/c64c53d5e7420e3a322a12e5fc63fd598a22a390/src/alire/alire-solver.adb#L2057) didn't seem acceptable because it would interrupt the flow of commands like `alr search --solve` and `alr show --solve`.

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
