### PR TITLE
add flags to forward gprbuild arguments with alr test

### DIFF
--- a/src/alire/alire-test_runner.adb
+++ b/src/alire/alire-test_runner.adb
@@ -552,9 +552,11 @@ package body Alire.Test_Runner is
    ---------
 
    function Run
-     (Root   : in out Roots.Root;
-      Filter : AAA.Strings.Vector := AAA.Strings.Empty_Vector;
-      Jobs   : Natural := 0) return Integer
+     (Root       : in out Roots.Root;
+      Filter     : AAA.Strings.Vector := AAA.Strings.Empty_Vector;
+      Jobs       : Natural := 0;
+      Build_Args : AAA.Strings.Vector := AAA.Strings.Empty_Vector;
+      Build_Only : Boolean := False) return Integer
    is
       Job_Count : constant Positive :=
         (if Jobs = 0
@@ -581,9 +583,14 @@ package body Alire.Test_Runner is
          Alire_Early_Elaboration.Switch_Q := True;
       end if;
 
-      if Roots.Build (Root, AAA.Strings.Empty_Vector) then
+      if Roots.Build (Root, Build_Args) then
          Alire_Early_Elaboration.Switch_Q := Original_Switch_Q;
          --  restore original value of `-q` switch
+
+         if Build_Only then
+            Put_Info ("Built " & Test_List.Length'Image & " tests");
+            return 0;
+         end if;
 
          Put_Info ("Running" & Test_List.Length'Image & " tests");
          Run_All_Tests (Root, Test_List, Job_Count);

--- a/src/alire/alire-test_runner.ads
+++ b/src/alire/alire-test_runner.ads
@@ -5,11 +5,16 @@ with AAA.Strings;
 package Alire.Test_Runner is
 
    function Run
-     (Root   : in out Alire.Roots.Root;
-      Filter : AAA.Strings.Vector := AAA.Strings.Empty_Vector;
-      Jobs   : Natural := 0) return Integer;
+     (Root       : in out Alire.Roots.Root;
+      Filter     : AAA.Strings.Vector := AAA.Strings.Empty_Vector;
+      Jobs       : Natural := 0;
+      Build_Args : AAA.Strings.Vector := AAA.Strings.Empty_Vector;
+      Build_Only : Boolean := False) return Integer;
    --  Run all .adb files in the `src` folder of the given root as
    --  separate tests. Return the number of failing tests.
+   --
+   --  Build_Args allows forwarding arguments directly to GPRbuild.
+   --  Build_Only stops the runner right after building the tests.
 
    procedure Show_List
      (Root   : Roots.Root;

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -14,6 +14,20 @@ package body Alr.Commands.Test is
 
    package Dirs renames Alire.Directories;
 
+   Build_Args : AAA.Strings.Vector := AAA.Strings.Empty_Vector;
+   --  A (private) global in which we can accumulate build arguments with a
+   --  procedure access.
+
+   ----------------------
+   -- Append_Build_Arg --
+   ----------------------
+
+   procedure Append_Build_Arg (Switch, Value : String) is
+      pragma Unreferenced (Switch);
+   begin
+      Build_Args.Append_Line (Value);
+   end Append_Build_Arg;
+
    --------------------
    -- Execute_Legacy --
    --------------------
@@ -83,6 +97,20 @@ package body Alr.Commands.Test is
               Report => False);
    end Find_Root_With_Tests;
 
+   --------------------------------
+   -- Warn_Builtin_Not_Forwarded --
+   --------------------------------
+
+   procedure Warn_Builtin_Not_Forwarded (Flag : String) is
+   begin
+      Trace.Warning
+        ("the "
+         & Flag
+         & " flag is not forwarded to external commands. If you"
+         & " intended to pass it to an external test runner, put it"
+         & " after ""--"" in the command line.");
+   end Warn_Builtin_Not_Forwarded;
+
    -------------
    -- Execute --
    -------------
@@ -96,6 +124,8 @@ package body Alr.Commands.Test is
 
       All_Settings : Alire.Properties.Vector;
    begin
+      Cmd.Build_Args.Move (Build_Args);
+      --  move the build args into the command struct
       Cmd.Requires_Workspace;
 
       if Cmd.Legacy then
@@ -166,20 +196,19 @@ package body Alr.Commands.Test is
          end if;
       end if;
 
-      if All_Settings.Length = 1
-        and then Settings (All_Settings.First_Element).Runner.Kind = External
+      if (for some S of All_Settings => Settings (S).Runner.Kind = External)
       then
          if Cmd.Jobs >= 0 then
-            Trace.Warning
-              ("the --jobs flag is not forwarded to external commands. If you"
-               & " intended to pass it to an external test runner, put it"
-               & " after ""--"" in the command line.");
+            Warn_Builtin_Not_Forwarded ("--jobs");
          end if;
          if Cmd.List then
-            Trace.Warning
-              ("the --list flag is not forwarded to external commands. If you"
-               & " intended to pass it to an external test runner, put it"
-               & " after ""--"" in the command line.");
+            Warn_Builtin_Not_Forwarded ("--list");
+         end if;
+         if Cmd.Build_Only then
+            Warn_Builtin_Not_Forwarded ("--build-only");
+         end if;
+         if not Cmd.Build_Args.Is_Empty then
+            Warn_Builtin_Not_Forwarded ("-B/--build-arg");
          end if;
       end if;
 
@@ -227,9 +256,12 @@ package body Alr.Commands.Test is
 
                      Failures :=
                        Alire.Test_Runner.Run
-                         (Test_Root.Value,
-                          Get_Args,
-                          (if Cmd.Jobs < 0 then S.Jobs else Cmd.Jobs));
+                         (Root       => Test_Root.Value,
+                          Filter     => Get_Args,
+                          Jobs       =>
+                            (if Cmd.Jobs < 0 then S.Jobs else Cmd.Jobs),
+                          Build_Only => Cmd.Build_Only,
+                          Build_Args => Cmd.Build_Args);
 
                   when External     =>
                      Cmd.Forbids_Structured_Output
@@ -281,9 +313,12 @@ package body Alr.Commands.Test is
              & " arguments.")
          .Append ("")
          .Append
-            ("When using a built-in runner, one can pass `--list` to get"
+            ("When using a built-in runner, one can pass --list to get"
              & " ahead of time a list of tests (optionally matching the"
-             & " command line filter)."));
+             & " command line filter).")
+         .Append
+            ("The --build-only and --build-arg switches allow finer control"
+             & " over the test build process."));
 
    --------------------
    -- Setup_Switches --
@@ -295,42 +330,60 @@ package body Alr.Commands.Test is
       Config : in out CLIC.Subcommand.Switches_Configuration)
    is
       use CLIC.Subcommand;
+
    begin
       Define_Switch
         (Config,
          Cmd.Jobs'Access,
-         "-j:",
-         "--jobs=",
-         "Run up to N tests in parallel, or as many as there are processors"
-         & " if 0",
-         Initial  => -1,
-         Default  => -1,
-         Argument => "N");
+         Switch      => "-j:",
+         Long_Switch => "--jobs=",
+         Help        =>
+           "Run up to N tests in parallel, or as many as there are processors"
+           & " if 0",
+         Initial     => -1,
+         Default     => -1,
+         Argument    => "N");
 
       Define_Switch
         (Config,
          Cmd.By_Id'Access,
-         "",
-         "--id=",
-         "Select a specific test runner by id",
-         Argument => "<id>");
+         Switch      => "",
+         Long_Switch => "--id=",
+         Help        => "Select a specific test runner by id",
+         Argument    => "<id>");
 
       Define_Switch
         (Config,
          Cmd.Legacy'Access,
-         "",
-         "--legacy",
-         CLIC.TTY.Error ("Deprecated")
-         & ". Force executing the legacy test actions",
-         Value => True);
+         Switch      => "",
+         Long_Switch => "--legacy",
+         Help        =>
+           CLIC.TTY.Error ("Deprecated")
+           & ". Force executing the legacy test actions",
+         Value       => True);
 
       Define_Switch
         (Config,
          Cmd.List'Access,
-         "",
-         "--list",
-         "Show a list of matching tests without running them",
-         Value => True);
+         Switch      => "",
+         Long_Switch => "--list",
+         Help        => "Show a list of matching tests without running them",
+         Value       => True);
+
+      Define_Switch
+        (Config,
+         Cmd.Build_Only'Access,
+         Switch      => "",
+         Long_Switch => "--build-only",
+         Help        => "Stop the runner right after building the tests",
+         Value       => True);
+
+      Define_Switch
+        (Config,
+         Callback    => Append_Build_Arg'Access,
+         Switch      => "-B:",
+         Long_Switch => "--build-arg=",
+         Help        => "Argument to forward to GPRbuild");
    end Setup_Switches;
 
 end Alr.Commands.Test;

--- a/src/alr/alr-commands-test.ads
+++ b/src/alr/alr-commands-test.ads
@@ -35,10 +35,13 @@ package Alr.Commands.Test is
 private
 
    type Command is new Commands.Command with record
-      Jobs   : aliased Integer := 0;
-      By_Id  : aliased GNAT.Strings.String_Access;
-      Legacy : aliased Boolean := False;
-      List   : aliased Boolean := False;
+      Jobs       : aliased Integer := 0;
+      By_Id      : aliased GNAT.Strings.String_Access;
+      Legacy     : aliased Boolean := False;
+      List       : aliased Boolean := False;
+      Build_Only : aliased Boolean := False;
+
+      Build_Args : AAA.Strings.Vector := AAA.Strings.Empty_Vector;
    end record;
 
 end Alr.Commands.Test;

--- a/testsuite/tests/test/build-arguments/test.py
+++ b/testsuite/tests/test/build-arguments/test.py
@@ -1,0 +1,21 @@
+"""
+Run tests with --build-only and --build-args
+"""
+
+import os
+
+from drivers.asserts import assert_file_exists, assert_not_substring, assert_substring
+from drivers.alr import init_local_crate, run_alr
+from drivers.helpers import exe_name, replace_in_file
+
+init_local_crate("xxx", with_test=True)
+
+p = run_alr("test", "--build-only")
+assert_not_substring("PASS", p.out)
+assert_not_substring("FAIL", p.out)
+assert_file_exists(exe_name("tests/bin/xxx_tests-assertions_enabled"))
+
+p = run_alr("test", "--build-only", "-B", "--version", quiet=False)
+assert_substring("This is free software", p.out)
+
+print("SUCCESS")

--- a/testsuite/tests/test/build-arguments/test.yaml
+++ b/testsuite/tests/test/build-arguments/test.yaml
@@ -1,0 +1,3 @@
+driver: python-script
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
This feature is made with the integration of GNATcoverage in mind. Users can now enter
`alr test -B--src-subdirs=gnatcov-instr...` and the like.

I plan to publish a small wrapper program in the index to have easy code instrumentation and coverage based on `alr test` :)

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
