### PR TITLE
feat: omit compiler version from linked dependencies' build hashes

### DIFF
--- a/src/alire/alire-builds-hashes.adb
+++ b/src/alire/alire-builds-hashes.adb
@@ -257,13 +257,18 @@ package body Alire.Builds.Hashes is
             Add_Externals;     -- GPR externals
             Add_Environment;   -- Environment variables
 
-            --  In the root crate we can skip compiler detection, as it has no
-            --  bearing on the hash or config regeneration. This allows most
-            --  operations in a crate without dependencies to succeed even in
-            --  absence of a configured compiler. Note that for linked crates,
-            --  even if they don't have a proper build dir, the hash is
-            --  important for dependents.
-            if not Root.Is_Root_Release (Rel.Name) then
+            --  We can skip compiler detection for crates not deployed to a
+            --  shared `builds` directory, as it has no bearing on config
+            --  regeneration, and we don't need to propagate any changes to
+            --  shared dependents (since they will hash the compiler version
+            --  directly themselves anyway).
+            --
+            --  This allows most operations in a crate without any indexed
+            --  dependencies to succeed even in absence of a configured
+            --  compiler (or any index at all).
+            if not (Root.Is_Root_Release (Rel.Name)
+                    or else Root.Solution.State (Rel.Name).Is_Linked)
+            then
                Add_Compiler;   -- Compiler version
             end if;
 

--- a/testsuite/drivers/helpers.py
+++ b/testsuite/drivers/helpers.py
@@ -290,7 +290,7 @@ def md5sum(file):
     return file_hash.hexdigest()
 
 
-def append_to_file(filename : str, lines : []) -> None:
+def append_to_file(filename : Union[str, os.PathLike], lines : list[str]) -> None:
     """
     Append the given lines to a file
     """
@@ -298,7 +298,7 @@ def append_to_file(filename : str, lines : []) -> None:
         file.write("\n".join(lines))
 
 
-def prepend_to_file(filename : str, lines : []) -> None:
+def prepend_to_file(filename : Union[str, os.PathLike], lines : list[str]) -> None:
     """
     Prepend the given lines to a file
     """
@@ -307,7 +307,7 @@ def prepend_to_file(filename : str, lines : []) -> None:
         file.write("\n".join(lines) + "\n" + old_contents)
 
 
-def replace_in_file(filename : str, old : str, new : str):
+def replace_in_file(filename : Union[str, os.PathLike], old : str, new : str):
     """
     Replace all occurrences of a string in a file
     """

--- a/testsuite/tests/build/hashes/compiler-missing/test.py
+++ b/testsuite/tests/build/hashes/compiler-missing/test.py
@@ -3,7 +3,7 @@ Check that when no compiler is available we cannot compute the build hash
 """
 
 
-from drivers.alr import run_alr, init_local_crate
+from drivers.alr import run_alr, init_local_crate, alr_settings_set
 from drivers.asserts import assert_match
 
 # The index in this test has no compilers configured; hence we cannot locate
@@ -17,11 +17,22 @@ init_local_crate("xxx")
 # crate hash inputs
 run_alr("build")
 
-# Adding a dependency works because this doen't yet trigger an update/build
+# A crate with only pinned dependencies can be built (since there is no build
+# path for which the compiler version needs to be hashed)
+run_alr("-C", "..", "init", "pinned_crate")
+run_alr("with", "pinned_crate", "--use=../pinned_crate")
+run_alr("build")
+
+# Adding a shared dependency works because this doesn't yet trigger an
+# update/build
 run_alr("with", "libhello")
 
 # The build fails because we cannot compute the dependency hash without a compiler
 p = run_alr("build", complain_on_error=False)
 assert_match(".*Unable to determine compiler version", p.out)
+
+# Disable shared dependencies, and check that the build now succeeds
+alr_settings_set("dependencies.shared", "false")
+run_alr("build")
 
 print("SUCCESS")

--- a/testsuite/tests/build/hashes/transitive-linked-dep/pinned_libhello/alire.toml
+++ b/testsuite/tests/build/hashes/transitive-linked-dep/pinned_libhello/alire.toml
@@ -1,0 +1,19 @@
+description = "\"Hello, world!\" demonstration project support library"
+name = "libhello"
+version = "1.2.3"
+maintainers = ["alejandro@mosteo.com"]
+maintainers-logins = ["mylogin"]
+
+
+[configuration.variables]
+Var1 = {type = "Boolean", default = true}
+
+[gpr-externals]
+SET_LOCALLY = ["val_A", "val_B"]
+SET_BY_ROOT = ["val_C", "val_D"]
+
+[gpr-set-externals]
+SET_LOCALLY = "val_A"
+
+[environment]
+MY_ENV.set = "env_one"

--- a/testsuite/tests/build/hashes/transitive-linked-dep/pinned_libhello/libhello.gpr
+++ b/testsuite/tests/build/hashes/transitive-linked-dep/pinned_libhello/libhello.gpr
@@ -1,0 +1,10 @@
+project Libhello is
+
+   for Source_Dirs use ("src");
+   for Object_Dir use "obj";
+
+   for Library_Name use "hello";
+   for Library_Dir use "lib";
+
+end Libhello;
+

--- a/testsuite/tests/build/hashes/transitive-linked-dep/pinned_libhello/src/libhello.adb
+++ b/testsuite/tests/build/hashes/transitive-linked-dep/pinned_libhello/src/libhello.adb
@@ -1,0 +1,15 @@
+with Ada.Text_IO;
+
+package body libhello is
+
+   -----------------
+   -- Hello_World --
+   -----------------
+
+   procedure Hello_World is
+      use Ada.Text_IO;
+   begin
+      Put_Line ("Hello world, from the pinned libhello!");
+   end Hello_World;
+
+end libhello;

--- a/testsuite/tests/build/hashes/transitive-linked-dep/pinned_libhello/src/libhello.ads
+++ b/testsuite/tests/build/hashes/transitive-linked-dep/pinned_libhello/src/libhello.ads
@@ -1,0 +1,5 @@
+package libhello is
+
+   procedure Hello_World;
+
+end libhello;

--- a/testsuite/tests/build/hashes/transitive-linked-dep/test.py
+++ b/testsuite/tests/build/hashes/transitive-linked-dep/test.py
@@ -1,0 +1,99 @@
+"""Test that build hashes reflect changes in transitive linked dependencies."""
+
+from glob import glob
+from pathlib import Path
+
+from drivers.alr import alr_pin, alr_settings_set, alr_with, init_local_crate, run_alr
+from drivers.asserts import assert_eq, assert_match, assert_not_substring
+from drivers.builds import path as builds_path
+from drivers.helpers import (
+    MockCommand,
+    append_to_file,
+    on_windows,
+    prepend_to_file,
+    replace_in_file,
+)
+
+test_root = Path.cwd()
+libhello_manifest = test_root / "pinned_libhello" / "alire.toml"
+
+
+# Create a crate with dependencies `xxx -> hello -> libhello`, and pin
+# `libhello` to a local path.
+init_local_crate()
+alr_with("hello")
+alr_pin("libhello", path="../pinned_libhello")
+# Make `xxx` actually depend on `hello`.
+main_file = test_root / "xxx" / "src" / "xxx.adb"
+prepend_to_file(main_file, ["with Hello;"])
+replace_in_file(main_file, "null;", "Hello;")
+
+
+def count_hello_dirs() -> int:
+    """Count the number of shared build directories for the `hello` crate."""
+    return len(glob(f"{builds_path()}/hello*/*"))
+
+
+def assert_new_hash() -> None:
+    """Build and assert that hello is compiled in a new build directory."""
+    expected = count_hello_dirs() + 1
+    p = run_alr("build", quiet=False)
+    actual = count_hello_dirs()
+    assert actual == expected, "new shared build directory not created"
+    # Check `gprbuild` reports a rebuild of `hello.adb`.
+    assert_match(r".*\[Ada\]\s+hello\.adb\n", p.out)
+
+
+def assert_build_reused() -> None:
+    """Build and assert that no new build dir is created and hello is not recompiled."""
+    expected = count_hello_dirs()
+    p = run_alr("build", quiet=False)
+    actual = count_hello_dirs()
+    assert actual == expected, "new shared build directory created unexpectedly"
+    # Check there was no `[Ada]   hello.adb` from `gprbuild`.
+    assert_not_substring("hello.adb", p.out)
+
+
+# The first `alr build` will put `hello` in a new shared build directory,
+# with a dependence on the pinned `libhello`.
+assert_new_hash()
+assert_eq("Hello world, from the pinned libhello!\n", run_alr("run").out)
+
+# Changing a GPR external should rebuild hello in a new directory.
+replace_in_file(libhello_manifest, 'SET_LOCALLY = "val_A"', 'SET_LOCALLY = "val_B"')
+assert_new_hash()
+# Reverting the change should reuse the previous build.
+replace_in_file(libhello_manifest, 'SET_LOCALLY = "val_B"', 'SET_LOCALLY = "val_A"')
+assert_build_reused()
+
+# An external set by the root crate should yield the same.
+root_manifest = test_root / "xxx" / "alire.toml"
+append_to_file(root_manifest, ["[gpr-set-externals]", 'SET_BY_ROOT = "val_C"'])
+assert_new_hash()
+replace_in_file(root_manifest, 'SET_BY_ROOT = "val_C"', 'SET_BY_ROOT = "val_D"')
+assert_new_hash()
+replace_in_file(root_manifest, '[gpr-set-externals]\nSET_BY_ROOT = "val_D"', "")
+assert_build_reused()
+
+# An environment variable change should give a new hash.
+replace_in_file(libhello_manifest, 'MY_ENV.set = "env_one"', 'MY_ENV.set = "env_two"')
+assert_new_hash()
+replace_in_file(libhello_manifest, 'MY_ENV.set = "env_two"', 'MY_ENV.set = "env_one"')
+assert_build_reused()
+append_to_file(root_manifest, ["[environment]", 'MY_ENV.append = "env_root"'])
+assert_new_hash()
+replace_in_file(root_manifest, '[environment]\nMY_ENV.append = "env_root"', "")
+assert_build_reused()
+
+# Changing the compiler should give a new hash.
+#
+# The `gnat_external` in `build_hash_index` has `version-command = ["echo", "1.0"]`;
+# we simulate a compiler change by mocking it to return `1.2` instead.
+if on_windows():
+    alr_settings_set("msys2.install_dir", str(test_root / "nonexistent"))
+with MockCommand("echo", "print('1.2')", "mock_cmd_dir"):
+    assert_new_hash()
+assert_build_reused()
+
+
+print("SUCCESS")

--- a/testsuite/tests/build/hashes/transitive-linked-dep/test.yaml
+++ b/testsuite/tests/build/hashes/transitive-linked-dep/test.yaml
@@ -1,0 +1,4 @@
+driver: python-script
+build_mode: shared
+indexes:
+    build_hash_index: {}


### PR DESCRIPTION
In offline environments, or other contexts where the community index is not available, it is currently necessary to explicitly set `dependencies.shared` to `false` (or construct a private index, with its own `gnat_external` definition) to build a crate with any dependencies, even if all dependencies are pins to local paths. In particular, this is required for `alr test`'s build of a nested test crate.

This PR omits the compiler version from the build hash of linked dependencies, so that default settings permit building a crate with no index-fetched dependencies without an index configured.

As far as I can tell, the fact that compiler version changes are no longer propagated to the build hashes of any shared dependents is unproblematic, as the compiler version is still hashed directly by such dependents themselves. This directly contradicts the existing comment, though, so I'm not at all confident that I have understood correctly.

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
