### PR TITLE
alire.toml: update the reference commit for ada-toml

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/alire-project/simple_logging.git
 [submodule "deps/ada-toml"]
 	path = deps/ada-toml
-	url = https://github.com/mosteo/ada-toml
+	url = https://github.com/pmderodat/ada-toml
 [submodule "deps/gnatcoll-slim"]
 	path = deps/gnatcoll-slim
 	url = https://github.com/alire-project/gnatcoll-core.git

--- a/alire.toml
+++ b/alire.toml
@@ -60,7 +60,7 @@ commit = "73d99ae1ff2f5210dc41c2ea7afebe600f9e9916"
 
 [pins.ada_toml]
 url    = "https://github.com/pmderodat/ada-toml"
-commit = "f51ff9730aa916f33981db4589666577e9dd05c7"
+commit = "669eacabc8cad45b89b0bfc34d99b4334d66bebd"
 
 [pins.ansiada]
 url    = "https://github.com/mosteo/ansi-ada"


### PR DESCRIPTION
Hello,

This update should be harmless to Alire itself (the actual changes in ada-toml are very minor (https://github.com/pmderodat/ada-toml/commit/4f7873f660eaea3382569c1373700e8e4f3948e0).

Let me know if this works for you!