### PR TITLE
fix XDG variables trailing slash error

### DIFF
--- a/src/alire/alire-platforms-common.adb
+++ b/src/alire/alire-platforms-common.adb
@@ -91,7 +91,7 @@ package body Alire.Platforms.Common is
       then
          return "/tmp";
       else
-         return Home_Var;
+         return Den.Scrub (Home_Var);
       end if;
    end Unix_Home_Folder;
 

--- a/src/alire/alire-platforms-common.ads
+++ b/src/alire/alire-platforms-common.ads
@@ -1,4 +1,5 @@
 with Alire.OS_Lib;
+with Den;
 
 private with GNATCOLL.OS.Constants;
 
@@ -26,29 +27,27 @@ private package Alire.Platforms.Common is
    ----------------------
 
    function Unix_Temp_Folder return String
-   is (OS_Lib.Getenv ("XDG_RUNTIME_DIR",
-                      Default => OS_Lib.Getenv ("TMPDIR",
-                                                Default => ".")));
+     is (Den.Scrub (OS_Lib.Getenv
+       ("XDG_RUNTIME_DIR",
+        Default => OS_Lib.Getenv ("TMPDIR", Default => "."))));
 
    -------------------
    -- XDG_Data_Home --
    -------------------
 
    function XDG_Data_Home return String
-   is (OS_Lib.Getenv
-         ("XDG_DATA_HOME",
-          Default => Unix_Home_Folder / ".local/share")
-       / "alire");
+     is (Den.Scrub (OS_Lib.Getenv
+       ("XDG_DATA_HOME",
+        Default => Unix_Home_Folder / ".local/share") / "alire"));
 
    ---------------------
    -- XDG_Config_Home --
    ---------------------
 
    function XDG_Config_Home return String
-   is (OS_Lib.Getenv
-         ("XDG_CONFIG_HOME",
-          Default => Unix_Home_Folder / ".config")
-       / "alire");
+     is (Den.Scrub (OS_Lib.Getenv
+       ("XDG_CONFIG_HOME",
+        Default => Unix_Home_Folder / ".config") / "alire"));
 
 private
 

--- a/testsuite/drivers/alr.py
+++ b/testsuite/drivers/alr.py
@@ -2,6 +2,7 @@
 Helpers to run alr in the testsuite.
 """
 
+import json
 import os
 import os.path
 import platform
@@ -25,6 +26,15 @@ DEFAULT_CRATE_NAME = "xxx"
 
 class CalledProcessError(Exception):
     pass
+
+
+def version_info() -> dict:
+    """
+    Key/value pairs reported by `alr version`, as a dictionary. The JSON
+    output is a list of {"key": ..., "value": ...} entries.
+    """
+    return {entry["key"]: entry["value"] for entry in
+            json.loads(run_alr("--format=JSON", "version").out)}
 
 
 def distro_is_known():

--- a/testsuite/tests/misc/scrub-xdg-paths/test.py
+++ b/testsuite/tests/misc/scrub-xdg-paths/test.py
@@ -1,0 +1,48 @@
+"""
+Verify that paths given in XDG_* environment variables are scrubbed for
+trailing slashes.
+"""
+
+import os
+
+from drivers.alr import run_alr, version_info
+from drivers.asserts import assert_eq
+
+
+run_alr("version") # prevent spurious output on first run
+
+fake = os.path.join(os.getcwd(), "FAKE")
+fake_settings = os.path.join(fake, "alire")
+
+# Pre-configure the settings that will be found at the fake location,
+# so no auto-configuration of the community index is attempted later.
+
+os.makedirs(fake_settings)
+run_alr("-s", fake_settings, "settings", "--global",
+        "--set", "index.auto_community", "false")
+
+# Point the XDG variables used by Alire to the fake dir, with extra
+# trailing slashes that formerly resulted in an invalid path error.
+# ALIRE_SETTINGS_DIR must be removed so the settings location (and in
+# turn the cache location) is derived from the XDG variables.
+
+del os.environ["ALIRE_SETTINGS_DIR"]
+os.environ["XDG_CONFIG_HOME"] = fake + "///"
+os.environ["XDG_DATA_HOME"] = fake + "///"
+os.environ["XDG_RUNTIME_DIR"] = fake + "///"
+
+info = version_info()
+
+# Settings and cache folders are <XDG var>/alire, once properly scrubbed
+
+assert_eq(fake_settings, info["settings folder"])
+assert_eq(fake_settings, info["cache folder"])
+
+# The temp folder is XDG_RUNTIME_DIR itself; it undergoes further
+# normalization, so we only check that it has been scrubbed
+
+temp = info["temp folder"]
+assert "//" not in temp and not temp.endswith("/"), \
+    f"temp folder not scrubbed: {temp}"
+
+print("SUCCESS")

--- a/testsuite/tests/misc/scrub-xdg-paths/test.yaml
+++ b/testsuite/tests/misc/scrub-xdg-paths/test.yaml
@@ -1,0 +1,5 @@
+driver: python-script
+control:
+    - [SKIP, "skip_unix", "XDG variables are Unix-only"]
+indexes:
+    compiler_only_index: {}


### PR DESCRIPTION
fixes https://github.com/alire-project/alire/issues/2144 by calling Den.Scrub before passing the XDG variables to alire.

I would have loved to add a test but I think the testsuite is broken. Running `set_default_user_settings()` or `os.environ['XDG_CONFIG_HOME'] = '/tmp/.config/'` does not seam to change anything. And looking into other tests using these methods did not yield concrete answers :/ 

If there is a test case where an environment variable is changed that alire uses please tell me which. I couldn't find one. 

##### PR creation checklist
- [x] A test is included, if required by the changes.
- [ ] `doc/user-changes.md` has been updated, if there are user-visible changes.
- [ ] `doc/catalog-format-spec.md`+`schemas/manifest-schema.yaml` has been updated, if applicable.
- [ ] `BREAKING.md` has been updated for major changes in `alr`, minor/major in catalog format.
