### PR TITLE
doc: document command quoting and cache relocation

### DIFF
--- a/doc/private-crates.md
+++ b/doc/private-crates.md
@@ -153,7 +153,8 @@ single-quotes.
 If you wish to use a `.wgetrc` configuration file instead, the equivalent `wget`
 command is `'wget ${URL} -q -O ${DEST}'`.
 
-This setting only accepts a simple space-separated command, with no scripting
-functionality. If this is not sufficient, you can write more complex logic (or
-commands with arguments containing spaces) to a separate script, for instance
-by setting the value to `'python /path/to/my_script.py ${URL} ${DEST}'`.
+This setting only accepts a simple command (using POSIX-style quoting rules),
+with no environment variable or command substitution performed, and no scripting
+functionality. If this is not sufficient, you can write more complex logic to a
+separate script, for instance by setting the value to
+`'python /path/to/my_script.py ${URL} ${DEST}'`.

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -69,8 +69,12 @@ including their default values and a short explanation of their effects.
 
 By default, `alr` stores its global settings at `<user home>/.config/alire`.
 You can use any other location by setting in the environment the variable
-`ALIRE_SETTINGS_DIR=</absolute/path/to/settings/folder>`, or by using the global `-s`
-switch: `alr -s </path/to/settings> <command>`.
+`ALIRE_SETTINGS_DIR=</absolute/path/to/settings/folder>`, or by using the global
+`-s` (or `--settings`) switch: `alr -s </path/to/settings> <command>`.
+
+This also relocates the global cache directory (where shared dependencies are
+cached and built) unless the `cache.dir` setting is explicitly set, and with it
+the toolchain directory unless `toolchain.dir` is explicitly set.
 
 Using pristine default settings can be useful to isolate the source of errors
 by ensuring that a misconfiguration is not at play.

--- a/src/alire/alire-settings-builtins.ads
+++ b/src/alire/alire-settings-builtins.ads
@@ -15,7 +15,8 @@ package Alire.Settings.Builtins is
       Kind => Stn_Absolute_Path,
       Def  => "",
       Help =>
-        "Directory where Alire will store its cache.");
+        "Directory where Alire will store its cache, and its toolchains "
+      & "unless 'toolchain.dir' is also set.");
 
    --  DEPENDENCIES
 

--- a/src/alire/alire-settings-builtins.ads
+++ b/src/alire/alire-settings-builtins.ads
@@ -62,8 +62,8 @@ package Alire.Settings.Builtins is
       Global_Only => True,
       Help        =>
         "Editor command and arguments for editing crate code (alr edit)." &
-        " The executables and arguments are separated by a single space" &
-        " character. The token ${GPR_FILE} is replaced by" &
+        " The executable and arguments are split according to POSIX-style" &
+        " quoting rules. The token ${GPR_FILE} is replaced by" &
         " a path to the project file to open.");
 
    --  INDEX
@@ -131,9 +131,9 @@ package Alire.Settings.Builtins is
       Global_Only => True,
       Help        =>
         "The command used to download crates which are published as archives."
-      & " The executables and arguments are separated by a single space"
-      & " character. The token ${DEST} is replaced by the destination path,"
-      & " and ${URL} by the URL to download.");
+      & " The executable and arguments are split according to POSIX-style"
+      & " quoting rules. The token ${DEST} is replaced by the destination"
+      & " path, and ${URL} by the URL to download.");
 
    Origins_Git_Trusted_Sites : constant Builtin := New_Builtin
      (Key         => "origins.git.trusted_sites",

--- a/src/alr/alr-commands-run.adb
+++ b/src/alr/alr-commands-run.adb
@@ -260,7 +260,8 @@ package body Alr.Commands.Run is
         (Config,
          Cmd.Args'Access,
          "-a:", "--args=",
-         "Arguments to pass through (quote them if more than one)",
+         "A single string of arguments to pass through to the executable;"
+         & " split according to POSIX-style quoting rules",
          Argument => "ARGS");
 
       Define_Switch

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -193,7 +193,9 @@ package body Alr.Commands is
       Define_Switch (Config,
                      Command_Line_Config_Path'Access,
                      "-s=", "--settings=",
-                     "Override settings folder location",
+                     "Override settings folder location (and that of the"
+                     & " cache, unless the 'cache.dir' setting is explicitly"
+                     & " set)",
                      Argument => "DIR");
 
       Define_Switch (Config,

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -194,7 +194,7 @@ package body Alr.Commands is
                      Command_Line_Config_Path'Access,
                      "-s=", "--settings=",
                      "Override settings folder location (and that of the"
-                     & " cache, unless the 'cache.dir' setting is explicitly"
+                     & " cache, unless the `cache.dir` setting is explicitly"
                      & " set)",
                      Argument => "DIR");
 


### PR DESCRIPTION
Update documentation in line with #1993, and document the effect of `-s` on the cache and toolchain locations.

##### PR creation checklist
- [ ] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
