### PR TITLE
fix: infinite loop in `alr -n init`

### DIFF
--- a/src/alr/alr-commands-init.adb
+++ b/src/alr/alr-commands-init.adb
@@ -152,7 +152,15 @@ package body Alr.Commands.Init is
    is
    begin
       case Args.Length is
-         when 0 => -- Query crate name
+         when 0 =>
+            if CLIC.User_Input.Not_Interactive then
+               Reportaise_Wrong_Arguments
+                 ("Crate name required (must be supplied as an argument in "
+                  & "non-interactive mode)");
+               --  Otherwise the invalid default results in an infinite loop
+            end if;
+
+            --  Query crate name
             loop
                declare
                   Tentative_Name : constant String :=

--- a/testsuite/tests/init/non-interactive-no-name/test.py
+++ b/testsuite/tests/init/non-interactive-no-name/test.py
@@ -1,0 +1,12 @@
+"""Check that `alr -n init` yields an error, not an infinite loop."""
+
+from drivers.alr import run_alr
+from drivers.asserts import assert_substring
+
+p = run_alr("init", complain_on_error=False)
+assert_substring(
+    "Crate name required (must be supplied as an argument in non-interactive mode)",
+    p.out,
+)
+
+print("SUCCESS")

--- a/testsuite/tests/init/non-interactive-no-name/test.yaml
+++ b/testsuite/tests/init/non-interactive-no-name/test.yaml
@@ -1,0 +1,1 @@
+driver: python-script


### PR DESCRIPTION
Now yields an error when the `<crate name>` argument is not provided, instead of looping due to the invalid default.

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
