### PR TITLE
dev: rename test runner unit

### DIFF
--- a/src/alire/alire-test-runner.adb
+++ b/src/alire/alire-test-runner.adb
@@ -16,7 +16,6 @@ with Alire.Directories; use Alire.Directories;
 with Alire.OS_Lib;
 with Alire.Paths;
 with Alire.Settings.Builtins;
-with Alire.Test;
 with Alire.TOML_Keys;
 with Alire.Utils.Tables;
 with Alire.Utils.Text_Files;
@@ -31,7 +30,7 @@ with LML.Output.Factory;
 with LML.Output.Yeison;
 with LML.Options.Pragmas;
 
-package body Alire.Test_Runner is
+package body Alire.Test.Runner is
    use Alire.Utils;
    use Ada.Strings.Unbounded;
 
@@ -1021,4 +1020,4 @@ package body Alire.Test_Runner is
          end loop;
       end if;
    end Show_List;
-end Alire.Test_Runner;
+end Alire.Test.Runner;

--- a/src/alire/alire-test-runner.ads
+++ b/src/alire/alire-test-runner.ads
@@ -2,7 +2,7 @@ with Alire.Roots;
 
 with AAA.Strings;
 
-package Alire.Test_Runner is
+package Alire.Test.Runner is
 
    function Run
      (Root       : in out Alire.Roots.Root;
@@ -22,4 +22,4 @@ package Alire.Test_Runner is
    --  Print a list of matching tests without running them. Respects structured
    --  output.
 
-end Alire.Test_Runner;
+end Alire.Test.Runner;

--- a/src/alr/alr-commands-test.adb
+++ b/src/alr/alr-commands-test.adb
@@ -6,7 +6,7 @@ with Alire.OS_Lib.Subprocess;
 with Alire.Properties.Actions.Executor;
 with Alire.Properties.Tests;
 with Alire.Roots;
-with Alire.Test_Runner;
+with Alire.Test.Runner;
 
 with CLIC.Subcommand;
 
@@ -259,13 +259,13 @@ package body Alr.Commands.Test is
                      end if;
 
                      if Cmd.List then
-                        Alire.Test_Runner.Show_List
+                        Alire.Test.Runner.Show_List
                           (Test_Root.Value, Get_Args);
                         OS_Lib.Bailout;
                      end if;
 
                      Failures :=
-                       Alire.Test_Runner.Run
+                       Alire.Test.Runner.Run
                          (Root       => Test_Root.Value,
                           Filter     => Get_Args,
                           Jobs       =>


### PR DESCRIPTION
`Alire.Test_Runner` -> `Alire.Test.Runner` for my OCD peace now that `Alire.Test` already exists.