### PR TITLE
Remove obsolescent ASCII

### DIFF
--- a/alire_common.gpr
+++ b/alire_common.gpr
@@ -73,6 +73,8 @@ abstract project Alire_Common is
      );
 
    package Compiler is
+      for Local_Configuration_Pragmas use "src/alire.adc";
+
       case Build_Mode is
          when "debug" =>
             for Default_Switches ("Ada") use Ada_Common_Switches &

--- a/src/alire.adc
+++ b/src/alire.adc
@@ -1,0 +1,1 @@
+pragma Restrictions (No_Obsolescent_Features);

--- a/src/alire/alire-errors.adb
+++ b/src/alire/alire-errors.adb
@@ -1,15 +1,12 @@
 with AAA.Debug;
 with AAA.Strings;
 
-with Ada.Characters.Latin_1;
 with Ada.Containers.Indefinite_Ordered_Maps;
 
 with Alire.OS_Lib;
 with Alire.Utils;
 
 package body Alire.Errors is
-
-   package Latin_1 renames Ada.Characters.Latin_1;
 
    use AAA.Strings;
 

--- a/src/alire/alire-errors.adb
+++ b/src/alire/alire-errors.adb
@@ -1,12 +1,15 @@
 with AAA.Debug;
 with AAA.Strings;
 
+with Ada.Characters.Latin_1;
 with Ada.Containers.Indefinite_Ordered_Maps;
 
 with Alire.OS_Lib;
 with Alire.Utils;
 
 package body Alire.Errors is
+
+   package Latin_1 renames Ada.Characters.Latin_1;
 
    use AAA.Strings;
 
@@ -129,7 +132,7 @@ package body Alire.Errors is
    procedure Pretty_Print (Error : String;
                            Level : Trace.Levels := Trace.Error)
    is
-      Lines : constant AAA.Strings.Vector := Split (Error, ASCII.LF);
+      Lines : constant AAA.Strings.Vector := Split (Error, Latin_1.LF);
    begin
       for I in Lines.First_Index .. Lines.Last_Index loop
          declare
@@ -163,7 +166,7 @@ package body Alire.Errors is
    ----------
 
    function Wrap (Upper, Lower : String) return String
-   is (Upper & ASCII.LF & Lower);
+   is (Upper & Latin_1.LF & Lower);
 
    -----------
    -- Print --
@@ -238,7 +241,7 @@ package body Alire.Errors is
          if I = Error_Stack.First_Index
            or else Error_Stack (I) /= Error_Stack (I - 1)
          then
-            Append (Msg, Error_Stack (I) & ASCII.LF);
+            Append (Msg, Error_Stack (I) & Latin_1.LF);
          end if;
       end loop;
 
@@ -259,7 +262,7 @@ package body Alire.Errors is
                    ((if Stack_Trace /= ""
                     then Stack_Trace
                     else AAA.Debug.Stack_Trace),
-                    ASCII.LF);
+                    Latin_1.LF);
 
       Caller : constant Positive :=
                  5 + Stack_Offset - (if Stack_Trace /= "" then 2 else 0);

--- a/src/alire/alire-externals-from_output.adb
+++ b/src/alire/alire-externals-from_output.adb
@@ -1,5 +1,7 @@
 with AAA.Strings; use AAA.Strings;
 
+with Ada.Characters.Latin_1;
+
 with Alire.Directories;
 with Alire.Index;
 with Alire.Origins;
@@ -24,6 +26,7 @@ package body Alire.Externals.From_Output is
    function Detect (This : External;
                     Name : Crate_Name) return Releases.Containers.Release_Set
    is
+      package Latin_1 renames Ada.Characters.Latin_1;
       use Directories.Operators;
       Location : GNAT.OS_Lib.String_Access :=
                    GNAT.OS_Lib.Locate_Exec_On_Path
@@ -55,7 +58,7 @@ package body Alire.Externals.From_Output is
                        (This.Command.First_Element,
                         This.Command.Tail,
                         Lines);
-         Output  : constant String := Lines.Flatten ("" & ASCII.LF);
+         Output  : constant String := Lines.Flatten ("" & Latin_1.LF);
          --  ASCII.LF is used by Regpat for new lines
       begin
          if Status /= 0 then

--- a/src/alire/alire-externals-from_output.adb
+++ b/src/alire/alire-externals-from_output.adb
@@ -1,7 +1,5 @@
 with AAA.Strings; use AAA.Strings;
 
-with Ada.Characters.Latin_1;
-
 with Alire.Directories;
 with Alire.Index;
 with Alire.Origins;
@@ -26,7 +24,6 @@ package body Alire.Externals.From_Output is
    function Detect (This : External;
                     Name : Crate_Name) return Releases.Containers.Release_Set
    is
-      package Latin_1 renames Ada.Characters.Latin_1;
       use Directories.Operators;
       Location : GNAT.OS_Lib.String_Access :=
                    GNAT.OS_Lib.Locate_Exec_On_Path

--- a/src/alire/alire-github.adb
+++ b/src/alire/alire-github.adb
@@ -1,5 +1,4 @@
 with Ada.Calendar;
-with Ada.Characters.Latin_1;
 with Ada.Exceptions;
 
 with Alire.Errors;
@@ -72,8 +71,6 @@ package body Alire.GitHub is
    is
       --  We receive either JSON Args or a Raw body to send
       pragma Assert (Raw = "" or else Args = Minirest.No_Arguments);
-
-      package Latin_1 renames Ada.Characters.Latin_1;
 
       Full_URL : constant String :=
                    Base_URL
@@ -166,8 +163,6 @@ package body Alire.GitHub is
                       Error  : String := "GitHub API call failed")
                       return GNATCOLL.JSON.JSON_Value
    is
-      package Latin_1 renames Ada.Characters.Latin_1;
-
       Response : constant Minirest.Response
         := API_Call (Proc   => Proc,
                      Args   => Args,
@@ -419,7 +414,6 @@ package body Alire.GitHub is
                              Node_ID : String)
    is
       pragma Unreferenced (Number);
-      package Latin_1 renames Ada.Characters.Latin_1;
       use AAA.Strings;
 
       --  Unfortunately, removing the draft flag isn't available through REST.

--- a/src/alire/alire-github.adb
+++ b/src/alire/alire-github.adb
@@ -1,4 +1,5 @@
 with Ada.Calendar;
+with Ada.Characters.Latin_1;
 with Ada.Exceptions;
 
 with Alire.Errors;
@@ -72,6 +73,8 @@ package body Alire.GitHub is
       --  We receive either JSON Args or a Raw body to send
       pragma Assert (Raw = "" or else Args = Minirest.No_Arguments);
 
+      package Latin_1 renames Ada.Characters.Latin_1;
+
       Full_URL : constant String :=
                    Base_URL
                    & (if Proc (Proc'First) /= '/' then "/" else "")
@@ -120,9 +123,9 @@ package body Alire.GitHub is
          Trace.Debug
            ("GitHub API response: " & This.Status_Line);
          Trace.Debug
-           ("Headers: " & This.Raw_Headers.Flatten (ASCII.LF));
+           ("Headers: " & This.Raw_Headers.Flatten (Latin_1.LF));
          Trace.Debug
-           ("Data: " & This.Content.Flatten (ASCII.LF));
+           ("Data: " & This.Content.Flatten (Latin_1.LF));
 
          if not This.Succeeded then
 
@@ -163,6 +166,8 @@ package body Alire.GitHub is
                       Error  : String := "GitHub API call failed")
                       return GNATCOLL.JSON.JSON_Value
    is
+      package Latin_1 renames Ada.Characters.Latin_1;
+
       Response : constant Minirest.Response
         := API_Call (Proc   => Proc,
                      Args   => Args,
@@ -177,7 +182,7 @@ package body Alire.GitHub is
             .Wrap (Error)
             .Wrap ("Status line: " & Response.Status_Line)
             .Wrap ("Response body:")
-            .Wrap (Response.Content.Flatten (ASCII.LF))
+            .Wrap (Response.Content.Flatten (Latin_1.LF))
             .Get);
       end if;
    end API_Call;
@@ -414,6 +419,7 @@ package body Alire.GitHub is
                              Node_ID : String)
    is
       pragma Unreferenced (Number);
+      package Latin_1 renames Ada.Characters.Latin_1;
       use AAA.Strings;
 
       --  Unfortunately, removing the draft flag isn't available through REST.
@@ -455,7 +461,7 @@ package body Alire.GitHub is
             .Wrap ("Error updating PR using GitHub GraphQL API")
             .Wrap ("Status line: " & Response.Status_Line)
             .Wrap ("Response body:")
-            .Wrap (Response.Content.Flatten (ASCII.LF))
+            .Wrap (Response.Content.Flatten (Latin_1.LF))
             .Get);
       end if;
 

--- a/src/alire/alire-install.adb
+++ b/src/alire/alire-install.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Ada.Containers;
 with Ada.Directories;
 
@@ -309,7 +308,6 @@ package body Alire.Install is
                              Rel    : Releases.Release)
                              return Actions
    is
-      package Latin_1 renames Ada.Characters.Latin_1;
    begin
 
       --  Crates declaring executables can only be installed once

--- a/src/alire/alire-install.adb
+++ b/src/alire/alire-install.adb
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 with Ada.Containers;
 with Ada.Directories;
 
@@ -308,6 +309,7 @@ package body Alire.Install is
                              Rel    : Releases.Release)
                              return Actions
    is
+      package Latin_1 renames Ada.Characters.Latin_1;
    begin
 
       --  Crates declaring executables can only be installed once
@@ -340,7 +342,7 @@ package body Alire.Install is
                     ("Release " & Rel.Milestone.TTY_Image
                      & " has another version already installed: ")
                   .Wrap (To_Image_Vector (Find_Installed
-                    (Prefix, Rel.Name)).Flatten (ASCII.LF))
+                    (Prefix, Rel.Name)).Flatten (Latin_1.LF))
                   .Wrap ("Releases installing executables can be "
                     & "installed only once")
                   .Wrap ("Forcing this install will overwrite the "

--- a/src/alire/alire-origins-deployers-system-portage.adb
+++ b/src/alire/alire-origins-deployers-system-portage.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with AAA.Strings; use AAA.Strings;
 
 with Alire.Errors;
@@ -7,7 +6,6 @@ with Alire.OS_Lib.Subprocess;
 
 package body Alire.Origins.Deployers.System.Portage is
 
-   package L1         renames Ada.Characters.Latin_1;
    package Subprocess renames Alire.OS_Lib.Subprocess;
 
    -----------------------
@@ -50,8 +48,8 @@ package body Alire.Origins.Deployers.System.Portage is
    begin
       for C in Tmp'Range loop
          --  Format: 0.0.0_release-rc9
-         if Tmp (C) = L1.Low_Line then
-            Tmp (C) := L1.Hyphen;
+         if Tmp (C) = Latin_1.Low_Line then
+            Tmp (C) := Latin_1.Hyphen;
 
             Trace.Debug ("To_Semantic_Version: " & Tmp);
 
@@ -74,7 +72,7 @@ package body Alire.Origins.Deployers.System.Portage is
       function Split_Version (Gentoo_Package_Version : String) return String is
       begin
          for Index in Gentoo_Package_Version'Range loop
-            if Gentoo_Package_Version (Index) = L1.Hyphen then
+            if Gentoo_Package_Version (Index) = Latin_1.Hyphen then
                return Gentoo_Package_Version
                  (Index + 1 .. Gentoo_Package_Version'Last);
             end if;

--- a/src/alire/alire-os_lib-subprocess.adb
+++ b/src/alire/alire-os_lib-subprocess.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Ada.Strings.Maps;
 with Ada.Text_IO;
 
@@ -114,7 +113,7 @@ package body Alire.OS_Lib.Subprocess is
       function Is_Blank (Char : Character) return Boolean is
          Blank_Set : constant Ada.Strings.Maps.Character_Set
                       := Ada.Strings.Maps.To_Set
-                         (" " & Ada.Characters.Latin_1.HT);
+                         (" " & Latin_1.HT);
          --  The <blank> character class in POSIX locale contains <tab>,
          --  <space> per chapter 3 (V1) section 3.45 of:
          --  https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/

--- a/src/alire/alire-properties-actions-runners.adb
+++ b/src/alire/alire-properties-actions-runners.adb
@@ -1,7 +1,5 @@
 with AAA.Enum_Tools;
 
-with Ada.Characters.Latin_1;
-
 with Alire.Utils.Did_You_Mean;
 
 package body Alire.Properties.Actions.Runners is
@@ -43,7 +41,6 @@ package body Alire.Properties.Actions.Runners is
 
       --  Actions come in a TOML array.
 
-      package Latin_1 renames Ada.Characters.Latin_1;
       use Conditional.For_Properties;
       use TOML;
 

--- a/src/alire/alire-properties-actions-runners.adb
+++ b/src/alire/alire-properties-actions-runners.adb
@@ -1,4 +1,7 @@
 with AAA.Enum_Tools;
+
+with Ada.Characters.Latin_1;
+
 with Alire.Utils.Did_You_Mean;
 
 package body Alire.Properties.Actions.Runners is
@@ -40,6 +43,7 @@ package body Alire.Properties.Actions.Runners is
 
       --  Actions come in a TOML array.
 
+      package Latin_1 renames Ada.Characters.Latin_1;
       use Conditional.For_Properties;
       use TOML;
 
@@ -104,7 +108,7 @@ package body Alire.Properties.Actions.Runners is
               ("action name must be a string made of "
                & "'a' .. 'z', '0' .. '9', '-', starting with a letter and not "
                & "ending with a dash nor containing consecutive dashes"
-               & ASCII.LF & "Offending name is: " & Name.As_String);
+               & Latin_1.LF & "Offending name is: " & Name.As_String);
          end if;
 
          if Command.Kind /= TOML_Array

--- a/src/alire/alire-properties-configurations.adb
+++ b/src/alire/alire-properties-configurations.adb
@@ -6,7 +6,6 @@ with Alire.Utils.YAML;
 with Alire.Utils.Did_You_Mean;
 
 with Ada.Characters.Handling;
-with Ada.Characters.Latin_1;
 
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 
@@ -318,7 +317,6 @@ package body Alire.Properties.Configurations is
 
    overriding
    function To_YAML (This : Config_Value_Assignment) return String is
-      package Latin_1 renames Ada.Characters.Latin_1;
       Ret : Unbounded_String;
       First : Boolean := True;
    begin
@@ -439,7 +437,7 @@ package body Alire.Properties.Configurations is
                                 Value : TOML.TOML_Value)
                                 return String
    is
-      use Ada.Characters.Latin_1;
+      use Latin_1;
       Name : constant String := +This.Name;
       Indent : constant String := "   ";
    begin
@@ -507,7 +505,7 @@ package body Alire.Properties.Configurations is
                                 Value : TOML.TOML_Value)
                                 return String
    is
-      use Ada.Characters.Latin_1;
+      use Latin_1;
       Name : constant String := +This.Name;
       Indent : constant String := "   ";
    begin
@@ -554,7 +552,7 @@ package body Alire.Properties.Configurations is
                               Value : TOML.TOML_Value)
                               return String
    is
-      use Ada.Characters.Latin_1;
+      use Latin_1;
       Name : constant String := To_Upper_Case (+This.Name);
 
    begin

--- a/src/alire/alire-properties-configurations.adb
+++ b/src/alire/alire-properties-configurations.adb
@@ -6,6 +6,7 @@ with Alire.Utils.YAML;
 with Alire.Utils.Did_You_Mean;
 
 with Ada.Characters.Handling;
+with Ada.Characters.Latin_1;
 
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 
@@ -317,6 +318,7 @@ package body Alire.Properties.Configurations is
 
    overriding
    function To_YAML (This : Config_Value_Assignment) return String is
+      package Latin_1 renames Ada.Characters.Latin_1;
       Ret : Unbounded_String;
       First : Boolean := True;
    begin
@@ -324,7 +326,7 @@ package body Alire.Properties.Configurations is
 
       for Elt of This.List loop
          if not First then
-            Append (Ret, ", " & ASCII.LF);
+            Append (Ret, ", " & Latin_1.LF);
          else
             First := False;
          end if;
@@ -437,7 +439,7 @@ package body Alire.Properties.Configurations is
                                 Value : TOML.TOML_Value)
                                 return String
    is
-      use ASCII;
+      use Ada.Characters.Latin_1;
       Name : constant String := +This.Name;
       Indent : constant String := "   ";
    begin
@@ -505,7 +507,7 @@ package body Alire.Properties.Configurations is
                                 Value : TOML.TOML_Value)
                                 return String
    is
-      use ASCII;
+      use Ada.Characters.Latin_1;
       Name : constant String := +This.Name;
       Indent : constant String := "   ";
    begin
@@ -552,7 +554,7 @@ package body Alire.Properties.Configurations is
                               Value : TOML.TOML_Value)
                               return String
    is
-      use ASCII;
+      use Ada.Characters.Latin_1;
       Name : constant String := To_Upper_Case (+This.Name);
 
    begin

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Ada.Directories;
 with Ada.Text_IO;
 
@@ -234,8 +233,6 @@ package body Alire.Publish is
    --  Checks the presence of recommended/mandatory fields in the release
    procedure Check_Release (Release : Releases.Release; Context : in out Data)
    is
-      package Latin_1 renames Ada.Characters.Latin_1;
-
       Recommend : AAA.Strings.Vector; -- Optional
       Missing   : AAA.Strings.Vector; -- Mandatory
 
@@ -668,7 +665,6 @@ package body Alire.Publish is
    --  plain tar otherwise.
 
    procedure Prepare_Archive (Context : in out Data) is
-      package Latin_1 renames Ada.Characters.Latin_1;
       use CLIC.User_Input;
 
       Target_Dir : constant Relative_Path :=
@@ -854,7 +850,6 @@ package body Alire.Publish is
    -------------------
 
    procedure Verify_Github (Context : in out Data) is
-      package Latin_1 renames Ada.Characters.Latin_1;
    begin
 
       --  Early return if forcing

--- a/src/alire/alire-publish.adb
+++ b/src/alire/alire-publish.adb
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 with Ada.Directories;
 with Ada.Text_IO;
 
@@ -233,6 +234,8 @@ package body Alire.Publish is
    --  Checks the presence of recommended/mandatory fields in the release
    procedure Check_Release (Release : Releases.Release; Context : in out Data)
    is
+      package Latin_1 renames Ada.Characters.Latin_1;
+
       Recommend : AAA.Strings.Vector; -- Optional
       Missing   : AAA.Strings.Vector; -- Mandatory
 
@@ -322,7 +325,7 @@ package body Alire.Publish is
          Ada.Text_IO.New_Line;
          Trace.Warning ("The release "
                         & TTY.Warn ("version ends with '-dev'") & "."
-                        & ASCII.LF
+                        & Latin_1.LF
                         & "Releases submitted to an index should usually"
                         & " not be pre-release versions.");
       end if;
@@ -665,6 +668,7 @@ package body Alire.Publish is
    --  plain tar otherwise.
 
    procedure Prepare_Archive (Context : in out Data) is
+      package Latin_1 renames Ada.Characters.Latin_1;
       use CLIC.User_Input;
 
       Target_Dir : constant Relative_Path :=
@@ -810,7 +814,7 @@ package body Alire.Publish is
                           "Please upload the archive generated"
                           & " at " & TTY.URL (Archive)
                           & " to its definitive online storage location."
-                          & ASCII.LF
+                          & Latin_1.LF
                           & "Once you have uploaded the file, enter its URL:",
                        Prompt   => "Enter URL> ",
                        Valid    => (Yes | No => True, others => False),
@@ -850,6 +854,7 @@ package body Alire.Publish is
    -------------------
 
    procedure Verify_Github (Context : in out Data) is
+      package Latin_1 renames Ada.Characters.Latin_1;
    begin
 
       --  Early return if forcing
@@ -892,7 +897,7 @@ package body Alire.Publish is
             if not Submit.Ask_To_Fork (Context) then
                Recoverable_User_Error
                  ("You must fork the community index to your GitHub account"
-               & ASCII.LF & "Please visit "
+               & Latin_1.LF & "Please visit "
                & TTY.URL (Tail (Index.Community_Repo, '+'))
                & " if you want to fork manually.");
             end if;

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Ada.Directories;
 with Ada.Text_IO;
 
@@ -86,7 +85,6 @@ package body Alire.Releases is
    -------------------------
    --  Warn of ^0.x dependencies that probably should be ~0.x
    function Check_Caret_Warning (This : Release) return Boolean is
-      package Latin_1 renames Ada.Characters.Latin_1;
       Newline    : constant String := Latin_1.LF & "   ";
    begin
       for Dep of This.Flat_Dependencies loop
@@ -1262,7 +1260,7 @@ package body Alire.Releases is
 
    overriding
    function To_YAML (R : Release) return String is
-      LF : Character renames Ada.Characters.Latin_1.LF;
+      LF : Character renames Latin_1.LF;
 
       function Props_To_YAML
       is new Utils.YAML.To_YAML (Alire.Properties.Property'Class,

--- a/src/alire/alire-releases.adb
+++ b/src/alire/alire-releases.adb
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 with Ada.Directories;
 with Ada.Text_IO;
 
@@ -85,7 +86,8 @@ package body Alire.Releases is
    -------------------------
    --  Warn of ^0.x dependencies that probably should be ~0.x
    function Check_Caret_Warning (This : Release) return Boolean is
-      Newline    : constant String := ASCII.LF & "   ";
+      package Latin_1 renames Ada.Characters.Latin_1;
+      Newline    : constant String := Latin_1.LF & "   ";
    begin
       for Dep of This.Flat_Dependencies loop
          if Settings.Builtins.Warning_Caret.Get
@@ -1260,6 +1262,7 @@ package body Alire.Releases is
 
    overriding
    function To_YAML (R : Release) return String is
+      LF : Character renames Ada.Characters.Latin_1.LF;
 
       function Props_To_YAML
       is new Utils.YAML.To_YAML (Alire.Properties.Property'Class,
@@ -1269,15 +1272,15 @@ package body Alire.Releases is
       Deps : constant String := R.Dependencies.To_YAML;
    begin
       return
-        "crate: " & Utils.YAML.YAML_Stringify (R.Name_Str) & ASCII.LF &
-        "authors: " & Props_To_YAML (R.Author) & ASCII.LF &
-        "maintainers: " & Props_To_YAML (R.Maintainer) & ASCII.LF &
-        "licenses: " & Props_To_YAML (R.License) & ASCII.LF &
-        "websites: " & Props_To_YAML (R.Website) & ASCII.LF &
-        "tags: " & Props_To_YAML (R.Tag) & ASCII.LF &
-        "version: " & Utils.YAML.YAML_Stringify (R.Version_Image) & ASCII.LF &
+        "crate: " & Utils.YAML.YAML_Stringify (R.Name_Str) & LF &
+        "authors: " & Props_To_YAML (R.Author) & LF &
+        "maintainers: " & Props_To_YAML (R.Maintainer) & LF &
+        "licenses: " & Props_To_YAML (R.License) & LF &
+        "websites: " & Props_To_YAML (R.Website) & LF &
+        "tags: " & Props_To_YAML (R.Tag) & LF &
+        "version: " & Utils.YAML.YAML_Stringify (R.Version_Image) & LF &
         "short_description: " & Utils.YAML.YAML_Stringify (R.Description) &
-        ASCII.LF &
+        LF &
 
         "dependencies: " &  (if Deps'Length = 0
                                or else
@@ -1287,12 +1290,12 @@ package body Alire.Releases is
                                 --  dependency or no dependency.
                                 "[" & Deps & "]"
                              else
-                                Deps) & ASCII.LF &
+                                Deps) & LF &
 
         "configuration_variables: " &
-           Props_To_YAML (R.Config_Variables) & ASCII.LF &
+           Props_To_YAML (R.Config_Variables) & LF &
         "configuration_values: " &
-           Props_To_YAML (R.Config_Settings) & ASCII.LF;
+           Props_To_YAML (R.Config_Settings) & LF;
    end To_YAML;
 
    -------------

--- a/src/alire/alire-roots-editable.adb
+++ b/src/alire/alire-roots-editable.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Ada.Directories;
 
 with Alire.Conditional;
@@ -261,8 +260,6 @@ package body Alire.Roots.Editable is
                                   Path  : Any_Path)
                                   return Crate_Name
    is
-      package Latin_1 renames Ada.Characters.Latin_1;
-
       Pin_Root : Optional.Root := Optional.Detect_Root (Path);
 
       -------------------------

--- a/src/alire/alire-roots-editable.adb
+++ b/src/alire/alire-roots-editable.adb
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 with Ada.Directories;
 
 with Alire.Conditional;
@@ -260,6 +261,8 @@ package body Alire.Roots.Editable is
                                   Path  : Any_Path)
                                   return Crate_Name
    is
+      package Latin_1 renames Ada.Characters.Latin_1;
+
       Pin_Root : Optional.Root := Optional.Detect_Root (Path);
 
       -------------------------
@@ -284,7 +287,7 @@ package body Alire.Roots.Editable is
       if Crate.Is_Empty and then not Pin_Root.Is_Valid then
          Raise_Checked_Error
            ("No crate name given and link target is not an Alire crate:"
-            & ASCII.LF & " Please provide an explicit crate name.");
+            & Latin_1.LF & " Please provide an explicit crate name.");
       end if;
 
       --  No need to check that Pin_Root.Name and Crate agree, as this will be

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Ada.Directories;
 with Ada.Unchecked_Deallocation;
 
@@ -998,7 +997,6 @@ package body Alire.Roots is
          procedure Add_Link_Pin (Crate : Crate_Name;
                                  Pin   : in out User_Pins.Pin)
          is
-            package Latin_1 renames Ada.Characters.Latin_1;
             use type User_Pins.Pin;
          begin
 

--- a/src/alire/alire-roots.adb
+++ b/src/alire/alire-roots.adb
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 with Ada.Directories;
 with Ada.Unchecked_Deallocation;
 
@@ -997,6 +998,7 @@ package body Alire.Roots is
          procedure Add_Link_Pin (Crate : Crate_Name;
                                  Pin   : in out User_Pins.Pin)
          is
+            package Latin_1 renames Ada.Characters.Latin_1;
             use type User_Pins.Pin;
          begin
 
@@ -1008,7 +1010,7 @@ package body Alire.Roots is
                  ("Pin circularity detected when adding pin "
                   & Utils.TTY.Name (This.Name) & " --> " &
                     Utils.TTY.Name (Crate)
-                  & ASCII.LF & "Last manifest in the cycle is "
+                  & Latin_1.LF & "Last manifest in the cycle is "
                   & TTY.URL (This.Crate_File));
             end if;
 

--- a/src/alire/alire-templates.adb
+++ b/src/alire/alire-templates.adb
@@ -1,5 +1,3 @@
-with Ada.Characters.Latin_1;
-
 with Alire.Directories;
 with Alire.Errors;
 with Alire.Utils.Text_Files;
@@ -105,7 +103,7 @@ package body Alire.Templates is
                        Report       => Parsing_Error'Access);
          Content : AAA.Strings.Vector
            := AAA.Strings.Split (Parsed,
-                                 Ada.Characters.Latin_1.LF);
+                                 Latin_1.LF);
          File : Utils.Text_Files.File := Utils.Text_Files.Create (Dst);
       begin
          --  Remove a possibly empty last line

--- a/src/alire/alire-test_runner.adb
+++ b/src/alire/alire-test_runner.adb
@@ -1,5 +1,4 @@
 with Ada.Calendar;
-with Ada.Characters.Latin_1;
 with Ada.Containers.Indefinite_Ordered_Maps;
 with Ada.Containers.Indefinite_Vectors;
 with Ada.Strings.Fixed;
@@ -199,7 +198,7 @@ package body Alire.Test_Runner is
       ------------
 
       procedure Report is
-         CR : Character renames Ada.Characters.Latin_1.CR;
+         CR : Character renames Latin_1.CR;
       begin
          if Structured_Output then
             --  finalize report according to format
@@ -331,7 +330,7 @@ package body Alire.Test_Runner is
    procedure Run_All_Tests
      (Root : Roots.Root; Test_List : Portable_Path_Vector; Jobs : Positive)
    is
-      CR : Character renames Ada.Characters.Latin_1.CR;
+      CR : Character renames Latin_1.CR;
       use GNAT.OS_Lib;
 
       ---------

--- a/src/alire/alire-test_runner.adb
+++ b/src/alire/alire-test_runner.adb
@@ -1,4 +1,5 @@
 with Ada.Calendar;
+with Ada.Characters.Latin_1;
 with Ada.Containers.Indefinite_Ordered_Maps;
 with Ada.Containers.Indefinite_Vectors;
 with Ada.Strings.Fixed;
@@ -198,6 +199,7 @@ package body Alire.Test_Runner is
       ------------
 
       procedure Report is
+         CR : Character renames Ada.Characters.Latin_1.CR;
       begin
          if Structured_Output then
             --  finalize report according to format
@@ -218,7 +220,7 @@ package body Alire.Test_Runner is
                --  clear line to avoid messing up
                --  progress display (on stderr)
                Ada.Text_IO.Put
-                 (Ada.Text_IO.Standard_Error, (1 .. 8 => ' ', 9 => ASCII.CR));
+                 (Ada.Text_IO.Standard_Error, (1 .. 8 => ' ', 9 => CR));
                Ada.Text_IO.Flush (Ada.Text_IO.Standard_Error);
             end if;
             Trace.Always (LML.Encode (Builder.To_Text));
@@ -329,6 +331,7 @@ package body Alire.Test_Runner is
    procedure Run_All_Tests
      (Root : Roots.Root; Test_List : Portable_Path_Vector; Jobs : Positive)
    is
+      CR : Character renames Ada.Characters.Latin_1.CR;
       use GNAT.OS_Lib;
 
       ---------
@@ -430,7 +433,7 @@ package body Alire.Test_Runner is
          Percentage : constant Long_Integer :=
            (if Len = 0 then 0 else (Completed * 100 + Len / 2) / Len);
       begin
-         Ada.Text_IO.Put ("[" & Tail (Percentage'Image, 4) & "% ]" & ASCII.CR);
+         Ada.Text_IO.Put ("[" & Tail (Percentage'Image, 4) & "% ]" & CR);
          Ada.Text_IO.Flush;
          Completed := Completed + 1;
       end Put_Progress;

--- a/src/alire/alire-toml_adapters.adb
+++ b/src/alire/alire-toml_adapters.adb
@@ -1,3 +1,5 @@
+with Ada.Characters.Latin_1;
+
 with Alire.Utils;
 
 package body Alire.TOML_Adapters is
@@ -9,6 +11,7 @@ package body Alire.TOML_Adapters is
    function Escape (S : String) return String
    --  We trick the TOML exporter to get a valid escaped string
    is
+      package Latin_1 renames Ada.Characters.Latin_1;
       use TOML;
       Table : constant TOML_Value := Create_Table;
    begin
@@ -20,7 +23,7 @@ package body Alire.TOML_Adapters is
                     Trim
                       (Trim
                          (Tail (TOML.Dump_As_String (Table), '='),
-                          ASCII.LF));
+                          Latin_1.LF));
       begin
          --  Trimming the TOML quotes at the extremes fails for a
          --  string with quotes at the extremes of the string because

--- a/src/alire/alire-toml_adapters.adb
+++ b/src/alire/alire-toml_adapters.adb
@@ -1,5 +1,3 @@
-with Ada.Characters.Latin_1;
-
 with Alire.Utils;
 
 package body Alire.TOML_Adapters is
@@ -11,7 +9,6 @@ package body Alire.TOML_Adapters is
    function Escape (S : String) return String
    --  We trick the TOML exporter to get a valid escaped string
    is
-      package Latin_1 renames Ada.Characters.Latin_1;
       use TOML;
       Table : constant TOML_Value := Create_Table;
    begin

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 with Ada.Directories;
 
 with Alire.Settings.Builtins;
@@ -105,6 +106,8 @@ package body Alire.TOML_Index is
    procedure Check_Index (Index  : Index_On_Disk.Index'Class;
                           Root   : Any_Path;
                           Result : out Load_Result) is
+      package Latin_1 renames Ada.Characters.Latin_1;
+
       Filename : constant String := Dirs.Compose (Root, "index.toml");
       Value    : TOML.TOML_Value;
       Key      : constant String := "version";
@@ -209,14 +212,14 @@ package body Alire.TOML_Index is
                  (Result, Filename,
                   "index version (" & Loading_Index_Version.Image
                   & ") is too old. The minimum compatible version is "
-                  & Alire.Index.Min_Compatible_Version.Image & ASCII.LF
+                  & Alire.Index.Min_Compatible_Version.Image & Latin_1.LF
                   & (if Index.Name = Alire.Index.Community_Name then
                        " Resetting the community index ("
                        & TTY.Terminal ("alr index --reset-community")
-                       & ") may solve the issue. " & ASCII.LF
+                       & ") may solve the issue. " & Latin_1.LF
                     else
                        " Updating your local index might solve the issue "
-                       & "(alr index --update-all). " & ASCII.LF
+                       & "(alr index --update-all). " & Latin_1.LF
                        & "Otherwise, remove the " & "index with name '"
                        & TTY.Emph (Index.Name)
                        & "' (alr index --del " & Index.Name & ")"));

--- a/src/alire/alire-toml_index.adb
+++ b/src/alire/alire-toml_index.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Ada.Directories;
 
 with Alire.Settings.Builtins;
@@ -106,8 +105,6 @@ package body Alire.TOML_Index is
    procedure Check_Index (Index  : Index_On_Disk.Index'Class;
                           Root   : Any_Path;
                           Result : out Load_Result) is
-      package Latin_1 renames Ada.Characters.Latin_1;
-
       Filename : constant String := Dirs.Compose (Root, "index.toml");
       Value    : TOML.TOML_Value;
       Key      : constant String := "version";

--- a/src/alire/alire-utils-user_input.adb
+++ b/src/alire/alire-utils-user_input.adb
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 with Ada.Directories;
 
 with GNAT.OS_Lib;
@@ -16,12 +17,13 @@ package body Alire.Utils.User_Input is
                          Force : Boolean := Alire.Force)
                          return Boolean
    is
+      package Latin_1 renames Ada.Characters.Latin_1;
    begin
       if not GNAT.OS_Lib.Is_Directory (Dir) then
          return Query
            (Question => TTY.Error (if TTY.Color_Enabled then U ("⚠") else "!")
                         & " Given path does not exist: " & TTY.URL (Dir)
-                        & ASCII.LF & "Do you want to continue anyway?",
+                        & Latin_1.LF & "Do you want to continue anyway?",
             Valid    => (Yes | No => True, others => False),
             Default  => (if Force then Yes else No))
            = Yes;

--- a/src/alire/alire-utils-user_input.adb
+++ b/src/alire/alire-utils-user_input.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Ada.Directories;
 
 with GNAT.OS_Lib;
@@ -17,7 +16,6 @@ package body Alire.Utils.User_Input is
                          Force : Boolean := Alire.Force)
                          return Boolean
    is
-      package Latin_1 renames Ada.Characters.Latin_1;
    begin
       if not GNAT.OS_Lib.Is_Directory (Dir) then
          return Query

--- a/src/alire/alire-utils-yaml.adb
+++ b/src/alire/alire-utils-yaml.adb
@@ -1,3 +1,5 @@
+with Ada.Characters.Latin_1;
+
 package body Alire.Utils.YAML is
 
    -------------
@@ -6,13 +8,14 @@ package body Alire.Utils.YAML is
 
    function To_YAML (V : Vector) return String is
 
+      package Latin_1 renames Ada.Characters.Latin_1;
       use all type Vectors.Index_Type;
 
       function Image (V : Vector; Pos : Vectors.Index_Type) return String is
         (T'Class (V.Element (Pos)).To_YAML &
          (if Pos = V.Last_Index
           then ""
-          else "," & ASCII.LF & Image (V, Pos + 1)));
+          else "," & Latin_1.LF & Image (V, Pos + 1)));
 
    begin
       if V.Is_Empty then
@@ -27,6 +30,8 @@ package body Alire.Utils.YAML is
    --------------------
 
    function YAML_Stringify (Input : String) return String is
+      package Latin_1 renames Ada.Characters.Latin_1;
+
       --  Inspired by AdaYaml, (c) 2017 Felix Krause
 
       Result : String (1 .. Input'Length * 4 + 2);
@@ -72,13 +77,13 @@ package body Alire.Utils.YAML is
       Result (Last) := '"';
       for C of Input loop
          case C is
-            when ASCII.LF              => Escape ('l');
-            when ASCII.CR              => Escape ('c');
-            when '"' | '\'             => Escape (C);
-            when ASCII.HT              => Escape ('t');
-            when ASCII.NUL .. ASCII.BS
-               | ASCII.VT  .. ASCII.FF
-               | ASCII.SO  .. ASCII.US => Escape_To_Hex (C);
+            when Latin_1.LF              => Escape ('l');
+            when Latin_1.CR              => Escape ('c');
+            when '"' | '\'               => Escape (C);
+            when Latin_1.HT              => Escape ('t');
+            when Latin_1.NUL .. Latin_1.BS
+               | Latin_1.VT  .. Latin_1.FF
+               | Latin_1.SO  .. Latin_1.US => Escape_To_Hex (C);
 
             when others =>
                Last := Last + 1;

--- a/src/alire/alire-utils-yaml.adb
+++ b/src/alire/alire-utils-yaml.adb
@@ -1,5 +1,3 @@
-with Ada.Characters.Latin_1;
-
 package body Alire.Utils.YAML is
 
    -------------
@@ -8,7 +6,6 @@ package body Alire.Utils.YAML is
 
    function To_YAML (V : Vector) return String is
 
-      package Latin_1 renames Ada.Characters.Latin_1;
       use all type Vectors.Index_Type;
 
       function Image (V : Vector; Pos : Vectors.Index_Type) return String is
@@ -30,8 +27,6 @@ package body Alire.Utils.YAML is
    --------------------
 
    function YAML_Stringify (Input : String) return String is
-      package Latin_1 renames Ada.Characters.Latin_1;
-
       --  Inspired by AdaYaml, (c) 2017 Felix Krause
 
       Result : String (1 .. Input'Length * 4 + 2);

--- a/src/alire/alire-vcss-git.adb
+++ b/src/alire/alire-vcss-git.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Ada.Directories;
 with Ada.Containers;
 
@@ -545,7 +544,6 @@ package body Alire.VCSs.Git is
                         return String
    is
       pragma Unreferenced (This);
-      package Latin_1 renames Ada.Characters.Latin_1;
       Guard  : Directories.Guard (Directories.Enter (Path)) with Unreferenced;
       Output : constant AAA.Strings.Vector :=
                  Run_Git_And_Capture (Empty_Vector & "remote" & "-v");
@@ -588,7 +586,6 @@ package body Alire.VCSs.Git is
                            From : URL;
                            Ref  : String := "HEAD") return String
    is
-      package Latin_1 renames Ada.Characters.Latin_1;
       Output : constant AAA.Strings.Vector :=
         Run_Git_And_Capture (Empty_Vector & "ls-remote" & Repo_URL (From));
    begin

--- a/src/alire/alire-vcss-git.adb
+++ b/src/alire/alire-vcss-git.adb
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 with Ada.Directories;
 with Ada.Containers;
 
@@ -544,13 +545,14 @@ package body Alire.VCSs.Git is
                         return String
    is
       pragma Unreferenced (This);
+      package Latin_1 renames Ada.Characters.Latin_1;
       Guard  : Directories.Guard (Directories.Enter (Path)) with Unreferenced;
       Output : constant AAA.Strings.Vector :=
                  Run_Git_And_Capture (Empty_Vector & "remote" & "-v");
    begin
       for Line of Output loop
          declare
-            Cols : constant Vector := Split (Line, ASCII.HT, Trim => True);
+            Cols : constant Vector := Split (Line, Latin_1.HT, Trim => True);
          begin
             if Cols (1) = Remote then
                return AAA.Strings.Split (Cols (2), ' ').First_Element;
@@ -586,6 +588,7 @@ package body Alire.VCSs.Git is
                            From : URL;
                            Ref  : String := "HEAD") return String
    is
+      package Latin_1 renames Ada.Characters.Latin_1;
       Output : constant AAA.Strings.Vector :=
         Run_Git_And_Capture (Empty_Vector & "ls-remote" & Repo_URL (From));
    begin
@@ -601,8 +604,8 @@ package body Alire.VCSs.Git is
       --  Prepare Ref to make it less ambiguous
 
       if Ref in "HEAD" | "" then
-         return This.Remote_Commit (From, ASCII.HT & "HEAD");
-      elsif Ref (Ref'First) not in '/' | ASCII.HT then
+         return This.Remote_Commit (From, Latin_1.HT & "HEAD");
+      elsif Ref (Ref'First) not in '/' | Latin_1.HT then
          return This.Remote_Commit (From, '/' & Ref);
       end if;
 
@@ -615,7 +618,7 @@ package body Alire.VCSs.Git is
          for Line of Output loop
             if Has_Suffix (Line, Ref) then
                if Result = Not_Found then
-                  Result := Head (Line, ASCII.HT);
+                  Result := Head (Line, Latin_1.HT);
                else
                   Raise_Checked_Error ("Reference is ambiguous: "
                                        & TTY.Emph (Ref));

--- a/src/alire/alire.ads
+++ b/src/alire/alire.ads
@@ -1,4 +1,5 @@
 with Ada.Assertions;
+with Ada.Characters.Latin_1;
 with Ada.Exceptions;
 with Ada.Strings.Unbounded;
 private with Ada.Strings.UTF_Encoding.Wide_Wide_Strings;
@@ -18,6 +19,8 @@ with Simple_Logging;
 with CLIC.TTY;
 
 package Alire with Preelaborate is
+
+   package Latin_1 renames Ada.Characters.Latin_1;
 
    Checked_Error : exception;
    --  A Checked_Error is an explicitly diagnosed error condition, usually in

--- a/src/alire/alire_early_elaboration.adb
+++ b/src/alire/alire_early_elaboration.adb
@@ -1,5 +1,6 @@
 with AAA.Strings;
 
+with Ada.Characters.Latin_1;
 with Ada.Command_Line;
 with Ada.Directories;
 
@@ -91,6 +92,7 @@ package body Alire_Early_Elaboration is
    ----------------------------
 
    procedure Early_Switch_Detection is
+      package Latin_1 renames Ada.Characters.Latin_1;
       use GNAT.Command_Line;
 
       Subcommand_Seen : Boolean := False;
@@ -225,7 +227,7 @@ package body Alire_Early_Elaboration is
             Option := Getopt
               ("* d? --debug? q v c= --config= s= --settings= C= --chdir=");
             case Option is
-               when ASCII.NUL =>
+               when Latin_1.NUL =>
                   exit;
                when '*' =>
                   if not Subcommand_Seen then

--- a/src/alire/alire_early_elaboration.adb
+++ b/src/alire/alire_early_elaboration.adb
@@ -20,6 +20,8 @@ with Simple_Logging.Filtering;
 
 package body Alire_Early_Elaboration is
 
+   package Latin_1 renames Ada.Characters.Latin_1;
+
    Real_Starting_Dir : constant Alire.Absolute_Path :=
      Ada.Directories.Current_Directory;
 
@@ -92,7 +94,6 @@ package body Alire_Early_Elaboration is
    ----------------------------
 
    procedure Early_Switch_Detection is
-      package Latin_1 renames Ada.Characters.Latin_1;
       use GNAT.Command_Line;
 
       Subcommand_Seen : Boolean := False;

--- a/src/alr/alr-commands-edit.adb
+++ b/src/alr/alr-commands-edit.adb
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 with Ada.Containers;
 
 with Alire; use Alire;
@@ -40,19 +41,20 @@ package body Alr.Commands.Edit is
    -----------------------------
 
    procedure Report_If_Not_Installed (Exec : String) is
+      LF : Character renames Ada.Characters.Latin_1.LF;
    begin
       if Alire.OS_Lib.Subprocess.Locate_In_Path (Exec) = "" then
          --  Executable not in PATH, report an error
          if Exec = "gnatstudio" or else Exec = "gnatstudio.exe" then
             Reportaise_Command_Failed
-              ("GNAT Studio not available or not in PATH. " & ASCII.LF &
-                 "You can download it at: " & ASCII.LF &
+              ("GNAT Studio not available or not in PATH. " & LF &
+                 "You can download it at: " & LF &
                  "https://github.com/AdaCore/gnatstudio/releases");
          elsif Exec = "code" or else Exec = "code.exe" then
             Reportaise_Command_Failed
-              ("VS Code not available or not in PATH. " & ASCII.LF &
-                 "You can download it at: " & ASCII.LF &
-                 "https://code.visualstudio.com/download"  & ASCII.LF &
+              ("VS Code not available or not in PATH. " & LF &
+                 "You can download it at: " & LF &
+                 "https://code.visualstudio.com/download"  & LF &
                  "We also recomend installing the 'AdaCore.ada' extension.");
          else
             Reportaise_Command_Failed

--- a/src/alr/alr-commands-edit.adb
+++ b/src/alr/alr-commands-edit.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Ada.Containers;
 
 with Alire; use Alire;
@@ -41,7 +40,7 @@ package body Alr.Commands.Edit is
    -----------------------------
 
    procedure Report_If_Not_Installed (Exec : String) is
-      LF : Character renames Ada.Characters.Latin_1.LF;
+      LF : Character renames Latin_1.LF;
    begin
       if Alire.OS_Lib.Subprocess.Locate_In_Path (Exec) = "" then
          --  Executable not in PATH, report an error

--- a/src/alr/alr-commands-settings.adb
+++ b/src/alr/alr-commands-settings.adb
@@ -1,3 +1,5 @@
+with Ada.Characters.Latin_1;
+
 with Alire.Settings.Edit;
 with Alire.Root;
 
@@ -14,6 +16,8 @@ package body Alr.Commands.Settings is
    procedure Execute (Cmd  : in out Command;
                       Args :        AAA.Strings.Vector)
    is
+      package Latin_1 renames Ada.Characters.Latin_1;
+
       Enabled : Natural := 0;
 
       Lvl : constant Alire.Settings.Level := (if Cmd.Global
@@ -86,13 +90,13 @@ package body Alr.Commands.Settings is
                  (CLIC.Config.Info.List
                     (Alire.Settings.DB.all,
                      Filter => ".*",
-                     Show_Origin => Cmd.Show_Origin).Flatten (ASCII.LF));
+                     Show_Origin => Cmd.Show_Origin).Flatten (Latin_1.LF));
             when 1 =>
                Trace.Always
                  (CLIC.Config.Info.List
                     (Alire.Settings.DB.all,
                      Filter => Args.First_Element,
-                     Show_Origin => Cmd.Show_Origin).Flatten (ASCII.LF));
+                     Show_Origin => Cmd.Show_Origin).Flatten (Latin_1.LF));
             when others =>
                Reportaise_Wrong_Arguments
                  ("List expects at most one argument");

--- a/src/alr/alr-commands-settings.adb
+++ b/src/alr/alr-commands-settings.adb
@@ -1,5 +1,3 @@
-with Ada.Characters.Latin_1;
-
 with Alire.Settings.Edit;
 with Alire.Root;
 
@@ -16,8 +14,6 @@ package body Alr.Commands.Settings is
    procedure Execute (Cmd  : in out Command;
                       Args :        AAA.Strings.Vector)
    is
-      package Latin_1 renames Ada.Characters.Latin_1;
-
       Enabled : Natural := 0;
 
       Lvl : constant Alire.Settings.Level := (if Cmd.Global

--- a/src/alr/alr-commands-toolchain.adb
+++ b/src/alr/alr-commands-toolchain.adb
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 
 with Alire.Settings.Edit;
 with Alire.Containers;
@@ -64,6 +65,7 @@ package body Alr.Commands.Toolchain is
    is
       use Alire;
       use all type Origins.Kinds;
+      LF : Character renames Ada.Characters.Latin_1.LF;
 
       Dep : constant Dependencies.Dependency :=
               Dependencies.From_String (Request);
@@ -216,7 +218,7 @@ package body Alr.Commands.Toolchain is
               ("Currently configured " & Utils.TTY.Name (The_Other (Dep.Crate))
                & " has origin " & TTY.Emph (Origin_Kind'Image)
                & " but newly selected " & Utils.TTY.Name (Dep.Crate)
-               & " has origin " & TTY.Emph (Rel.Origin.Kind'Image) & ASCII.LF
+               & " has origin " & TTY.Emph (Rel.Origin.Kind'Image) & LF
                & "Mixing tool origins may result in a broken toolchain");
          end if;
 

--- a/src/alr/alr-commands-toolchain.adb
+++ b/src/alr/alr-commands-toolchain.adb
@@ -1,5 +1,3 @@
-with Ada.Characters.Latin_1;
-
 with Alire.Settings.Edit;
 with Alire.Containers;
 with Alire.Dependencies;
@@ -65,7 +63,7 @@ package body Alr.Commands.Toolchain is
    is
       use Alire;
       use all type Origins.Kinds;
-      LF : Character renames Ada.Characters.Latin_1.LF;
+      LF : Character renames Latin_1.LF;
 
       Dep : constant Dependencies.Dependency :=
               Dependencies.From_String (Request);

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -1,4 +1,5 @@
 with Ada.Characters.Handling; use Ada.Characters.Handling;
+with Ada.Characters.Latin_1;
 with Ada.Command_Line;
 with Ada.Directories;
 with Ada.Environment_Variables;
@@ -787,16 +788,17 @@ package body Alr.Commands is
    ------------------------
 
    function Crate_Version_Sets return AAA.Strings.Vector is
+      package Latin_1 renames Ada.Characters.Latin_1;
    begin
       return AAA.Strings.Empty_Vector
         .Append ("Version selection syntax (global policy applies "
                  & "within the allowed version subsets):")
         .New_Line
-        .Append ("crate        " & ASCII.HT & "Newest/oldest version")
-        .Append ("crate=version" & ASCII.HT & "Exact version")
-        .Append ("crate^version" & ASCII.HT & "Major-compatible version")
-        .Append ("crate~version" & ASCII.HT & "Minor-compatible version")
-        .Append ("crate[op]version " & ASCII.HT
+        .Append ("crate        " & Latin_1.HT & "Newest/oldest version")
+        .Append ("crate=version" & Latin_1.HT & "Exact version")
+        .Append ("crate^version" & Latin_1.HT & "Major-compatible version")
+        .Append ("crate~version" & Latin_1.HT & "Minor-compatible version")
+        .Append ("crate[op]version " & Latin_1.HT
                  & "Newest/oldest in set where [op] can be >, >=, <, <=, /=")
       ;
    end Crate_Version_Sets;

--- a/src/alr/alr-commands.adb
+++ b/src/alr/alr-commands.adb
@@ -1,5 +1,4 @@
 with Ada.Characters.Handling; use Ada.Characters.Handling;
-with Ada.Characters.Latin_1;
 with Ada.Command_Line;
 with Ada.Directories;
 with Ada.Environment_Variables;
@@ -788,7 +787,6 @@ package body Alr.Commands is
    ------------------------
 
    function Crate_Version_Sets return AAA.Strings.Vector is
-      package Latin_1 renames Ada.Characters.Latin_1;
    begin
       return AAA.Strings.Empty_Vector
         .Append ("Version selection syntax (global policy applies "

--- a/src/alr/alr-last_chance_handler.adb
+++ b/src/alr/alr-last_chance_handler.adb
@@ -1,5 +1,6 @@
 with AAA.Strings;
 
+with Ada.Characters.Latin_1;
 with Ada.Exceptions;
 
 with Alire.Errors;
@@ -7,9 +8,11 @@ with Alire.Errors;
 with Alr.OS_Lib;
 
 procedure Alr.Last_Chance_Handler (E : Ada.Exceptions.Exception_Occurrence) is
+   package Latin_1 renames Ada.Characters.Latin_1;
+
    Stack : constant AAA.Strings.Vector :=
              AAA.Strings.Split (Ada.Exceptions.Exception_Information (E),
-                                ASCII.LF);
+                                Latin_1.LF);
    Caller : constant := 3; -- 1) except name 2) exe name 3) stack start
 begin
    --  Ensure we do not show an exception trace to unsuspecting users

--- a/src/alr/alr-last_chance_handler.adb
+++ b/src/alr/alr-last_chance_handler.adb
@@ -1,6 +1,5 @@
 with AAA.Strings;
 
-with Ada.Characters.Latin_1;
 with Ada.Exceptions;
 
 with Alire.Errors;
@@ -8,7 +7,6 @@ with Alire.Errors;
 with Alr.OS_Lib;
 
 procedure Alr.Last_Chance_Handler (E : Ada.Exceptions.Exception_Occurrence) is
-   package Latin_1 renames Ada.Characters.Latin_1;
 
    Stack : constant AAA.Strings.Vector :=
              AAA.Strings.Split (Ada.Exceptions.Exception_Information (E),

--- a/src/alr/alr-os_lib.ads
+++ b/src/alr/alr-os_lib.ads
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Ada.Directories;
 
 with Alire.Directories;
@@ -66,7 +65,7 @@ package Alr.OS_Lib is
 
 private
 
-   Line_Separator : constant String := Ada.Characters.Latin_1.LF & "";
+   Line_Separator : constant String := Latin_1.LF & "";
    --  This should be made OS independent
 
    function "/" (L, R : String) return String is

--- a/src/alr/alr-os_lib.ads
+++ b/src/alr/alr-os_lib.ads
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 with Ada.Directories;
 
 with Alire.Directories;
@@ -65,7 +66,7 @@ package Alr.OS_Lib is
 
 private
 
-   Line_Separator : constant String := ASCII.LF & "";
+   Line_Separator : constant String := Ada.Characters.Latin_1.LF & "";
    --  This should be made OS independent
 
    function "/" (L, R : String) return String is

--- a/src/alr/alr-testing-console.adb
+++ b/src/alr/alr-testing-console.adb
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 with Alr.Commands.Version;
 
 with GNAT.IO; use GNAT.IO;
@@ -6,7 +7,7 @@ with Stopwatch;
 
 package body Alr.Testing.Console is
 
-   Tab : constant Character := ASCII.HT;
+   Tab : constant Character := Ada.Characters.Latin_1.HT;
 
    ---------------
    -- Start_Run --

--- a/src/alr/alr-testing-console.adb
+++ b/src/alr/alr-testing-console.adb
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 with Alr.Commands.Version;
 
 with GNAT.IO; use GNAT.IO;
@@ -7,7 +6,7 @@ with Stopwatch;
 
 package body Alr.Testing.Console is
 
-   Tab : constant Character := Ada.Characters.Latin_1.HT;
+   Tab : constant Character := Latin_1.HT;
 
    ---------------
    -- Start_Run --

--- a/src/alr/alr-testing-junit.adb
+++ b/src/alr/alr-testing-junit.adb
@@ -1,11 +1,10 @@
-with Ada.Characters.Latin_1;
 with Ada.Text_IO; use Ada.Text_IO;
 
 with Alr.Commands.Version;
 
 package body Alr.Testing.JUnit is
 
-   Newline : constant String := "" & Ada.Characters.Latin_1.LF;
+   Newline : constant String := "" & Latin_1.LF;
 
    ---------------
    -- Start_Run --

--- a/src/alr/alr-testing-junit.adb
+++ b/src/alr/alr-testing-junit.adb
@@ -1,10 +1,11 @@
+with Ada.Characters.Latin_1;
 with Ada.Text_IO; use Ada.Text_IO;
 
 with Alr.Commands.Version;
 
 package body Alr.Testing.JUnit is
 
-   Newline : constant String := "" & ASCII.LF;
+   Newline : constant String := "" & Ada.Characters.Latin_1.LF;
 
    ---------------
    -- Start_Run --

--- a/src/alr/alr-testing-text.adb
+++ b/src/alr/alr-testing-text.adb
@@ -1,12 +1,10 @@
-with Ada.Characters.Latin_1;
-
 with Alr.Commands.Version;
 
 package body Alr.Testing.Text is
 
    use Ada.Text_IO;
 
-   Tab : constant Character := Ada.Characters.Latin_1.HT;
+   Tab : constant Character := Latin_1.HT;
 
    ---------------
    -- Start_Run --

--- a/src/alr/alr-testing-text.adb
+++ b/src/alr/alr-testing-text.adb
@@ -1,10 +1,12 @@
+with Ada.Characters.Latin_1;
+
 with Alr.Commands.Version;
 
 package body Alr.Testing.Text is
 
    use Ada.Text_IO;
 
-   Tab : constant Character := ASCII.HT;
+   Tab : constant Character := Ada.Characters.Latin_1.HT;
 
    ---------------
    -- Start_Run --

--- a/src/alr/alr.ads
+++ b/src/alr/alr.ads
@@ -1,3 +1,4 @@
+with Ada.Characters.Latin_1;
 private with Ada.Strings.UTF_Encoding.Wide_Wide_Strings;
 
 with Alire;
@@ -6,6 +7,8 @@ with Simple_Logging;
 with CLIC.TTY;
 
 package Alr with Preelaborate is
+
+   package Latin_1 renames Ada.Characters.Latin_1;
 
    --  Nothing of note in this root package. Entities declared here are
    --  generally useful everywhere or in many packages: Exceptions for

--- a/src/alr/alr.ads
+++ b/src/alr/alr.ads
@@ -8,7 +8,7 @@ with CLIC.TTY;
 
 package Alr with Preelaborate is
 
-   package Latin_1 renames Ada.Characters.Latin_1;
+   package Latin_1 renames Alire.Latin_1;
 
    --  Nothing of note in this root package. Entities declared here are
    --  generally useful everywhere or in many packages: Exceptions for

--- a/src/alr/alr.ads
+++ b/src/alr/alr.ads
@@ -1,4 +1,3 @@
-with Ada.Characters.Latin_1;
 private with Ada.Strings.UTF_Encoding.Wide_Wide_Strings;
 
 with Alire;


### PR DESCRIPTION
Replace obsolescent `ASCII` package with `Ada.Characters.Latin_1`.

Added compiler configuration file `alire.adc`. GNAT does not flag `ASCII` as obsolescent with `-gnatwa/-gnatwj` even though it is. `pragma Restrictions (No_Obsolescent_Features)` does.

There are still around 10 grep references to `ASCII` in the code in output to user and comments.

